### PR TITLE
Force server cnx_id xmit when modifying cnx_id

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -77,7 +77,8 @@ extern "C" {
 	 */
 	typedef enum {
 		picoquic_context_server = 1,
-        picoquic_context_check_cookie = 2
+		picoquic_context_check_cookie = 2,
+		picoquic_context_unconditional_cnx_id = 4
 	} picoquic_context_flags;
 
 	/*

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -125,6 +125,11 @@ picoquic_quic_t * picoquic_create(uint32_t nb_connections,
 		quic->cnx_id_callback_fn = cnx_id_callback;
 		quic->cnx_id_callback_ctx = cnx_id_callback_ctx;
 
+		if (cnx_id_callback != NULL)
+		{
+			quic->flags |= picoquic_context_unconditional_cnx_id;
+		}
+
         if (cert_file_name != NULL)
         {
             quic->flags |= picoquic_context_server;

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -351,7 +351,8 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t * cnx, int extension_mo
 						}
 						else
 						{
-							cnx->remote_parameters.omit_connection_id = 1;
+							if (cnx->quic->flags & picoquic_context_unconditional_cnx_id == 0)
+								cnx->remote_parameters.omit_connection_id = 1;
 						}
 						break;
 					case picoquic_transport_parameter_max_packet_size:

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -1341,6 +1341,7 @@ void usage()
 	fprintf(stderr, "  -r                    Do Reset Request\n");
 	fprintf(stderr, "  -s <64b 64b>        Reset seed\n");
 	fprintf(stderr, "  -i <src mask value>   Connection ID modification: (src & ~mask) || val\n");
+	fprintf(stderr, "                        Implies unconditional server cnx_id xmit\n");
 	fprintf(stderr, "                          where <src> is int:\n");
 	fprintf(stderr, "                            0: picoquic_cnx_id_random\n");
 	fprintf(stderr, "                            1: picoquic_cnx_id_remote (client)\n");


### PR DESCRIPTION
Modifying cnx_id implies you are doing some sort of load balancing based on
cnx_id, therefore a server should always xmit cnx_id such that you can find
that packet's origin later, for example if it comes back in an icmp error.

Signed-off-by: Debabrata Banerjee <dbanerje@akamai.com>