### PR TITLE
Adds support for using a quic context as server/client

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -115,7 +115,7 @@ int picoquic_find_or_create_stream(picoquic_cnx_t * cnx, uint64_t stream_id,
         /* Verify the stream ID control conditions */
 
         /* Check parity */
-        int parity = ((cnx->quic->flags&picoquic_context_server) == 0) ?
+        int parity = cnx->client_mode ?
             is_remote : is_remote ^ 1;
         if ((stream_id & 1) != parity)
         {
@@ -760,7 +760,7 @@ picoquic_stream_head * picoquic_find_ready_stream(picoquic_cnx_t * cnx, int rest
 				else
 				{
 					/* Check parity */
-					int parity = ((cnx->quic->flags&picoquic_context_server) == 0) ? 0 : 1;
+					int parity = cnx->client_mode ? 0 : 1;
 
 					if (((stream->stream_id & 1) ^ parity) == 1)
 					{
@@ -1430,8 +1430,7 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t * cnx, picoquic_p
     picoquic_cnx_t * pcnx = cnx;
 
     /* Get the packet type */
-    ret = picoquic_parse_packet_header(cnx->quic, p->bytes, (uint32_t)p->length, NULL,
-        ((cnx->quic->flags&picoquic_context_server) == 0) ? 1 : 0, &ph, &pcnx);
+    ret = picoquic_parse_packet_header(cnx->quic, p->bytes, (uint32_t)p->length, NULL, &ph, &pcnx);
 
     if (ret == 0 && ph.ptype == picoquic_packet_0rtt_protected)
     {
@@ -2180,7 +2179,7 @@ int picoquic_decode_max_stream_id_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
 
     if (ret == 0)
     {
-        if ((cnx->quic->flags&picoquic_context_server) == 0)
+        if (cnx->client_mode)
         {
             /* Should only accept client stream ID */
             if ((max_stream_id & 1) != 0)

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -923,7 +923,7 @@ void picoquic_log_decrypt_encrypted_cleartext(FILE* F,
 }
 
 
-void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx, 
+void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx,
 	struct sockaddr * addr_peer, int receiving,
 	uint8_t * bytes,  size_t length, uint64_t current_time)
 {
@@ -935,16 +935,14 @@ void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx,
 	picoquic_log_packet_address(F, cnx, addr_peer, receiving, length, current_time);
 
 	/* Parse the clear text header */
-    ret = picoquic_parse_packet_header(quic, bytes, (uint32_t)length, NULL,
-        ((cnx->quic->flags&picoquic_context_server) == 0) ? 
-        ((receiving == 0)?1:0): ((receiving == 0) ? 0 : 1), &ph, &pcnx);
+    ret = picoquic_parse_packet_header(quic, bytes, (uint32_t)length, NULL, &ph, &pcnx);
 
 	if (ret != 0)
 	{
 		/* packet does not even parse */
 		fprintf(F, "   Cannot parse the packet header.\n");
 	}
-	else 
+	else
 	{
         if (cnx == NULL)
         {
@@ -959,7 +957,7 @@ void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx,
 		if (cnx != NULL)
 		{
 			ph.pn64 = picoquic_get_packet_number64(
-                (receiving == 0)?cnx->send_sequence:cnx->first_sack_item.end_of_sack_range, 
+                (receiving == 0)?cnx->send_sequence:cnx->first_sack_item.end_of_sack_range,
                 ph.pnmask, ph.pn);
 		}
 		else

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -67,6 +67,7 @@ extern "C" {
 #define PICOQUIC_ERROR_SEND_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS  + 25)
 #define PICOQUIC_ERROR_UNEXPECTED_STATE (PICOQUIC_ERROR_CLASS  + 26)
 #define PICOQUIC_ERROR_UNEXPECTED_ERROR (PICOQUIC_ERROR_CLASS  + 27)
+#define PICOQUIC_ERROR_TLS_SERVER_CON_WITHOUT_CERT (PICOQUIC_ERROR_CLASS  + 28)
 
 /*
  * Protocol errors defined in the QUIC spec
@@ -191,11 +192,11 @@ extern "C" {
 	/* Connection context creation and registration */
 	picoquic_cnx_t * picoquic_create_cnx(picoquic_quic_t * quic,
 		uint64_t cnx_id, struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-		char const * sni, char const * alpn);
+		char const * sni, char const * alpn, char client_mode);
 
-	picoquic_cnx_t * picoquic_create_client_cnx(picoquic_quic_t * quic, 
+	picoquic_cnx_t * picoquic_create_client_cnx(picoquic_quic_t * quic,
 		struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-		char const * sni, char const * alpn, 
+		char const * sni, char const * alpn,
 		picoquic_stream_data_cb_fn callback_fn, void * callback_ctx);
 
 	void picoquic_delete_cnx(picoquic_cnx_t * cnx);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -170,9 +170,8 @@ extern "C" {
 	 * Quic context flags
 	 */
 	typedef enum {
-		picoquic_context_server = 1,
-		picoquic_context_check_cookie = 2,
-		picoquic_context_unconditional_cnx_id = 4
+		picoquic_context_check_cookie = 1,
+		picoquic_context_unconditional_cnx_id = 2
 	} picoquic_context_flags;
 
 	/*
@@ -436,6 +435,8 @@ extern "C" {
 		/* Management of streams */
 		picoquic_stream_head first_stream;
 
+    /* Is this connection the client side? */
+    char client_mode;
 	} picoquic_cnx_t;
 
     /* Init of transport parameters */
@@ -511,7 +512,6 @@ extern "C" {
         uint8_t * bytes,
         uint32_t length,
         struct sockaddr * addr_from,
-        int to_server,
         picoquic_packet_header * ph,
         picoquic_cnx_t ** pcnx);
 

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -64,7 +64,7 @@ size_t picoquic_aead_0rtt_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t
 size_t picoquic_aead_0rtt_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
     uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
 
-int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx, int is_server);
+int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx);
 
 size_t picoquic_aead_cleartext_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, 
     size_t input_length, uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -965,9 +965,9 @@ int quic_client(const char * ip_address_text, int server_port, uint32_t proposed
     {
         /* Create a client connection */
 
-        cnx_client = picoquic_create_cnx(qclient, 0, 
-            (struct sockaddr *)&server_address, current_time, 
-            proposed_version, sni, alpn);
+        cnx_client = picoquic_create_cnx(qclient, 0,
+            (struct sockaddr *)&server_address, current_time,
+            proposed_version, sni, alpn, 1);
 
         if (cnx_client == NULL)
         {

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -101,7 +101,7 @@ int cleartext_aead_test()
         test_addr_c.sin_port = 12345;
 
         cnx_client = picoquic_create_cnx(qclient, 0,
-            (struct sockaddr *)&test_addr_c, 0, 0, NULL, NULL);
+            (struct sockaddr *)&test_addr_c, 0, 0, NULL, NULL, 1);
         if (cnx_client == NULL)
         {
             ret = -1;
@@ -118,7 +118,7 @@ int cleartext_aead_test()
 
         cnx_server = picoquic_create_cnx(qserver, cnx_client->initial_cnxid, 
             (struct sockaddr *)&test_addr_s, 0,
-            cnx_client->proposed_version, NULL, NULL);
+            cnx_client->proposed_version, NULL, NULL, 0);
 
         if (cnx_server == NULL)
         {

--- a/picoquictest/cnx_creation_test.c
+++ b/picoquictest/cnx_creation_test.c
@@ -106,14 +106,14 @@ int cnxcreation_test()
 
     for (int i = 0; ret == 0 && i < 5; i++)
     {
-        test_cnx[i] = picoquic_create_cnx(quic, test_cnx_id[i], test_cnx_addr[i], 0, 0, NULL, NULL);
+        test_cnx[i] = picoquic_create_cnx(quic, test_cnx_id[i], test_cnx_addr[i], 0, 0, NULL, NULL, 1);
         if (test_cnx[i] == NULL)
         {
             ret = -1;
         }
     }
 
- 
+
     /*
      *  -Verify that all these connections can be retrieved using their
      *    registered attributes.

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -209,7 +209,7 @@ int parseheadertest()
     else
     {
         cnx_08 = picoquic_create_cnx(quic, TEST_CNXID_08_VAL, (struct sockaddr *) &addr_08,
-            0, PICOQUIC_INTERNAL_TEST_VERSION_1, NULL, NULL);
+            0, PICOQUIC_INTERNAL_TEST_VERSION_1, NULL, NULL, 1);
 
         if (cnx_08 == NULL)
         {
@@ -222,8 +222,7 @@ int parseheadertest()
         pcnx = NULL;
 
         if (picoquic_parse_packet_header(quic, test_entries[i].packet, (uint32_t)test_entries[i].length,
-            (struct sockaddr *)&addr_08,
-            0, &ph, &pcnx) != 0)
+            (struct sockaddr *)&addr_08, &ph, &pcnx) != 0)
         {
             ret = -1;
         }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -265,9 +265,9 @@ static int test_api_queue_initial_queries(picoquic_test_tls_api_ctx_t * test_ctx
 		if (test_ctx->test_stream[i].previous_stream_id == stream_id)
 		{
             picoquic_cnx_t * cnx = NULL;
-            
+
             cnx = (test_ctx->test_stream[i].stream_id & 1) ?
-                    test_ctx->cnx_server: test_ctx->cnx_client;
+                    test_ctx->cnx_server : test_ctx->cnx_client;
 
 			ret = picoquic_add_to_stream(cnx, test_ctx->test_stream[i].stream_id,
 				test_ctx->test_stream[i].q_src,
@@ -760,7 +760,7 @@ static int tls_api_init_ctx(picoquic_test_tls_api_ctx_t ** pctx, uint32_t propos
 			/* Create a client connection */
 			test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient, 0,
 				(struct sockaddr *)&test_ctx->server_addr, 0,
-				proposed_version, sni, alpn);
+				proposed_version, sni, alpn, 1);
 
 			if (test_ctx->cnx_client == NULL)
 			{
@@ -915,6 +915,7 @@ static int tls_api_one_sim_round(picoquic_test_tls_api_ctx_t * test_ctx,
 
                 next_time = server_arrival;
                 *simulated_time = next_time;
+
                 ret = picoquic_incoming_packet(test_ctx->qserver, packet->bytes, (uint32_t)packet->length,
                     (struct sockaddr *)&test_ctx->client_addr,
                     (struct sockaddr *)&test_ctx->server_addr, 0,
@@ -1129,7 +1130,7 @@ int tls_api_silence_test()
     {
         ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
     }
-    
+
     /* simulate 5 seconds of silence */
     next_time = simulated_time + 5000000;
     while (ret == 0 && simulated_time < next_time &&
@@ -1538,7 +1539,7 @@ int tls_api_two_connections_test()
         /* Create a new connection in the client context */
 
         test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient, 0,
-            (struct sockaddr *)&test_ctx->server_addr, simulated_time, 0, NULL, "test-alpn");
+            (struct sockaddr *)&test_ctx->server_addr, simulated_time, 0, NULL, "test-alpn", 1);
 
         if (test_ctx->cnx_client == NULL)
         {
@@ -2093,7 +2094,7 @@ int mtu_discovery_test()
 
     if (ret == 0)
     {
-        if (test_ctx->cnx_client->send_mtu != 
+        if (test_ctx->cnx_client->send_mtu !=
             test_ctx->cnx_server->local_parameters.max_packet_size)
         {
             ret = -1;
@@ -2115,7 +2116,7 @@ int mtu_discovery_test()
 }
 
 /*
- * Trying to reproduce the scenario that resulted in 
+ * Trying to reproduce the scenario that resulted in
  * spurious retransmissions,and checking that it is fixed.
  */
 
@@ -2279,7 +2280,7 @@ int wrong_keyshare_test()
 
         cnx = picoquic_create_cnx(qserver, cnx_id, 
             (struct sockaddr *) &addr_from, simulated_time, 
-            PICOQUIC_INTERNAL_TEST_VERSION_1, NULL, NULL);
+            PICOQUIC_INTERNAL_TEST_VERSION_1, NULL, NULL, 0);
 
         if (cnx == NULL)
         {


### PR DESCRIPTION
Before these changes, a context could either be a serer or a client.
With these changes, a context can be both.

All tests are working.