### PR TITLE
Formats source code with clang-format and adds clangformat target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,3 +95,15 @@ TARGET_LINK_LIBRARIES(picoquic_ct picoquic-core
 )
 
 SET(TEST_EXES picoquic_ct)
+
+# get all project files for formatting
+file(GLOB_RECURSE CLANG_FORMAT_SOURCE_FILES *.c *.h)
+
+# Adds clangformat as target that formats all source files
+add_custom_target(
+    clangformat
+    COMMAND clang-format
+    -style=Webkit
+    -i
+    ${CLANG_FORMAT_SOURCE_FILES}
+)

--- a/picoquic/fnv1a.c
+++ b/picoquic/fnv1a.c
@@ -19,13 +19,12 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic_internal.h"
 #include "fnv1a.h"
+#include "picoquic_internal.h"
 
-uint64_t fnv1a_hash(uint64_t hash, uint8_t * bytes, size_t length)
+uint64_t fnv1a_hash(uint64_t hash, uint8_t* bytes, size_t length)
 {
-    for (size_t i = 0; i < length; i++)
-    {
+    for (size_t i = 0; i < length; i++) {
         hash ^= bytes[i];
         hash *= FNV1A_PRIME;
     }
@@ -33,12 +32,11 @@ uint64_t fnv1a_hash(uint64_t hash, uint8_t * bytes, size_t length)
     return hash;
 }
 
-size_t fnv1a_protect(uint8_t * bytes, size_t length, size_t length_max)
+size_t fnv1a_protect(uint8_t* bytes, size_t length, size_t length_max)
 {
     size_t ret = 0;
 
-    if (length + 8 <= length_max)
-    {
+    if (length + 8 <= length_max) {
         uint64_t hash = fnv1a_hash(FNV1A_OFFSET, bytes, length);
         picoformat_64(&bytes[length], hash);
         ret = length + 8;
@@ -47,17 +45,15 @@ size_t fnv1a_protect(uint8_t * bytes, size_t length, size_t length_max)
     return ret;
 }
 
-size_t fnv1a_check(uint8_t * bytes, size_t length)
+size_t fnv1a_check(uint8_t* bytes, size_t length)
 {
     size_t ret = 0;
 
-    if (length  > 8)
-    {
-        uint64_t hash1 = fnv1a_hash(FNV1A_OFFSET, bytes, ret = length-8);
-        uint64_t hash2 = PICOPARSE_64(bytes+ret);
+    if (length > 8) {
+        uint64_t hash1 = fnv1a_hash(FNV1A_OFFSET, bytes, ret = length - 8);
+        uint64_t hash2 = PICOPARSE_64(bytes + ret);
 
-        if (hash1 != hash2)
-        {
+        if (hash1 != hash2) {
             ret = 0;
         }
     }

--- a/picoquic/fnv1a.h
+++ b/picoquic/fnv1a.h
@@ -44,13 +44,14 @@ The offset basis for the 64-bit FNV-1a is the decimal value
 Once all octets have been processed in this fashion, the final integer
 value is encoded as 8 octets in network byte order.
 */
+#include <stddef.h>
 #include <stdint.h>
 
 #define FNV1A_OFFSET 0xcbf29ce484222325ull
 #define FNV1A_PRIME 0x100000001b3ull
 
-uint64_t fnv1a_hash(uint64_t hash, uint8_t * bytes, size_t length);
-size_t fnv1a_protect(uint8_t * bytes, size_t length, size_t length_max);
-size_t fnv1a_check(uint8_t * bytes, size_t length);
+uint64_t fnv1a_hash(uint64_t hash, uint8_t* bytes, size_t length);
+size_t fnv1a_protect(uint8_t* bytes, size_t length, size_t length_max);
+size_t fnv1a_check(uint8_t* bytes, size_t length);
 
 #endif

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -20,146 +20,119 @@
 */
 
 /* Decoding of the various frames, and application to context */
+#include "picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picoquic_internal.h"
 
-picoquic_stream_head * picoquic_create_stream(picoquic_cnx_t * cnx, uint64_t stream_id)
+picoquic_stream_head* picoquic_create_stream(picoquic_cnx_t* cnx, uint64_t stream_id)
 {
-	picoquic_stream_head * stream = (picoquic_stream_head *)malloc(sizeof(picoquic_stream_head));
-	if (stream != NULL)
-	{
-        picoquic_stream_head * previous_stream = NULL;
-        picoquic_stream_head * next_stream = cnx->first_stream.next_stream;
+    picoquic_stream_head* stream = (picoquic_stream_head*)malloc(sizeof(picoquic_stream_head));
+    if (stream != NULL) {
+        picoquic_stream_head* previous_stream = NULL;
+        picoquic_stream_head* next_stream = cnx->first_stream.next_stream;
 
-		memset(stream, 0, sizeof(picoquic_stream_head));
-		stream->stream_id = stream_id;
-		stream->maxdata_local = cnx->local_parameters.initial_max_stream_data;
-		stream->maxdata_remote = cnx->remote_parameters.initial_max_stream_data;
+        memset(stream, 0, sizeof(picoquic_stream_head));
+        stream->stream_id = stream_id;
+        stream->maxdata_local = cnx->local_parameters.initial_max_stream_data;
+        stream->maxdata_remote = cnx->remote_parameters.initial_max_stream_data;
 
         /*
          * Make sure that the streams are open in order.
          */
 
-        while (next_stream != NULL && next_stream->stream_id < stream_id)
-        {
+        while (next_stream != NULL && next_stream->stream_id < stream_id) {
             previous_stream = next_stream;
             next_stream = next_stream->next_stream;
         }
 
         stream->next_stream = next_stream;
 
-        if (previous_stream == NULL)
-        {
+        if (previous_stream == NULL) {
             cnx->first_stream.next_stream = stream;
-        }
-        else
-        {
+        } else {
             previous_stream->next_stream = stream;
         }
-	}
+    }
 
-	return stream;
+    return stream;
 }
 
 /* if the initial remote has changed, update the existing streams 
  */
 
-void picoquic_update_stream_initial_remote(picoquic_cnx_t * cnx)
+void picoquic_update_stream_initial_remote(picoquic_cnx_t* cnx)
 {
-    picoquic_stream_head * stream = &cnx->first_stream;
+    picoquic_stream_head* stream = &cnx->first_stream;
 
     do {
-        if (stream->stream_id != 0 && 
-            stream->maxdata_remote < cnx->remote_parameters.initial_max_stream_data)
-        {
+        if (stream->stream_id != 0 && stream->maxdata_remote < cnx->remote_parameters.initial_max_stream_data) {
             stream->maxdata_remote = cnx->remote_parameters.initial_max_stream_data;
         }
         stream = stream->next_stream;
     } while (stream);
 }
 
-picoquic_stream_head * picoquic_find_stream(picoquic_cnx_t * cnx, uint64_t stream_id, int create)
+picoquic_stream_head* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t stream_id, int create)
 {
-	picoquic_stream_head * stream = &cnx->first_stream;
+    picoquic_stream_head* stream = &cnx->first_stream;
 
-	do {
-		if (stream->stream_id == stream_id)
-		{
-			break;
-		}
-		else
-		{
-			stream = stream->next_stream;
-		}
-	} while (stream);
+    do {
+        if (stream->stream_id == stream_id) {
+            break;
+        } else {
+            stream = stream->next_stream;
+        }
+    } while (stream);
 
-	if (create != 0 && stream == NULL)
-	{
-		stream = picoquic_create_stream(cnx, stream_id);
-	}
+    if (create != 0 && stream == NULL) {
+        stream = picoquic_create_stream(cnx, stream_id);
+    }
 
-	return stream;
+    return stream;
 }
 
-int picoquic_find_or_create_stream(picoquic_cnx_t * cnx, uint64_t stream_id,
-    picoquic_stream_head ** stream, int is_remote)
+int picoquic_find_or_create_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
+    picoquic_stream_head** stream, int is_remote)
 {
     int ret = 0;
     int is_unidir = 0;
 
     *stream = picoquic_find_stream(cnx, stream_id, 0);
 
-    if (*stream == NULL)
-    {
+    if (*stream == NULL) {
         /* Verify the stream ID control conditions */
 
         /* Check parity */
-        int parity = cnx->client_mode ?
-            is_remote : is_remote ^ 1;
-        if ((stream_id & 1) != parity)
-        {
+        int parity = cnx->client_mode ? is_remote : is_remote ^ 1;
+        if ((stream_id & 1) != parity) {
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_ID_ERROR);
-        }
-        else
-        {
-            if ((stream_id & 2) == 0)
-            {
-                if (stream_id > cnx->max_stream_id_bidir_local)
-                {
+        } else {
+            if ((stream_id & 2) == 0) {
+                if (stream_id > cnx->max_stream_id_bidir_local) {
                     ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_ID_ERROR);
                 }
-            }
-            else
-            {
+            } else {
                 is_unidir = 1;
 
-                if (stream_id > cnx->max_stream_id_unidir_local)
-                {
+                if (stream_id > cnx->max_stream_id_unidir_local) {
                     ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_ID_ERROR);
                 }
             }
         }
 
-
-        if (ret == 0)
-        {
+        if (ret == 0) {
             *stream = picoquic_create_stream(cnx, stream_id);
 
-            if (*stream == NULL)
-            {
+            if (*stream == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
-            }
-            else if (is_unidir)
-            {
+            } else if (is_unidir) {
                 /* Mark the stream as already finished in our direction */
-                (*stream)->stream_flags |= picoquic_stream_flag_fin_notified |
-                    picoquic_stream_flag_fin_sent;
+                (*stream)->stream_flags |= picoquic_stream_flag_fin_notified | picoquic_stream_flag_fin_sent;
             }
         }
     }
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -167,44 +140,35 @@ int picoquic_find_or_create_stream(picoquic_cnx_t * cnx, uint64_t stream_id,
  * when a new max offset is learnt for a stream.
  */
 
-int picoquic_flow_control_check_stream_offset(picoquic_cnx_t * cnx, picoquic_stream_head * stream,
-	uint64_t new_fin_offset)
+int picoquic_flow_control_check_stream_offset(picoquic_cnx_t* cnx, picoquic_stream_head* stream,
+    uint64_t new_fin_offset)
 {
-	int ret = 0;
+    int ret = 0;
 
-	if (stream->stream_id == 0)
-	{
-		return 0;
-	}
+    if (stream->stream_id == 0) {
+        return 0;
+    }
 
-	if (new_fin_offset > stream->maxdata_local)
-	{
-		/* protocol violation */
-		ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FLOW_CONTROL_ERROR);
-	}
-	else if (new_fin_offset > stream->fin_offset)
-	{
-		/* Checking the flow control limits. Need to pay attention
+    if (new_fin_offset > stream->maxdata_local) {
+        /* protocol violation */
+        ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FLOW_CONTROL_ERROR);
+    } else if (new_fin_offset > stream->fin_offset) {
+        /* Checking the flow control limits. Need to pay attention
 		* to possible integer overflow */
 
-		uint64_t new_bytes = new_fin_offset - stream->fin_offset;
+        uint64_t new_bytes = new_fin_offset - stream->fin_offset;
 
-		if (new_bytes > cnx->maxdata_local ||
-			cnx->maxdata_local - new_bytes < cnx->data_received)
-		{
-			/* protocol violation */
+        if (new_bytes > cnx->maxdata_local || cnx->maxdata_local - new_bytes < cnx->data_received) {
+            /* protocol violation */
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FLOW_CONTROL_ERROR);
-		}
-		else
-		{
-			cnx->data_received += new_bytes;
-			stream->fin_offset = new_fin_offset;
-		}
-	}
+        } else {
+            cnx->data_received += new_bytes;
+            stream->fin_offset = new_fin_offset;
+        }
+    }
 
-	return ret;
+    return ret;
 }
-
 
 /*
  * RST_STREAM Frame
@@ -212,27 +176,21 @@ int picoquic_flow_control_check_stream_offset(picoquic_cnx_t * cnx, picoquic_str
  * An endpoint may use a RST_STREAM frame (type=0x01) to abruptly terminate a stream.
  */
 
-int picoquic_prepare_stream_reset_frame(picoquic_stream_head * stream,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_stream_reset_frame(picoquic_stream_head* stream,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
-	int ret = 0;
+    int ret = 0;
     size_t byte_index = 0;
 
-    if ((stream->stream_flags&picoquic_stream_flag_reset_requested) == 0 ||
-            (stream->stream_flags&picoquic_stream_flag_reset_sent) != 0)
-    {
+    if ((stream->stream_flags & picoquic_stream_flag_reset_requested) == 0 || (stream->stream_flags & picoquic_stream_flag_reset_sent) != 0) {
         *consumed = 0;
-    }
-    else
-    {
+    } else {
         size_t l1 = 0, l2 = 0;
-        if (bytes_max > 2)
-        {
+        if (bytes_max > 2) {
             bytes[byte_index++] = picoquic_frame_type_reset_stream;
             l1 = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, stream->stream_id);
             byte_index += l1;
-            if (l1 > 0 && bytes_max > byte_index + 3)
-            {
+            if (l1 > 0 && bytes_max > byte_index + 3) {
                 picoformat_16(bytes + byte_index, (uint16_t)stream->local_error);
                 byte_index += 2;
                 l2 = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, stream->sent_offset);
@@ -240,20 +198,16 @@ int picoquic_prepare_stream_reset_frame(picoquic_stream_head * stream,
             }
         }
 
-        if (l1 == 0 || l2 == 0)
-        {
+        if (l1 == 0 || l2 == 0) {
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
             *consumed = 0;
-        }
-        else
-        {
+        } else {
             *consumed = byte_index;
             stream->stream_flags |= picoquic_stream_flag_reset_sent | picoquic_stream_flag_fin_sent;
 
             /* Free the queued data */
-            while (stream->send_queue != NULL)
-            {
-                picoquic_stream_data * next = stream->send_queue->next_stream_data;
+            while (stream->send_queue != NULL) {
+                picoquic_stream_data* next = stream->send_queue->next_stream_data;
                 free(stream->send_queue->bytes);
                 free(stream->send_queue);
                 stream->send_queue = next;
@@ -261,26 +215,24 @@ int picoquic_prepare_stream_reset_frame(picoquic_stream_head * stream,
         }
     }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_decode_stream_reset_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_stream_reset_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint64_t stream_id = 0;
     uint32_t error_code = 0;
     uint64_t final_offset = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     size_t byte_index = 1;
     size_t l1 = 0, l2 = 0;
 
-    if (bytes_max > 2)
-    {
+    if (bytes_max > 2) {
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &stream_id);
         byte_index += l1;
-        if (l1 > 0 && bytes_max >= byte_index + 3)
-        {
+        if (l1 > 0 && bytes_max >= byte_index + 3) {
             error_code = PICOPARSE_16(bytes + byte_index);
             byte_index += 2;
             l2 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &final_offset);
@@ -288,46 +240,30 @@ int picoquic_decode_stream_reset_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
         }
     }
 
-    if (l1 == 0 || l2 == 0)
-    {
+    if (l1 == 0 || l2 == 0) {
         ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR);
         *consumed = bytes_max;
-    }
-    else
-    {
+    } else {
         *consumed = byte_index;
     }
 
-    if (ret == 0)
-    {
-        if (stream_id == 0)
-        {
+    if (ret == 0) {
+        if (stream_id == 0) {
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR);
-        }
-        else
-        {
+        } else {
             ret = picoquic_find_or_create_stream(cnx, stream_id, &stream, 1);
 
-            if (ret == 0)
-            {
-                if ((stream->stream_flags&
-                    (picoquic_stream_flag_fin_received | picoquic_stream_flag_reset_received)) != 0 &&
-                    final_offset != stream->fin_offset)
-                {
+            if (ret == 0) {
+                if ((stream->stream_flags & (picoquic_stream_flag_fin_received | picoquic_stream_flag_reset_received)) != 0 && final_offset != stream->fin_offset) {
                     ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FINAL_OFFSET_ERROR);
-                }
-                else
-                {
+                } else {
                     stream->stream_flags |= picoquic_stream_flag_reset_received;
                     stream->remote_error = error_code;
 
                     ret = picoquic_flow_control_check_stream_offset(cnx, stream, final_offset);
 
-                    if (ret == 0)
-                    {
-                        if (cnx->callback_fn != NULL &&
-                            (stream->stream_flags&picoquic_stream_flag_reset_signalled) == 0)
-                        {
+                    if (ret == 0) {
+                        if (cnx->callback_fn != NULL && (stream->stream_flags & picoquic_stream_flag_reset_signalled) == 0) {
                             cnx->callback_fn(cnx, stream->stream_id, NULL, 0,
                                 picoquic_callback_stream_reset, cnx->callback_ctx);
                             stream->stream_flags |= picoquic_stream_flag_reset_signalled;
@@ -345,28 +281,20 @@ int picoquic_decode_stream_reset_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * STOP SENDING Frame
  */
 
-int picoquic_prepare_stop_sending_frame(picoquic_stream_head * stream,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_stop_sending_frame(picoquic_stream_head* stream,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     const size_t min_length = 1 + 4 + 2;
     size_t byte_index = 0;
 
-    if (bytes_max < min_length)
-    {
+    if (bytes_max < min_length) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-    }
-    else if ((stream->stream_flags&picoquic_stream_flag_stop_sending_requested) == 0 ||
-        (stream->stream_flags&picoquic_stream_flag_stop_sending_sent) != 0 ||
-        (stream->stream_flags&picoquic_stream_flag_fin_received) != 0 ||
-        (stream->stream_flags&picoquic_stream_flag_reset_received) != 0)
-    {
+    } else if ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) == 0 || (stream->stream_flags & picoquic_stream_flag_stop_sending_sent) != 0 || (stream->stream_flags & picoquic_stream_flag_fin_received) != 0 || (stream->stream_flags & picoquic_stream_flag_reset_received) != 0) {
         *consumed = 0;
-    }
-    else
-    {
+    } else {
         bytes[byte_index++] = picoquic_frame_type_stop_sending;
-        byte_index += picoquic_varint_encode(bytes+byte_index, bytes_max - byte_index, 
+        byte_index += picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
             (uint64_t)stream->stream_id);
         picoformat_16(bytes + byte_index, (uint16_t)stream->local_stop_error);
         byte_index += 2;
@@ -377,51 +305,40 @@ int picoquic_prepare_stop_sending_frame(picoquic_stream_head * stream,
     return ret;
 }
 
-int picoquic_decode_stop_sending_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_stop_sending_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
-    const size_t min_length = 1 + picoquic_varint_skip(bytes+1) + 2;
+    const size_t min_length = 1 + picoquic_varint_skip(bytes + 1) + 2;
     uint64_t stream_id = 0;
     uint32_t error_code = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     size_t byte_index = 1;
 
-    if (bytes_max < min_length)
-    {
+    if (bytes_max < min_length) {
         ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR);
         *consumed = bytes_max;
-    }
-    else
-    {
+    } else {
         byte_index += picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &stream_id);
         error_code = PICOPARSE_16(bytes + byte_index);
         byte_index += 2;
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         *consumed = byte_index;
 
-        if (stream_id == 0)
-        {
+        if (stream_id == 0) {
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR);
-        }
-        else
-        {
+        } else {
             /* TODO: change stream_id to 64 bits! */
             ret = picoquic_find_or_create_stream(cnx, stream_id, &stream, 1);
 
-            if (ret == 0)
-            {
-                if ((stream->stream_flags&picoquic_stream_flag_stop_sending_received) == 0 &&
-                    (stream->stream_flags&picoquic_stream_flag_reset_requested) == 0)
-                {
+            if (ret == 0) {
+                if ((stream->stream_flags & picoquic_stream_flag_stop_sending_received) == 0 && (stream->stream_flags & picoquic_stream_flag_reset_requested) == 0) {
                     stream->remote_stop_error = error_code;
                     stream->stream_flags |= picoquic_stream_flag_stop_sending_received;
-                    
-                    if (cnx->callback_fn != NULL)
-                    {
+
+                    if (cnx->callback_fn != NULL) {
                         cnx->callback_fn(cnx, stream->stream_id, NULL, 0,
                             picoquic_callback_stop_sending, cnx->callback_ctx);
                         stream->stream_flags |= picoquic_stream_flag_stop_sending_signalled;
@@ -434,7 +351,6 @@ int picoquic_decode_stop_sending_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
     return ret;
 }
 
-
 /*
  * Stream frame.
  * In our implementation, stream 0 is special, and feeds directly
@@ -443,24 +359,21 @@ int picoquic_decode_stop_sending_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * STREAM frames implicitly create a stream and carry stream data. 
  */
 
-int picoquic_test_stream_frame_unlimited(uint8_t * bytes)
+int picoquic_test_stream_frame_unlimited(uint8_t* bytes)
 {
     int ret = 0;
     int first_byte = bytes[0];
 
-    if (first_byte >= picoquic_frame_type_stream_range_min &&
-        first_byte <= picoquic_frame_type_stream_range_max &&
-        (first_byte & 0x02) == 0)
-    {
+    if (first_byte >= picoquic_frame_type_stream_range_min && first_byte <= picoquic_frame_type_stream_range_max && (first_byte & 0x02) == 0) {
         ret = 1;
     }
 
     return ret;
 }
 
-int picoquic_parse_stream_header(const uint8_t * bytes, size_t bytes_max,
-								 uint64_t * stream_id, uint64_t * offset, size_t * data_length, int * fin,
-								 size_t * consumed)
+int picoquic_parse_stream_header(const uint8_t* bytes, size_t bytes_max,
+    uint64_t* stream_id, uint64_t* offset, size_t* data_length, int* fin,
+    size_t* consumed)
 {
     int ret = 0;
     int len = bytes[0] & 2;
@@ -473,53 +386,40 @@ int picoquic_parse_stream_header(const uint8_t * bytes, size_t bytes_max,
 
     *fin = bytes[0] & 1;
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_stream = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, stream_id);
         byte_index += l_stream;
     }
 
-    if (off == 0)
-    {
+    if (off == 0) {
         *offset = 0;
-    }
-    else if (bytes_max > byte_index)
-    {
+    } else if (bytes_max > byte_index) {
         l_off = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, offset);
         byte_index += l_off;
     }
 
-    if (bytes_max < byte_index || l_stream == 0 || (off != 0 && l_off == 0))
-    {
+    if (bytes_max < byte_index || l_stream == 0 || (off != 0 && l_off == 0)) {
         DBG_PRINTF("stream frame header too large: first_byte=0x%02x, bytes_max=%" PRIst,
             bytes[0], bytes_max);
         ret = -1;
         *data_length = 0;
         byte_index = bytes_max;
         ret = -1;
-    }
-    else if (len == 0)
-    {
+    } else if (len == 0) {
         *data_length = bytes_max - byte_index;
-    }
-    else
-    {
-        if (bytes_max > byte_index)
-        {
+    } else {
+        if (bytes_max > byte_index) {
             l_len = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &length);
             byte_index += l_len;
             *data_length = (size_t)length;
         }
 
-        if (l_len == 0 || bytes_max < byte_index)
-        {
+        if (l_len == 0 || bytes_max < byte_index) {
             DBG_PRINTF("stream frame header too large: first_byte=0x%02x, bytes_max=%" PRIst,
                 bytes[0], bytes_max);
             byte_index = bytes_max;
             ret = -1;
-        }
-        else if (byte_index + length > bytes_max)
-        {
+        } else if (byte_index + length > bytes_max) {
             DBG_PRINTF("stream data past the end of the packet: first_byte=0x%02x, data_length=%" PRIst ", max_bytes=%" PRIst,
                 bytes[0], *data_length, bytes_max);
             ret = -1;
@@ -530,198 +430,155 @@ int picoquic_parse_stream_header(const uint8_t * bytes, size_t bytes_max,
     return ret;
 }
 
-void picoquic_stream_data_callback(picoquic_cnx_t * cnx, picoquic_stream_head * stream)
+void picoquic_stream_data_callback(picoquic_cnx_t* cnx, picoquic_stream_head* stream)
 {
-	picoquic_stream_data * data = stream->stream_data;
+    picoquic_stream_data* data = stream->stream_data;
 
-	while (data != NULL && data->offset <= stream->consumed_offset)
-	{
-		size_t start = (size_t)(stream->consumed_offset - data->offset);
-		size_t data_length = data->length - start;
-		picoquic_call_back_event_t fin_now = picoquic_callback_no_event;
-		
-		stream->consumed_offset += data_length;
+    while (data != NULL && data->offset <= stream->consumed_offset) {
+        size_t start = (size_t)(stream->consumed_offset - data->offset);
+        size_t data_length = data->length - start;
+        picoquic_call_back_event_t fin_now = picoquic_callback_no_event;
 
-		if (stream->consumed_offset >= stream->fin_offset &&
-			(stream->stream_flags&
-			(picoquic_stream_flag_fin_received | picoquic_stream_flag_fin_signalled)) ==
-			picoquic_stream_flag_fin_received)
-		{
-			fin_now = picoquic_callback_stream_fin;
-			stream->stream_flags |= picoquic_stream_flag_fin_signalled;
-		}
+        stream->consumed_offset += data_length;
 
-		cnx->callback_fn(cnx, stream->stream_id, data->bytes + start, data_length, fin_now,
-			cnx->callback_ctx);
-		
-		free(data->bytes);
-		stream->stream_data = data->next_stream_data;
-		free(data);
-		data = stream->stream_data;
-	}
+        if (stream->consumed_offset >= stream->fin_offset && (stream->stream_flags & (picoquic_stream_flag_fin_received | picoquic_stream_flag_fin_signalled)) == picoquic_stream_flag_fin_received) {
+            fin_now = picoquic_callback_stream_fin;
+            stream->stream_flags |= picoquic_stream_flag_fin_signalled;
+        }
 
-	/* handle the case where the fin frame does not carry any data */
+        cnx->callback_fn(cnx, stream->stream_id, data->bytes + start, data_length, fin_now,
+            cnx->callback_ctx);
 
-	if (stream->consumed_offset >= stream->fin_offset &&
-		(stream->stream_flags&
-		(picoquic_stream_flag_fin_received | picoquic_stream_flag_fin_signalled)) ==
-		picoquic_stream_flag_fin_received)
-	{
-		cnx->callback_fn(cnx, stream->stream_id, NULL, 0, picoquic_callback_stream_fin,
-			cnx->callback_ctx);
-		stream->stream_flags |= picoquic_stream_flag_fin_signalled;
-	}
+        free(data->bytes);
+        stream->stream_data = data->next_stream_data;
+        free(data);
+        data = stream->stream_data;
+    }
+
+    /* handle the case where the fin frame does not carry any data */
+
+    if (stream->consumed_offset >= stream->fin_offset && (stream->stream_flags & (picoquic_stream_flag_fin_received | picoquic_stream_flag_fin_signalled)) == picoquic_stream_flag_fin_received) {
+        cnx->callback_fn(cnx, stream->stream_id, NULL, 0, picoquic_callback_stream_fin,
+            cnx->callback_ctx);
+        stream->stream_flags |= picoquic_stream_flag_fin_signalled;
+    }
 }
 
-int picoquic_stream_network_input(picoquic_cnx_t * cnx, uint64_t stream_id,
-    uint64_t offset, int fin, uint8_t * bytes, size_t length, uint64_t current_time)
+int picoquic_stream_network_input(picoquic_cnx_t* cnx, uint64_t stream_id,
+    uint64_t offset, int fin, uint8_t* bytes, size_t length, uint64_t current_time)
 {
     int ret = 0;
-	uint64_t should_notify = 0;
+    uint64_t should_notify = 0;
     /* Is there such a stream, is it still open? */
-	picoquic_stream_head * stream = NULL; 
-	uint64_t new_fin_offset = offset + length;
+    picoquic_stream_head* stream = NULL;
+    uint64_t new_fin_offset = offset + length;
 
-	ret = picoquic_find_or_create_stream(cnx, stream_id, &stream, 1);
-	
-	if (ret == 0)
-	{
-		if ((stream->stream_flags&picoquic_stream_flag_fin_received) != 0)
-		{
-			if (new_fin_offset > stream->fin_offset)
-			{
-				ret = -1;
-			}
-			else if (fin != 0 && stream->fin_offset != new_fin_offset)
-			{
-				ret = -1;
-			}
-		}
-		else if (fin)
-		{
-			if (stream_id == 0)
-			{
-				ret = -1;
-			}
-			else
-			{
-				stream->stream_flags |= picoquic_stream_flag_fin_received;
-				should_notify = stream_id;
+    ret = picoquic_find_or_create_stream(cnx, stream_id, &stream, 1);
+
+    if (ret == 0) {
+        if ((stream->stream_flags & picoquic_stream_flag_fin_received) != 0) {
+            if (new_fin_offset > stream->fin_offset) {
+                ret = -1;
+            } else if (fin != 0 && stream->fin_offset != new_fin_offset) {
+                ret = -1;
+            }
+        } else if (fin) {
+            if (stream_id == 0) {
+                ret = -1;
+            } else {
+                stream->stream_flags |= picoquic_stream_flag_fin_received;
+                should_notify = stream_id;
                 cnx->latest_progress_time = current_time;
-			}
-		}
-	}
+            }
+        }
+    }
 
-	if (ret == 0 && new_fin_offset > stream->fin_offset)
-	{
-		ret = picoquic_flow_control_check_stream_offset(cnx, stream, new_fin_offset);
-	}
+    if (ret == 0 && new_fin_offset > stream->fin_offset) {
+        ret = picoquic_flow_control_check_stream_offset(cnx, stream, new_fin_offset);
+    }
 
-	if (ret == 0)
-    {
-        picoquic_stream_data ** pprevious = &stream->stream_data;
-        picoquic_stream_data * next = stream->stream_data;
+    if (ret == 0) {
+        picoquic_stream_data** pprevious = &stream->stream_data;
+        picoquic_stream_data* next = stream->stream_data;
         size_t start = 0;
 
-        if (offset <= stream->consumed_offset)
-        {
-            if (offset + length <= stream->consumed_offset)
-            {
+        if (offset <= stream->consumed_offset) {
+            if (offset + length <= stream->consumed_offset) {
                 /* already received */
                 start = length;
-            }
-            else
-            {
+            } else {
                 start = (size_t)(stream->consumed_offset - offset);
             }
         }
-        
+
         /* Queue of a block in the stream */
 
-        while (next != NULL && start < length && next->offset <= offset + start )
-        {
-            if (offset + length <= next->offset + next->length)
-            {
+        while (next != NULL && start < length && next->offset <= offset + start) {
+            if (offset + length <= next->offset + next->length) {
                 start = length;
-            }
-            else if (offset < next->offset + next->length)
-            {
+            } else if (offset < next->offset + next->length) {
                 start = (size_t)(next->offset + next->length - offset);
             }
             pprevious = &next->next_stream_data;
             next = next->next_stream_data;
         }
 
-		if (start < length)
-		{
-			size_t data_length = length - start;
+        if (start < length) {
+            size_t data_length = length - start;
 
-			if (next != NULL && next->offset < offset + length)
-			{
-				data_length -= (size_t)(offset + length - next->offset);
-			}
+            if (next != NULL && next->offset < offset + length) {
+                data_length -= (size_t)(offset + length - next->offset);
+            }
 
-			if (data_length > 0)
-			{
-				picoquic_stream_data * data = (picoquic_stream_data*)malloc(sizeof(picoquic_stream_data));
+            if (data_length > 0) {
+                picoquic_stream_data* data = (picoquic_stream_data*)malloc(sizeof(picoquic_stream_data));
 
-				if (data == NULL)
-				{
-					ret = -1;
-				}
-				else
-				{
-					data->length = data_length;
-					data->bytes = (uint8_t *)malloc(data_length);
-					if (data->bytes == NULL)
-					{
-						ret = -1;
-						free(data);
-					}
-					else
-					{
-						data->offset = offset + start;
-						memcpy(data->bytes, bytes + start, data_length);
-						data->next_stream_data = next;
-						*pprevious = data;
-						should_notify = stream_id; /* this way, do not notify stream 0 */
+                if (data == NULL) {
+                    ret = -1;
+                } else {
+                    data->length = data_length;
+                    data->bytes = (uint8_t*)malloc(data_length);
+                    if (data->bytes == NULL) {
+                        ret = -1;
+                        free(data);
+                    } else {
+                        data->offset = offset + start;
+                        memcpy(data->bytes, bytes + start, data_length);
+                        data->next_stream_data = next;
+                        *pprevious = data;
+                        should_notify = stream_id; /* this way, do not notify stream 0 */
                         cnx->latest_progress_time = current_time;
-					}
-				}
-			}
-		}
+                    }
+                }
+            }
+        }
     }
 
-	if (ret == 0 && should_notify != 0 && cnx->callback_fn != NULL)
-	{
-		/* check how much data there is to send */
-		picoquic_stream_data_callback(cnx, stream);
-	}
-    
+    if (ret == 0 && should_notify != 0 && cnx->callback_fn != NULL) {
+        /* check how much data there is to send */
+        picoquic_stream_data_callback(cnx, stream);
+    }
+
     return ret;
 }
 
-int picoquic_decode_stream_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, int restricted, size_t * consumed, uint64_t current_time)
+int picoquic_decode_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, int restricted, size_t* consumed, uint64_t current_time)
 {
-    int      ret;
+    int ret;
     int fin = 0;
     uint64_t stream_id;
-    size_t   data_length;
+    size_t data_length;
     uint64_t offset;
 
     ret = picoquic_parse_stream_header(bytes, bytes_max,
         &stream_id, &offset, &data_length, &fin, consumed);
 
-    if (ret == 0)
-    {
-        if (restricted && stream_id != 0)
-        {
+    if (ret == 0) {
+        if (restricted && stream_id != 0) {
             DBG_PRINTF("non-zero stream (%u), where only stream 0 is expected", stream_id);
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-        }
-        else
-        {
+        } else {
             ret = picoquic_stream_network_input(cnx, stream_id, offset, fin,
                 bytes + *consumed, data_length, current_time);
             *consumed += data_length;
@@ -731,98 +588,60 @@ int picoquic_decode_stream_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
     return ret;
 }
 
-
-picoquic_stream_head * picoquic_find_ready_stream(picoquic_cnx_t * cnx, int restricted)
+picoquic_stream_head* picoquic_find_ready_stream(picoquic_cnx_t* cnx, int restricted)
 {
-	picoquic_stream_head * stream = &cnx->first_stream;
+    picoquic_stream_head* stream = &cnx->first_stream;
 
-	if (restricted == 0 && cnx->maxdata_remote > cnx->data_sent)
-	{
-		do {
-			if ((stream->send_queue != NULL &&
-				stream->send_queue->length > stream->send_queue->offset &&
-				(stream->stream_id == 0 ||
-				stream->sent_offset < stream->maxdata_remote)) ||
-				((stream->stream_flags&picoquic_stream_flag_fin_notified) != 0 &&
-				(stream->stream_flags&picoquic_stream_flag_fin_sent) == 0) ||
-				((stream->stream_flags&picoquic_stream_flag_reset_requested) != 0 &&
-				(stream->stream_flags&picoquic_stream_flag_reset_sent) == 0) ||
-                    ((stream->stream_flags&picoquic_stream_flag_stop_sending_requested) != 0 &&
-                (stream->stream_flags&picoquic_stream_flag_stop_sending_sent) == 0))
-			{
-				/* if the stream is not active yet, verify that it fits under
+    if (restricted == 0 && cnx->maxdata_remote > cnx->data_sent) {
+        do {
+            if ((stream->send_queue != NULL && stream->send_queue->length > stream->send_queue->offset && (stream->stream_id == 0 || stream->sent_offset < stream->maxdata_remote)) || ((stream->stream_flags & picoquic_stream_flag_fin_notified) != 0 && (stream->stream_flags & picoquic_stream_flag_fin_sent) == 0) || ((stream->stream_flags & picoquic_stream_flag_reset_requested) != 0 && (stream->stream_flags & picoquic_stream_flag_reset_sent) == 0) || ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) != 0 && (stream->stream_flags & picoquic_stream_flag_stop_sending_sent) == 0)) {
+                /* if the stream is not active yet, verify that it fits under
 				 * the max stream id limit */
 
-				if (stream->stream_id == 0)
-				{
-					break;
-				}
-				else
-				{
-					/* Check parity */
-					int parity = cnx->client_mode ? 0 : 1;
+                if (stream->stream_id == 0) {
+                    break;
+                } else {
+                    /* Check parity */
+                    int parity = cnx->client_mode ? 0 : 1;
 
-					if (((stream->stream_id & 1) ^ parity) == 1)
-					{
-						if (stream->stream_id < cnx->max_stream_id_bidir_remote)
-						{
-							break;
-						}
-					}
-					else
-					{
-						break;
-					}
-				}
-			}
+                    if (((stream->stream_id & 1) ^ parity) == 1) {
+                        if (stream->stream_id < cnx->max_stream_id_bidir_remote) {
+                            break;
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
 
-			stream = stream->next_stream;
+            stream = stream->next_stream;
 
-		} while (stream);
-	}
-	else
-	{
-		if ((stream->send_queue == NULL ||
-			stream->send_queue->length <= stream->send_queue->offset) &&
-			((stream->stream_flags&picoquic_stream_flag_fin_notified) == 0 ||
-			(stream->stream_flags&picoquic_stream_flag_fin_sent) != 0) &&
-				((stream->stream_flags&picoquic_stream_flag_reset_requested) == 0 ||
-			(stream->stream_flags&picoquic_stream_flag_reset_sent) != 0) &&
-                    ((stream->stream_flags&picoquic_stream_flag_stop_sending_requested) == 0 ||
-            (stream->stream_flags&picoquic_stream_flag_stop_sending_sent) != 0))
-		{
-			stream = NULL;
-		}
-	}
+        } while (stream);
+    } else {
+        if ((stream->send_queue == NULL || stream->send_queue->length <= stream->send_queue->offset) && ((stream->stream_flags & picoquic_stream_flag_fin_notified) == 0 || (stream->stream_flags & picoquic_stream_flag_fin_sent) != 0) && ((stream->stream_flags & picoquic_stream_flag_reset_requested) == 0 || (stream->stream_flags & picoquic_stream_flag_reset_sent) != 0) && ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) == 0 || (stream->stream_flags & picoquic_stream_flag_stop_sending_sent) != 0)) {
+            stream = NULL;
+        }
+    }
 
-	return stream;
+    return stream;
 }
 
-int picoquic_prepare_stream_frame(picoquic_cnx_t * cnx, picoquic_stream_head * stream,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* stream,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
 
-    if ((stream->stream_flags&picoquic_stream_flag_reset_requested) != 0)
-    {
+    if ((stream->stream_flags & picoquic_stream_flag_reset_requested) != 0) {
         return picoquic_prepare_stream_reset_frame(stream, bytes, bytes_max, consumed);
     }
 
-    if ((stream->stream_flags&picoquic_stream_flag_stop_sending_requested) != 0 &&
-        (stream->stream_flags&picoquic_stream_flag_stop_sending_sent) == 0)
-    {
+    if ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) != 0 && (stream->stream_flags & picoquic_stream_flag_stop_sending_sent) == 0) {
         return picoquic_prepare_stop_sending_frame(stream, bytes, bytes_max, consumed);
     }
 
-    if ((stream->send_queue == NULL ||
-        stream->send_queue->length <= stream->send_queue->offset) &&
-        ((stream->stream_flags&picoquic_stream_flag_fin_notified) == 0 ||
-        (stream->stream_flags&picoquic_stream_flag_fin_sent) != 0))
-    {
+    if ((stream->send_queue == NULL || stream->send_queue->length <= stream->send_queue->offset) && ((stream->stream_flags & picoquic_stream_flag_fin_notified) == 0 || (stream->stream_flags & picoquic_stream_flag_fin_sent) != 0)) {
         *consumed = 0;
-    }
-    else
-    {
+    } else {
         size_t byte_index = 0;
         size_t l_stream = 0;
         size_t l_off = 0;
@@ -830,59 +649,45 @@ int picoquic_prepare_stream_frame(picoquic_cnx_t * cnx, picoquic_stream_head * s
 
         bytes[byte_index++] = picoquic_frame_type_stream_range_min;
 
-        if (bytes_max > byte_index)
-        {
+        if (bytes_max > byte_index) {
             l_stream = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, stream->stream_id);
             byte_index += l_stream;
         }
 
-        if (stream->sent_offset > 0 && bytes_max > byte_index)
-        {
+        if (stream->sent_offset > 0 && bytes_max > byte_index) {
             bytes[0] |= 4; /* Indicates presence of offset */
             l_off = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, stream->sent_offset);
             byte_index += l_off;
         }
 
-        if (byte_index > bytes_max || l_stream == 0 || (stream->sent_offset > 0 && l_off == 0))
-        {
+        if (byte_index > bytes_max || l_stream == 0 || (stream->sent_offset > 0 && l_off == 0)) {
             *consumed = 0;
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-        }
-        else
-        {
+        } else {
             /* Compute the length */
             size_t space = bytes_max - byte_index;
 
-            if (space < 2 || stream->send_queue == NULL)
-            {
+            if (space < 2 || stream->send_queue == NULL) {
                 length = 0;
-            }
-            else
-            {
+            } else {
                 size_t available = (size_t)(stream->send_queue->length - stream->send_queue->offset);
 
                 length = available;
 
                 /* Abide by flow control and packet size  restrictions */
-                if (stream->stream_id != 0)
-                {
-                    if (length > (cnx->maxdata_remote - cnx->data_sent))
-                    {
+                if (stream->stream_id != 0) {
+                    if (length > (cnx->maxdata_remote - cnx->data_sent)) {
                         length = (size_t)(cnx->maxdata_remote - cnx->data_sent);
                     }
 
-                    if (length > (stream->maxdata_remote - stream->sent_offset))
-                    {
+                    if (length > (stream->maxdata_remote - stream->sent_offset)) {
                         length = (size_t)(stream->maxdata_remote - stream->sent_offset);
                     }
                 }
 
-                if (length >= space)
-                {
+                if (length >= space) {
                     length = space;
-                }
-                else
-                {
+                } else {
                     /* This is going to be a trial and error process */
                     size_t l_len = 0;
 
@@ -890,59 +695,47 @@ int picoquic_prepare_stream_frame(picoquic_cnx_t * cnx, picoquic_stream_head * s
                     bytes[0] |= 2; /* Indicates presence of length */
                     l_len = picoquic_varint_encode(bytes + byte_index, space,
                         (uint64_t)length);
-                    if (l_len == 0 || (l_len == space && length > 0))
-                    {
+                    if (l_len == 0 || (l_len == space && length > 0)) {
                         /* Will not try a silly encoding */
                         *consumed = 0;
                         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-                    }
-                    else if (length + l_len > space)
-                    {
+                    } else if (length + l_len > space) {
                         /* try a shorter packet */
                         length = space - l_len;
                         l_len = picoquic_varint_encode(bytes + byte_index, space,
                             (uint64_t)length);
                         byte_index += l_len;
-                    }
-                    else
-                    {
+                    } else {
                         /* This is good */
                         byte_index += l_len;
                     }
                 }
             }
 
-            if (ret == 0 && length > 0)
-            {
+            if (ret == 0 && length > 0) {
                 memcpy(&bytes[byte_index], stream->send_queue->bytes + stream->send_queue->offset, length);
                 byte_index += length;
 
                 stream->send_queue->offset += length;
-                if (stream->send_queue->offset >= stream->send_queue->length)
-                {
-                    picoquic_stream_data * next = stream->send_queue->next_stream_data;
+                if (stream->send_queue->offset >= stream->send_queue->length) {
+                    picoquic_stream_data* next = stream->send_queue->next_stream_data;
                     free(stream->send_queue->bytes);
                     free(stream->send_queue);
                     stream->send_queue = next;
                 }
 
                 stream->sent_offset += length;
-                if (stream->stream_id != 0)
-                {
+                if (stream->stream_id != 0) {
                     cnx->data_sent += length;
                 }
                 *consumed = byte_index;
             }
 
-            if (ret == 0 && (stream->stream_flags&picoquic_stream_flag_fin_notified) != 0 &&
-                stream->send_queue == 0)
-            {
+            if (ret == 0 && (stream->stream_flags & picoquic_stream_flag_fin_notified) != 0 && stream->send_queue == 0) {
                 /* Set the fin bit */
                 stream->stream_flags |= picoquic_stream_flag_fin_sent;
                 bytes[0] |= 1;
-            }
-            else if (ret == 0 && length == 0)
-            {
+            } else if (ret == 0 && length == 0) {
                 /* No point in sending a silly packet */
                 *consumed = 0;
                 ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
@@ -953,122 +746,101 @@ int picoquic_prepare_stream_frame(picoquic_cnx_t * cnx, picoquic_stream_head * s
     return ret;
 }
 
-
 /*
  * ACK Frames
  */
 
-int picoquic_parse_ack_header(uint8_t const * bytes, size_t bytes_max, 
-    uint64_t * num_block,
-    uint64_t * largest, uint64_t * ack_delay, size_t * consumed,
+int picoquic_parse_ack_header(uint8_t const* bytes, size_t bytes_max,
+    uint64_t* num_block,
+    uint64_t* largest, uint64_t* ack_delay, size_t* consumed,
     uint8_t ack_delay_exponent)
 {
-	int ret = 0;
-	size_t byte_index = 1;
-	uint8_t first_byte = bytes[0];
+    int ret = 0;
+    size_t byte_index = 1;
+    uint8_t first_byte = bytes[0];
     size_t l_largest = 0;
     size_t l_delay = 0;
     size_t l_blocks = 0;
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_largest = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, largest);
         byte_index += l_largest;
     }
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_delay = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, ack_delay);
         *ack_delay <<= ack_delay_exponent;
         byte_index += l_delay;
     }
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_blocks = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, num_block);
         byte_index += l_blocks;
     }
 
-    if (l_largest == 0 || l_delay == 0 || l_blocks == 0 || bytes_max < byte_index)
-    {
+    if (l_largest == 0 || l_delay == 0 || l_blocks == 0 || bytes_max < byte_index) {
         DBG_PRINTF("ack frame fixed header too large: first_byte=0x%02x, bytes_max=%" PRIst,
             first_byte, bytes_max);
         byte_index = bytes_max;
         ret = -1;
-	}
+    }
 
-	*consumed = byte_index;
-	return ret;
+    *consumed = byte_index;
+    return ret;
 }
 
-void picoquic_check_spurious_retransmission(picoquic_cnx_t * cnx, 
+void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
     uint64_t start_of_range, uint64_t end_of_range, uint64_t current_time)
 {
-    picoquic_packet * p = cnx->retransmitted_newest;
+    picoquic_packet* p = cnx->retransmitted_newest;
 
-    while (p != NULL)
-    {
-        picoquic_packet * should_delete = NULL;
+    while (p != NULL) {
+        picoquic_packet* should_delete = NULL;
 
-        if (p->sequence_number >= start_of_range && p->sequence_number <= end_of_range)
-        {
+        if (p->sequence_number >= start_of_range && p->sequence_number <= end_of_range) {
 
             uint64_t max_spurious_rtt = current_time - p->send_time;
             uint64_t max_reorder_delay = cnx->latest_time_acknowledged - p->send_time;
             uint64_t max_reorder_gap = cnx->highest_acknowledged - p->sequence_number;
 
-            if (p->length + p->checksum_overhead > cnx->send_mtu)
-            {
+            if (p->length + p->checksum_overhead > cnx->send_mtu) {
                 cnx->send_mtu = p->length + p->checksum_overhead;
-                if (cnx->send_mtu > cnx->send_mtu_max_tried)
-                {
+                if (cnx->send_mtu > cnx->send_mtu_max_tried) {
                     cnx->send_mtu_max_tried = cnx->send_mtu;
                 }
                 cnx->mtu_probe_sent = 0;
             }
 
-            if (max_spurious_rtt > cnx->max_spurious_rtt)
-            {
+            if (max_spurious_rtt > cnx->max_spurious_rtt) {
                 cnx->max_spurious_rtt = max_spurious_rtt;
             }
 
-            if (max_reorder_delay > cnx->max_reorder_delay)
-            {
+            if (max_reorder_delay > cnx->max_reorder_delay) {
                 cnx->max_reorder_delay = max_reorder_delay;
             }
 
-            if (max_reorder_gap > cnx->max_reorder_gap)
-            {
+            if (max_reorder_gap > cnx->max_reorder_gap) {
                 cnx->max_reorder_gap = max_reorder_gap;
             }
 
             cnx->nb_spurious++;
             should_delete = p;
-        }
-        else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->latest_time_acknowledged)
-        {
+        } else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->latest_time_acknowledged) {
             should_delete = p;
         }
-        
+
         p = p->next_packet;
 
-        if (should_delete != NULL)
-        {
-            if (should_delete->previous_packet == NULL)
-            {
+        if (should_delete != NULL) {
+            if (should_delete->previous_packet == NULL) {
                 cnx->retransmitted_newest = should_delete->next_packet;
-            }
-            else
-            {
+            } else {
                 should_delete->previous_packet->next_packet = should_delete->next_packet;
             }
 
-            if (should_delete->next_packet == NULL)
-            {
+            if (should_delete->next_packet == NULL) {
                 cnx->retransmitted_oldest = should_delete->previous_packet;
-            }
-            else
-            {
+            } else {
                 should_delete->next_packet->previous_packet = should_delete->previous_packet;
             }
 
@@ -1077,159 +849,121 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t * cnx,
     }
 }
 
-static picoquic_packet * picoquic_update_rtt(picoquic_cnx_t * cnx, uint64_t largest,
-	uint64_t current_time, uint64_t ack_delay)
+static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t largest,
+    uint64_t current_time, uint64_t ack_delay)
 {
-	picoquic_packet * packet = cnx->retransmit_newest;
+    picoquic_packet* packet = cnx->retransmit_newest;
 
-	/* Check whether this is a new acknowledgement */
-	if (largest > cnx->highest_acknowledged )
-	{
-		cnx->highest_acknowledged = largest;
+    /* Check whether this is a new acknowledgement */
+    if (largest > cnx->highest_acknowledged) {
+        cnx->highest_acknowledged = largest;
 
-		if (ack_delay < PICOQUIC_ACK_DELAY_MAX)
-		{
-			/* if the ACK is reasonably recent, use it to update the RTT */
-			/* find the stored copy of the largest acknowledged packet */
+        if (ack_delay < PICOQUIC_ACK_DELAY_MAX) {
+            /* if the ACK is reasonably recent, use it to update the RTT */
+            /* find the stored copy of the largest acknowledged packet */
 
-			while (packet != NULL && packet->sequence_number > largest)
-			{
-				packet = packet->next_packet;
-			}
+            while (packet != NULL && packet->sequence_number > largest) {
+                packet = packet->next_packet;
+            }
 
-			if (packet == NULL || packet->sequence_number < largest)
-			{
-				/* There is no copy of this packet in store. It may have
+            if (packet == NULL || packet->sequence_number < largest) {
+                /* There is no copy of this packet in store. It may have
                  * been deleted because too old, or maybe already
                  * retransmitted */
-			}
-			else
-			{
-				uint64_t acknowledged_time = current_time - ack_delay;
-				int64_t rtt_estimate = acknowledged_time - packet->send_time;
+            } else {
+                uint64_t acknowledged_time = current_time - ack_delay;
+                int64_t rtt_estimate = acknowledged_time - packet->send_time;
 
-                if (cnx->latest_time_acknowledged < packet->send_time)
-                {
+                if (cnx->latest_time_acknowledged < packet->send_time) {
                     cnx->latest_time_acknowledged = packet->send_time;
                 }
                 cnx->latest_progress_time = current_time;
 
-				if (rtt_estimate > 0)
-				{
-                    if (ack_delay > cnx->max_ack_delay)
-                    {
+                if (rtt_estimate > 0) {
+                    if (ack_delay > cnx->max_ack_delay) {
                         cnx->max_ack_delay = ack_delay;
                     }
 
-					if (cnx->smoothed_rtt == PICOQUIC_INITIAL_RTT &&
-						cnx->rtt_variant == 0)
-					{
-						cnx->smoothed_rtt = rtt_estimate;
-						cnx->rtt_variant = rtt_estimate / 2;
-						cnx->rtt_min = rtt_estimate;
-						cnx->retransmit_timer = 3 * rtt_estimate + cnx->max_ack_delay;
+                    if (cnx->smoothed_rtt == PICOQUIC_INITIAL_RTT && cnx->rtt_variant == 0) {
+                        cnx->smoothed_rtt = rtt_estimate;
+                        cnx->rtt_variant = rtt_estimate / 2;
+                        cnx->rtt_min = rtt_estimate;
+                        cnx->retransmit_timer = 3 * rtt_estimate + cnx->max_ack_delay;
                         cnx->ack_delay_local = cnx->rtt_min / 4;
-                        if (cnx->ack_delay_local < 1000)
-                        {
+                        if (cnx->ack_delay_local < 1000) {
                             cnx->ack_delay_local = 1000;
                         }
-					}
-					else
-					{
-						/* Computation per RFC 6298 */
-						int64_t delta_rtt = rtt_estimate - cnx->smoothed_rtt;
-						int64_t delta_rtt_average = 0;
-						cnx->smoothed_rtt += delta_rtt / 8;
+                    } else {
+                        /* Computation per RFC 6298 */
+                        int64_t delta_rtt = rtt_estimate - cnx->smoothed_rtt;
+                        int64_t delta_rtt_average = 0;
+                        cnx->smoothed_rtt += delta_rtt / 8;
 
-						if (delta_rtt < 0)
-						{
-							delta_rtt_average = (-delta_rtt) - cnx->rtt_variant;
-						}
-						else
-						{
-							delta_rtt_average = delta_rtt - cnx->rtt_variant;
-						}
+                        if (delta_rtt < 0) {
+                            delta_rtt_average = (-delta_rtt) - cnx->rtt_variant;
+                        } else {
+                            delta_rtt_average = delta_rtt - cnx->rtt_variant;
+                        }
                         cnx->rtt_variant += delta_rtt_average / 4;
 
-						if (rtt_estimate < (int64_t) cnx->rtt_min)
-						{
-							cnx->rtt_min = rtt_estimate;
+                        if (rtt_estimate < (int64_t)cnx->rtt_min) {
+                            cnx->rtt_min = rtt_estimate;
 
                             cnx->ack_delay_local = cnx->rtt_min / 4;
-                            if (cnx->ack_delay_local < 1000)
-                            {
+                            if (cnx->ack_delay_local < 1000) {
                                 cnx->ack_delay_local = 1000;
-                            }
-                            else if (cnx->ack_delay_local > 10000)
-                            {
+                            } else if (cnx->ack_delay_local > 10000) {
                                 cnx->ack_delay_local = 10000;
                             }
-						}
+                        }
 
-                        if (4 * cnx->rtt_variant < cnx->rtt_min)
-                        {
+                        if (4 * cnx->rtt_variant < cnx->rtt_min) {
                             cnx->rtt_variant = cnx->rtt_min / 4;
                         }
 
                         cnx->retransmit_timer = cnx->smoothed_rtt + 4 * cnx->rtt_variant + cnx->max_ack_delay;
-					}
+                    }
 
-					if (PICOQUIC_MIN_RETRANSMIT_TIMER > cnx->retransmit_timer)
-					{
-						cnx->retransmit_timer = PICOQUIC_MIN_RETRANSMIT_TIMER;
-					}
+                    if (PICOQUIC_MIN_RETRANSMIT_TIMER > cnx->retransmit_timer) {
+                        cnx->retransmit_timer = PICOQUIC_MIN_RETRANSMIT_TIMER;
+                    }
 
-
-					if (cnx->congestion_alg != NULL)
-					{
-						cnx->congestion_alg->alg_notify(cnx,
-							picoquic_congestion_notification_rtt_measurement,
-							rtt_estimate, 0, 0, current_time);
-					}
-				}
-			}
-		}
-	}
-
-	return packet;
-}
-
-static void picoquic_process_ack_of_ack_range(picoquic_sack_item_t * first_sack, 
-    uint64_t start_of_range, uint64_t end_of_range)
-{
-    if (first_sack->start_of_sack_range == start_of_range)
-    {
-        if (end_of_range < first_sack->end_of_sack_range)
-        {
-            first_sack->start_of_sack_range = end_of_range + 1;
-        }
-        else
-        {
-            first_sack->start_of_sack_range = first_sack->end_of_sack_range;
+                    if (cnx->congestion_alg != NULL) {
+                        cnx->congestion_alg->alg_notify(cnx,
+                            picoquic_congestion_notification_rtt_measurement,
+                            rtt_estimate, 0, 0, current_time);
+                    }
+                }
+            }
         }
     }
-    else
-    {
-        picoquic_sack_item_t * previous = first_sack;
-        picoquic_sack_item_t * next = previous->next_sack;
 
-        while (next != NULL)
-        {
-            if (next->end_of_sack_range == end_of_range &&
-                next->start_of_sack_range == start_of_range)
-            {
+    return packet;
+}
+
+static void picoquic_process_ack_of_ack_range(picoquic_sack_item_t* first_sack,
+    uint64_t start_of_range, uint64_t end_of_range)
+{
+    if (first_sack->start_of_sack_range == start_of_range) {
+        if (end_of_range < first_sack->end_of_sack_range) {
+            first_sack->start_of_sack_range = end_of_range + 1;
+        } else {
+            first_sack->start_of_sack_range = first_sack->end_of_sack_range;
+        }
+    } else {
+        picoquic_sack_item_t* previous = first_sack;
+        picoquic_sack_item_t* next = previous->next_sack;
+
+        while (next != NULL) {
+            if (next->end_of_sack_range == end_of_range && next->start_of_sack_range == start_of_range) {
                 /* Matching range should be removed */
                 previous->next_sack = next->next_sack;
                 free(next);
                 break;
-            }
-            else if (next->end_of_sack_range > end_of_range)
-            {
+            } else if (next->end_of_sack_range > end_of_range) {
                 previous = next;
                 next = next->next_sack;
-            }
-            else
-            {
+            } else {
                 break;
             }
         }
@@ -1237,67 +971,58 @@ static void picoquic_process_ack_of_ack_range(picoquic_sack_item_t * first_sack,
 }
 
 int picoquic_process_ack_of_ack_frame(
-    picoquic_sack_item_t * first_sack,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+    picoquic_sack_item_t* first_sack,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
-	int ret;
-	uint64_t largest;
-	uint64_t ack_delay;
-	uint64_t num_block;
+    int ret;
+    uint64_t largest;
+    uint64_t ack_delay;
+    uint64_t num_block;
 
-	/* Find the oldest ACK range, in order to calibrate the
+    /* Find the oldest ACK range, in order to calibrate the
 	 * extension of the largest number to 64 bits */
 
-	picoquic_sack_item_t * target_sack = first_sack;
-	while (target_sack->next_sack != NULL)
-	{
-		target_sack = target_sack->next_sack;
-	}
+    picoquic_sack_item_t* target_sack = first_sack;
+    while (target_sack->next_sack != NULL) {
+        target_sack = target_sack->next_sack;
+    }
 
-	ret = picoquic_parse_ack_header(bytes, bytes_max,
+    ret = picoquic_parse_ack_header(bytes, bytes_max,
         &num_block, &largest, &ack_delay, consumed, 0);
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         size_t byte_index = *consumed;
         uint64_t extra_ack = 1;
 
         /* Process each successive range */
 
-        while (1)
-        {
+        while (1) {
             uint64_t range;
             size_t l_range;
             uint64_t block_to_block;
 
-            if (byte_index >= bytes_max)
-            {
+            if (byte_index >= bytes_max) {
                 ret = -1;
                 break;
             }
 
             l_range = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &range);
-            if (l_range == 0)
-            {
+            if (l_range == 0) {
                 byte_index = bytes_max;
                 ret = -1;
                 break;
-            }
-            else
-            {
+            } else {
                 byte_index += l_range;
             }
 
             range += extra_ack;
-            if (largest + 1 < range)
-            {
+            if (largest + 1 < range) {
                 DBG_PRINTF("ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
                 ret = -1;
                 break;
             }
 
-            if (range > 0)
-            {
+            if (range > 0) {
                 picoquic_process_ack_of_ack_range(first_sack, largest + 1 - range, largest);
             }
 
@@ -1306,29 +1031,22 @@ int picoquic_process_ack_of_ack_frame(
 
             /* Skip the gap */
 
-            if (byte_index >= bytes_max)
-            {
+            if (byte_index >= bytes_max) {
                 ret = -1;
                 break;
-            }
-            else
-            {
+            } else {
                 size_t l_gap = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &block_to_block);
-                if (l_gap == 0)
-                {
+                if (l_gap == 0) {
                     byte_index = bytes_max;
                     ret = -1;
                     break;
-                }
-                else
-                {
+                } else {
                     byte_index += l_gap;
                     block_to_block += range;
                 }
             }
 
-            if (largest < block_to_block)
-            {
+            if (largest < block_to_block) {
                 DBG_PRINTF("ack gap error: largest=%" PRIx64 ", range=%" PRIx64 ", gap=%" PRIu64,
                     largest, range, block_to_block - range);
                 ret = -1;
@@ -1342,43 +1060,35 @@ int picoquic_process_ack_of_ack_frame(
         *consumed = byte_index;
     }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_check_stream_frame_already_acked(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, int * no_need_to_repeat)
+int picoquic_check_stream_frame_already_acked(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, int* no_need_to_repeat)
 {
     int ret = 0;
-    int      fin;
-    size_t   data_length;
+    int fin;
+    size_t data_length;
     uint64_t stream_id;
     uint64_t offset;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     size_t consumed = 0;
 
     *no_need_to_repeat = 0;
 
-    if (bytes[0] >= picoquic_frame_type_stream_range_min && bytes[0] <= picoquic_frame_type_stream_range_max)
-    {
+    if (bytes[0] >= picoquic_frame_type_stream_range_min && bytes[0] <= picoquic_frame_type_stream_range_max) {
         ret = picoquic_parse_stream_header(bytes, bytes_max,
             &stream_id, &offset, &data_length, &fin, &consumed);
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             stream = picoquic_find_stream(cnx, stream_id, 0);
-            if (stream == NULL)
-            {
+            if (stream == NULL) {
                 /* this is weird -- the stream was destroyed. */
                 *no_need_to_repeat = 1;
-            }
-            else
-            {
-                if ((stream->stream_flags&picoquic_stream_flag_reset_sent) != 0)
-                {
+            } else {
+                if ((stream->stream_flags & picoquic_stream_flag_reset_sent) != 0) {
                     *no_need_to_repeat = 1;
-                }
-                else
-                {
+                } else {
                     /* Check whether the ack was already received */
                     *no_need_to_repeat = picoquic_check_sack_list(&stream->first_sack_item, offset, offset + data_length);
                 }
@@ -1389,72 +1099,62 @@ int picoquic_check_stream_frame_already_acked(picoquic_cnx_t * cnx, uint8_t * by
     return ret;
 }
 
-static int picoquic_process_ack_of_stream_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+static int picoquic_process_ack_of_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
-    int      ret;
-    int      fin;
-    size_t   data_length;
+    int ret;
+    int fin;
+    size_t data_length;
     uint64_t stream_id;
     uint64_t offset;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
 
     /* skip stream frame */
     ret = picoquic_parse_stream_header(bytes, bytes_max,
-                                       &stream_id, &offset, &data_length, &fin, consumed);
+        &stream_id, &offset, &data_length, &fin, consumed);
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         *consumed += data_length;
 
         /* record the ack range for the stream */
         stream = picoquic_find_stream(cnx, stream_id, 0);
-        if (stream != NULL)
-        {
+        if (stream != NULL) {
             uint64_t blocksize;
             (void)picoquic_update_sack_list(&stream->first_sack_item,
-                    offset, offset + data_length - 1, &blocksize);
+                offset, offset + data_length - 1, &blocksize);
         }
     }
 
     return ret;
 }
 
-void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t * cnx, picoquic_packet * p)
+void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_packet* p)
 {
     int ret = 0;
     size_t byte_index;
     picoquic_packet_header ph;
     int frame_is_pure_ack = 0;
     size_t frame_length = 0;
-    picoquic_cnx_t * pcnx = cnx;
+    picoquic_cnx_t* pcnx = cnx;
 
     /* Get the packet type */
     ret = picoquic_parse_packet_header(cnx->quic, p->bytes, (uint32_t)p->length, NULL, &ph, &pcnx);
 
-    if (ret == 0 && ph.ptype == picoquic_packet_0rtt_protected)
-    {
+    if (ret == 0 && ph.ptype == picoquic_packet_0rtt_protected) {
         cnx->nb_zero_rtt_acked++;
     }
 
     byte_index = ph.offset;
 
-    while (ret == 0 && byte_index < p->length)
-    {
-        if (p->bytes[byte_index] == picoquic_frame_type_ack)
-        {
+    while (ret == 0 && byte_index < p->length) {
+        if (p->bytes[byte_index] == picoquic_frame_type_ack) {
             ret = picoquic_process_ack_of_ack_frame(&cnx->first_sack_item, &p->bytes[byte_index],
                 p->length - byte_index, &frame_length);
             byte_index += frame_length;
-        }
-        else if (p->bytes[byte_index] >= picoquic_frame_type_stream_range_min &&
-            p->bytes[byte_index] <= picoquic_frame_type_stream_range_max)
-        {
+        } else if (p->bytes[byte_index] >= picoquic_frame_type_stream_range_min && p->bytes[byte_index] <= picoquic_frame_type_stream_range_max) {
             ret = picoquic_process_ack_of_stream_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
-        }
-        else
-        {
+        } else {
             ret = picoquic_skip_frame(&p->bytes[byte_index],
                 p->length - ph.offset, &frame_length, &frame_is_pure_ack);
             byte_index += frame_length;
@@ -1462,99 +1162,85 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t * cnx, picoquic_p
     }
 }
 
-static picoquic_packet * picoquic_process_ack_range(
-	picoquic_cnx_t * cnx, uint64_t highest, uint64_t range, picoquic_packet * p,
-	uint64_t current_time, int restricted, int * ret)
+static picoquic_packet* picoquic_process_ack_range(
+    picoquic_cnx_t* cnx, uint64_t highest, uint64_t range, picoquic_packet* p,
+    uint64_t current_time, int restricted, int* ret)
 {
-	/* Compare the range to the retransmit queue */
-	while (p != NULL && range > 0)
-	{
-		if (p->sequence_number > highest)
-		{
-			p = p->next_packet;
-		}
-		else
-		{
-            if (restricted)
-            {
+    /* Compare the range to the retransmit queue */
+    while (p != NULL && range > 0) {
+        if (p->sequence_number > highest) {
+            p = p->next_packet;
+        } else {
+            if (restricted) {
                 /* check that the packet was sent in clear text */
-                if (picoquic_is_packet_encrypted(cnx, p->bytes[0]))
-                {
+                if (picoquic_is_packet_encrypted(cnx, p->bytes[0])) {
                     /* Protocol error! */
-                    *ret = picoquic_connection_error(cnx, 
+                    *ret = picoquic_connection_error(cnx,
                         PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
                     p = NULL;
                     break;
                 }
             }
 
-			if (p->sequence_number == highest)
-			{
-				/* TODO: RTT Estimate */
-				picoquic_packet * next = p->next_packet;
-				if (cnx->congestion_alg != NULL)
-				{
-					cnx->congestion_alg->alg_notify(cnx,
-						picoquic_congestion_notification_acknowledgement,
-						0, p->length, 0, current_time);
-				}
+            if (p->sequence_number == highest) {
+                /* TODO: RTT Estimate */
+                picoquic_packet* next = p->next_packet;
+                if (cnx->congestion_alg != NULL) {
+                    cnx->congestion_alg->alg_notify(cnx,
+                        picoquic_congestion_notification_acknowledgement,
+                        0, p->length, 0, current_time);
+                }
 
                 /* If the packet contained an ACK frame, perform the ACK of ACK pruning logic */
                 picoquic_process_possible_ack_of_ack_frame(cnx, p);
 
                 /* If packet is larger than the current MTU, update the MTU */
-                if ((p->length + p->checksum_overhead) > cnx->send_mtu)
-                {
+                if ((p->length + p->checksum_overhead) > cnx->send_mtu) {
                     cnx->send_mtu = p->length + p->checksum_overhead;
                     cnx->mtu_probe_sent = 0;
                 }
 
-				picoquic_dequeue_retransmit_packet(cnx, p, 1);
-				p = next;
-				/* Any acknowledgement shows progress */
-				cnx->nb_retransmit = 0;
-			}
+                picoquic_dequeue_retransmit_packet(cnx, p, 1);
+                p = next;
+                /* Any acknowledgement shows progress */
+                cnx->nb_retransmit = 0;
+            }
 
-			range--;
-			highest--;
-		}
-	}
+            range--;
+            highest--;
+        }
+    }
 
-	return p;
+    return p;
 }
 
-int picoquic_decode_ack_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed, uint64_t current_time, int restricted)
+int picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed, uint64_t current_time, int restricted)
 {
-	int ret;
-	uint64_t num_block;
-	uint64_t largest;
-	uint64_t ack_delay;
+    int ret;
+    uint64_t num_block;
+    uint64_t largest;
+    uint64_t ack_delay;
 
-	ret = picoquic_parse_ack_header(bytes, bytes_max,
+    ret = picoquic_parse_ack_header(bytes, bytes_max,
         &num_block, &largest, &ack_delay, consumed,
         cnx->remote_parameters.ack_delay_exponent);
 
-    if (ret != 0)
-    {
+    if (ret != 0) {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
-    }
-    else
-	{
-		size_t byte_index = *consumed;
+    } else {
+        size_t byte_index = *consumed;
 
-		/* Attempt to update the RTT */
-		picoquic_packet * top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay);
-		unsigned extra_ack = 1;
+        /* Attempt to update the RTT */
+        picoquic_packet* top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay);
+        unsigned extra_ack = 1;
 
-        while (ret == 0)
-        {
+        while (ret == 0) {
             uint64_t range;
             uint64_t block_to_block;
 
-            if (byte_index >= bytes_max)
-            {
+            if (byte_index >= bytes_max) {
                 DBG_PRINTF("Malformed ACK RANGE, %d blocks remain.\n", (int)num_block);
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
@@ -1562,39 +1248,33 @@ int picoquic_decode_ack_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
             }
 
             size_t l_range = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &range);
-            if (l_range == 0)
-            {
+            if (l_range == 0) {
                 byte_index = bytes_max;
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
                 DBG_PRINTF("Malformed ACK RANGE, requires %d bytes out of %d\n", (int)picoquic_varint_skip(bytes),
                     (int)bytes_max - byte_index);
                 break;
-            }
-            else
-            {
+            } else {
                 byte_index += l_range;
             }
 
             range += extra_ack;
-            if (largest + 1 < range)
-            {
+            if (largest + 1 < range) {
                 DBG_PRINTF("ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
                 break;
             }
 
-            top_packet = picoquic_process_ack_range(cnx, largest, range, 
+            top_packet = picoquic_process_ack_range(cnx, largest, range,
                 top_packet, current_time, restricted, &ret);
 
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 break;
             }
 
-            if (range > 0)
-            {
+            if (range > 0) {
                 picoquic_check_spurious_retransmission(cnx, largest + 1 - range, largest, current_time);
             }
 
@@ -1603,34 +1283,27 @@ int picoquic_decode_ack_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
 
             /* Skip the gap */
 
-            if (byte_index >= bytes_max)
-            {
+            if (byte_index >= bytes_max) {
                 DBG_PRINTF("    Malformed ACK GAP, %d blocks remain.\n", (int)num_block);
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
                 break;
-            }
-            else
-            {
+            } else {
                 size_t l_gap = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &block_to_block);
-                if (l_gap == 0)
-                {
+                if (l_gap == 0) {
                     DBG_PRINTF("    Malformed ACK GAP, requires %d bytes out of %d\n", (int)picoquic_varint_skip(bytes),
                         (int)bytes_max - byte_index);
                     byte_index = bytes_max;
                     ret = picoquic_connection_error(cnx,
                         PICOQUIC_TRANSPORT_FRAME_ERROR(bytes[0]));
                     break;
-                }
-                else
-                {
+                } else {
                     block_to_block += range;
                     byte_index += l_gap;
                 }
             }
 
-            if (largest < block_to_block)
-            {
+            if (largest < block_to_block) {
                 DBG_PRINTF("ack gap error: largest=%" PRIx64 ", range=%" PRIx64 ", gap=%" PRIu64,
                     largest, range, block_to_block - range);
                 ret = picoquic_connection_error(cnx,
@@ -1642,14 +1315,14 @@ int picoquic_decode_ack_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
             extra_ack = 0;
         }
 
-		*consumed = byte_index;
-	}
+        *consumed = byte_index;
+    }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t byte_index = 0;
@@ -1657,7 +1330,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
     size_t l_largest = 0;
     size_t l_delay = 0;
     size_t l_first_range = 0;
-    picoquic_sack_item_t * next_sack = cnx->first_sack_item.next_sack;
+    picoquic_sack_item_t* next_sack = cnx->first_sack_item.next_sack;
     uint64_t ack_delay = 0;
     uint64_t ack_range = 0;
     uint64_t ack_gap = 0;
@@ -1665,35 +1338,26 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
     size_t num_block_index = 0;
 
     /* Check that there is enough room in the packet, and something to acknowledge */
-    if (cnx->first_sack_item.start_of_sack_range == 0 &&
-        cnx->first_sack_item.end_of_sack_range == 0)
-    {
+    if (cnx->first_sack_item.start_of_sack_range == 0 && cnx->first_sack_item.end_of_sack_range == 0) {
         *consumed = 0;
-    }
-    else if (bytes_max < 13)
-    {
+    } else if (bytes_max < 13) {
         /* A valid ACK, with our encoding, uses at least 13 bytes.
         * If there is not enough space, don't attempt to encode it.
         */
         *consumed = 0;
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-    }
-    else
-    {
+    } else {
         /* Encode the first byte */
         bytes[byte_index++] = picoquic_frame_type_ack;
         /* Encode the largest seen */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             l_largest = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
                 cnx->first_sack_item.end_of_sack_range);
             byte_index += l_largest;
         }
         /* Encode the ack delay */
-        if (byte_index < bytes_max)
-        {
-            if (current_time > cnx->time_stamp_largest_received)
-            {
+        if (byte_index < bytes_max) {
+            if (current_time > cnx->time_stamp_largest_received) {
                 ack_delay = current_time - cnx->time_stamp_largest_received;
                 ack_delay >>= cnx->local_parameters.ack_delay_exponent;
             }
@@ -1705,51 +1369,41 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
         num_block_index = byte_index;
         byte_index++;
         /* Encode the size of the first ack range */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             ack_range = cnx->first_sack_item.end_of_sack_range - cnx->first_sack_item.start_of_sack_range;
             l_first_range = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
                 ack_range);
             byte_index += l_first_range;
         }
 
-        if (l_delay == 0 || l_largest == 0 || l_first_range == 0 || byte_index > bytes_max)
-        {
+        if (l_delay == 0 || l_largest == 0 || l_first_range == 0 || byte_index > bytes_max) {
             /* not enough space */
             *consumed = 0;
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-        }
-        else
-        {
+        } else {
             /* Set the lowest acknowledged */
             lowest_acknowledged = cnx->first_sack_item.start_of_sack_range;
             /* Encode the ack blocks that fir in the allocated space */
-            while (num_block < 63 && next_sack != NULL)
-            {
+            while (num_block < 63 && next_sack != NULL) {
                 size_t l_gap = 0;
                 size_t l_range = 0;
 
-                if (byte_index < bytes_max)
-                {
+                if (byte_index < bytes_max) {
                     ack_gap = lowest_acknowledged - next_sack->end_of_sack_range - 1;
                     l_gap = picoquic_varint_encode(bytes + byte_index,
                         bytes_max - byte_index, ack_gap);
                 }
 
-                if (byte_index + l_gap < bytes_max)
-                {
+                if (byte_index + l_gap < bytes_max) {
                     ack_range = next_sack->end_of_sack_range - next_sack->start_of_sack_range + 1;
                     l_range = picoquic_varint_encode(bytes + byte_index + l_gap,
                         bytes_max - byte_index - l_gap, ack_range);
                 }
 
-                if (l_gap == 0 || l_range == 0)
-                {
+                if (l_gap == 0 || l_range == 0) {
                     /* Not enough space to encode this gap. */
                     break;
-                }
-                else
-                {
+                } else {
                     byte_index += l_gap + l_range;
                     lowest_acknowledged = next_sack->start_of_sack_range;
                     next_sack = next_sack->next_sack;
@@ -1757,7 +1411,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
                 }
             }
             /* When numbers are lower than 64, varint encoding fits on one byte */
-            bytes[num_block_index] = (uint8_t) num_block;
+            bytes[num_block_index] = (uint8_t)num_block;
 
             /* Remember the ACK value and time */
             cnx->highest_ack_sent = cnx->first_sack_item.end_of_sack_range;
@@ -1767,45 +1421,38 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
         }
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         cnx->ack_needed = 0;
     }
 
     return ret;
 }
 
-int picoquic_is_ack_needed(picoquic_cnx_t * cnx, uint64_t current_time)
+int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time)
 {
-	int ret = 0;
+    int ret = 0;
 
-	if (cnx->highest_ack_sent + 2 <= cnx->first_sack_item.end_of_sack_range ||
-			cnx->highest_ack_time + cnx->ack_delay_local <= current_time)
-	{
-		ret = cnx->ack_needed;
-	}
-    else if (cnx->ack_needed)
-    {
+    if (cnx->highest_ack_sent + 2 <= cnx->first_sack_item.end_of_sack_range || cnx->highest_ack_time + cnx->ack_delay_local <= current_time) {
+        ret = cnx->ack_needed;
+    } else if (cnx->ack_needed) {
         ret = 0;
     }
 
-	return ret;
+    return ret;
 }
 
 /*
  * Connection close frame
  */
 
-
-int picoquic_prepare_connection_close_frame(picoquic_cnx_t * cnx,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_connection_close_frame(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t byte_index = 0;
     size_t l1 = 0;
 
-    if (bytes_max > 4)
-    {
+    if (bytes_max > 4) {
         bytes[byte_index++] = picoquic_frame_type_connection_close;
         picoformat_16(bytes + byte_index, (uint16_t)cnx->local_error);
         byte_index += 2;
@@ -1813,14 +1460,11 @@ int picoquic_prepare_connection_close_frame(picoquic_cnx_t * cnx,
         byte_index += l1;
         *consumed = byte_index;
 
-        if (l1 == 0)
-        {
+        if (l1 == 0) {
             *consumed = 0;
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         }
-    }
-    else
-    {
+    } else {
         *consumed = 0;
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
     }
@@ -1828,16 +1472,15 @@ int picoquic_prepare_connection_close_frame(picoquic_cnx_t * cnx,
     return ret;
 }
 
-int picoquic_decode_connection_close_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint32_t error_code = 0;
     uint64_t string_length = 0;
     size_t byte_index = 1;
     size_t l1 = 0;
-    if (bytes_max >= 4)
-    {
+    if (bytes_max >= 4) {
         error_code = PICOPARSE_16(bytes + byte_index);
         byte_index += 2;
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &string_length);
@@ -1845,27 +1488,21 @@ int picoquic_decode_connection_close_frame(picoquic_cnx_t * cnx, uint8_t * bytes
         byte_index += (size_t)string_length;
     }
 
-    if (l1 == 0 || byte_index > bytes_max)
-    {
+    if (l1 == 0 || byte_index > bytes_max) {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_connection_close));
         *consumed = bytes_max;
     }
 
-    if (ret == 0)
-    {
-        if (cnx->cnx_state < picoquic_state_client_ready)
-        {
+    if (ret == 0) {
+        if (cnx->cnx_state < picoquic_state_client_ready) {
             cnx->cnx_state = picoquic_state_disconnected;
-        }
-        else
-        {
+        } else {
             cnx->cnx_state = picoquic_state_closing_received;
         }
         cnx->remote_error = error_code;
         *consumed = (size_t)(string_length + byte_index);
-        if (cnx->callback_fn)
-        {
+        if (cnx->callback_fn) {
             (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
         }
     }
@@ -1877,15 +1514,14 @@ int picoquic_decode_connection_close_frame(picoquic_cnx_t * cnx, uint8_t * bytes
  * Application close frame
  */
 
-int picoquic_prepare_application_close_frame(picoquic_cnx_t * cnx,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_application_close_frame(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t byte_index = 0;
     size_t l1 = 0;
 
-    if (bytes_max >= 4)
-    {
+    if (bytes_max >= 4) {
         bytes[byte_index++] = picoquic_frame_type_application_close;
         picoformat_16(bytes + byte_index, (uint16_t)cnx->application_error);
         byte_index += 2;
@@ -1893,14 +1529,11 @@ int picoquic_prepare_application_close_frame(picoquic_cnx_t * cnx,
         byte_index += l1;
         *consumed = byte_index;
 
-        if (l1 == 0)
-        {
+        if (l1 == 0) {
             *consumed = 0;
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         }
-    }
-    else
-    {
+    } else {
         *consumed = 0;
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
     }
@@ -1908,16 +1541,15 @@ int picoquic_prepare_application_close_frame(picoquic_cnx_t * cnx,
     return ret;
 }
 
-int picoquic_decode_application_close_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_application_close_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint32_t error_code = 0;
     uint64_t string_length = 0;
     size_t byte_index = 1;
     size_t l1 = 0;
-    if (bytes_max >= 4)
-    {
+    if (bytes_max >= 4) {
         error_code = PICOPARSE_16(bytes + byte_index);
         byte_index += 2;
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &string_length);
@@ -1925,20 +1557,17 @@ int picoquic_decode_application_close_frame(picoquic_cnx_t * cnx, uint8_t * byte
         byte_index += (size_t)string_length;
     }
 
-    if (l1 == 0 || byte_index > bytes_max)
-    {
+    if (l1 == 0 || byte_index > bytes_max) {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_application_close));
         *consumed = bytes_max;
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         cnx->cnx_state = picoquic_state_closing_received;
         cnx->remote_application_error = error_code;
         *consumed = (size_t)(string_length + byte_index);
-        if (cnx->callback_fn)
-        {
+        if (cnx->callback_fn) {
             (cnx->callback_fn)(cnx, 0, NULL, 0,
                 picoquic_callback_application_close, cnx->callback_ctx);
         }
@@ -1955,54 +1584,44 @@ int picoquic_decode_application_close_frame(picoquic_cnx_t * cnx, uint8_t * byte
 #define PICOQUIC_MAX_MAXDATA_1K (PICOQUIC_MAX_MAXDATA >> 10)
 #define PICOQUIC_MAX_MAXDATA_1K_MASK (PICOQUIC_MAX_MAXDATA << 10)
 
-int picoquic_prepare_max_data_frame(picoquic_cnx_t * cnx, uint64_t maxdata_increase,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_max_data_frame(picoquic_cnx_t* cnx, uint64_t maxdata_increase,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t l1 = 0;
 
-	if (bytes_max < 1)
-	{
-		ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-	}
-    else
-    {
+    if (bytes_max < 1) {
+        ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
+    } else {
         bytes[0] = picoquic_frame_type_max_data;
         l1 = picoquic_varint_encode(bytes + 1, bytes_max - 1, cnx->maxdata_local + maxdata_increase);
 
-        if (l1 == 0)
-        {
+        if (l1 == 0) {
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-        }
-        else
-        {
+        } else {
             cnx->maxdata_local = (cnx->maxdata_local + maxdata_increase);
         }
 
         *consumed = 1 + l1;
     }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_decode_max_data_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_max_data_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint64_t maxdata;
     /* TODO: what about reason message? */
     size_t l1 = picoquic_varint_decode(bytes + 1, bytes_max - 1, &maxdata);
 
-    if (l1 > 0)
-    {
+    if (l1 > 0) {
         *consumed = 1 + l1;
-        if (maxdata > cnx->maxdata_remote)
-        {
+        if (maxdata > cnx->maxdata_remote) {
             cnx->maxdata_remote = maxdata;
         }
-    }
-    else
-    {
+    } else {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_max_data));
         *consumed = bytes_max;
@@ -2015,20 +1634,17 @@ int picoquic_decode_max_data_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * Max stream data frame
  */
 
-int picoquic_prepare_max_stream_data_frame(picoquic_stream_head * stream,
-    uint8_t * bytes, size_t bytes_max, uint64_t new_max_data, size_t * consumed)
+int picoquic_prepare_max_stream_data_frame(picoquic_stream_head* stream,
+    uint8_t* bytes, size_t bytes_max, uint64_t new_max_data, size_t* consumed)
 {
     int ret = 0;
     size_t l1 = picoquic_varint_encode(bytes + 1, bytes_max - 1, stream->stream_id);
     size_t l2 = picoquic_varint_encode(bytes + 1 + l1, bytes_max - 1 - l1, new_max_data);
 
-    if (l1 == 0 || l2 == 0)
-    {
+    if (l1 == 0 || l2 == 0) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         *consumed = 0;
-    }
-    else
-    {
+    } else {
         bytes[0] = picoquic_frame_type_max_stream_data;
         *consumed = 1 + l1 + l2;
         stream->maxdata_local = new_max_data;
@@ -2037,46 +1653,35 @@ int picoquic_prepare_max_stream_data_frame(picoquic_stream_head * stream,
     return ret;
 }
 
-int picoquic_decode_max_stream_data_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_max_stream_data_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint64_t stream_id = 0;
     uint64_t maxdata = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     size_t l1 = picoquic_varint_decode(bytes + 1, bytes_max - 1, &stream_id);
     size_t l2 = picoquic_varint_decode(bytes + 1 + l1, bytes_max - 1 - l1, &maxdata);
 
-    if (l1 == 0 || l2 == 0)
-    {
+    if (l1 == 0 || l2 == 0) {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_max_stream_data));
         *consumed = bytes_max;
-    }
-    else
-    {
+    } else {
         *consumed = 1 + l1 + l2;
     }
 
-    if (ret == 0)
-    {
-        if (stream_id == 0)
-        {
+    if (ret == 0) {
+        if (stream_id == 0) {
             ret = PICOQUIC_ERROR_CANNOT_CONTROL_STREAM_ZERO;
-        }
-        else
-        {
+        } else {
             stream = picoquic_find_stream(cnx, stream_id, 1);
 
-            if (stream == NULL)
-            {
+            if (stream == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
-            }
-            else
-            {
+            } else {
                 /* TODO: call back if the stream was blocked? */
-                if (maxdata > stream->maxdata_remote)
-                {
+                if (maxdata > stream->maxdata_remote) {
                     stream->maxdata_remote = maxdata;
                 }
             }
@@ -2086,70 +1691,55 @@ int picoquic_decode_max_stream_data_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
     return ret;
 }
 
-int picoquic_prepare_required_max_stream_data_frames(picoquic_cnx_t * cnx,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_required_max_stream_data_frames(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
-	int ret = 0;
-	size_t byte_index = 0;
-	picoquic_stream_head * stream = &cnx->first_stream;
+    int ret = 0;
+    size_t byte_index = 0;
+    picoquic_stream_head* stream = &cnx->first_stream;
 
-	while (stream != NULL && ret == 0 && byte_index < bytes_max)
-	{
-		if (stream->stream_id != 0 &&
-			(stream->stream_flags&(picoquic_stream_flag_fin_received |
-				picoquic_stream_flag_reset_received)) == 0 &&
-			2 * stream->consumed_offset > stream->maxdata_local)
-		{
-			size_t bytes_in_frame = 0;
+    while (stream != NULL && ret == 0 && byte_index < bytes_max) {
+        if (stream->stream_id != 0 && (stream->stream_flags & (picoquic_stream_flag_fin_received | picoquic_stream_flag_reset_received)) == 0 && 2 * stream->consumed_offset > stream->maxdata_local) {
+            size_t bytes_in_frame = 0;
 
-			ret = picoquic_prepare_max_stream_data_frame(stream,
-				bytes + byte_index, bytes_max - byte_index,
-				stream->maxdata_local + 2 * stream->consumed_offset,
-				&bytes_in_frame);
-			if (ret == 0)
-			{
-				byte_index += bytes_in_frame;
-			}
-            else
-            {
+            ret = picoquic_prepare_max_stream_data_frame(stream,
+                bytes + byte_index, bytes_max - byte_index,
+                stream->maxdata_local + 2 * stream->consumed_offset,
+                &bytes_in_frame);
+            if (ret == 0) {
+                byte_index += bytes_in_frame;
+            } else {
                 break;
             }
-		}
-		stream = stream->next_stream;
-	}
+        }
+        stream = stream->next_stream;
+    }
 
-	if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-	{
-		ret = 0;
-	}
+    if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+        ret = 0;
+    }
 
-	if (ret == 0)
-	{
-		*consumed = byte_index;
-	}
-	else
-	{
-		*consumed = 0;
-	}
+    if (ret == 0) {
+        *consumed = byte_index;
+    } else {
+        *consumed = 0;
+    }
 
-	return ret;
+    return ret;
 }
 
 /*
  * Max stream ID frame
  */
-int picoquic_prepare_max_stream_ID_frame(picoquic_cnx_t * cnx, uint32_t increment,
-    uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_max_stream_ID_frame(picoquic_cnx_t* cnx, uint32_t increment,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t l1 = picoquic_varint_encode(bytes + 1, bytes_max - 1, cnx->max_stream_id_bidir_local + increment);
 
-    if (l1 == 0)
-    {
+    if (l1 == 0) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
-    }
-    else
-    {
+    } else {
         bytes[0] = picoquic_frame_type_max_stream_id;
         cnx->max_stream_id_bidir_local += increment;
         *consumed = 1 + l1;
@@ -2158,56 +1748,41 @@ int picoquic_prepare_max_stream_ID_frame(picoquic_cnx_t * cnx, uint32_t incremen
     return ret;
 }
 
-int picoquic_decode_max_stream_id_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_max_stream_id_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     uint64_t max_stream_id;
 
     size_t l1 = picoquic_varint_decode(bytes + 1, bytes_max - 1, &max_stream_id);
-    if (l1 == 0)
-    {
+    if (l1 == 0) {
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_max_stream_id));
         *consumed = bytes_max;
         max_stream_id = 0;
-    }
-    else
-    {
+    } else {
         *consumed = 1 + l1;
     }
 
-    if (ret == 0)
-    {
-        if (cnx->client_mode)
-        {
+    if (ret == 0) {
+        if (cnx->client_mode) {
             /* Should only accept client stream ID */
-            if ((max_stream_id & 1) != 0)
-            {
+            if ((max_stream_id & 1) != 0) {
                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_ID_ERROR);
             }
-        }
-        else
-        {
-            if ((max_stream_id & 1) == 0)
-            {
+        } else {
+            if ((max_stream_id & 1) == 0) {
                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_ID_ERROR);
             }
         }
 
-        if (ret == 0)
-        {
-            if ((max_stream_id & 2) == 0)
-            {
-                if (max_stream_id > cnx->max_stream_id_bidir_remote)
-                {
+        if (ret == 0) {
+            if ((max_stream_id & 2) == 0) {
+                if (max_stream_id > cnx->max_stream_id_bidir_remote) {
                     cnx->max_stream_id_bidir_remote = max_stream_id;
                 }
-            }
-            else
-            {
-                if (max_stream_id > cnx->max_stream_id_unidir_remote)
-                {
+            } else {
+                if (max_stream_id > cnx->max_stream_id_unidir_remote) {
                     cnx->max_stream_id_unidir_remote = max_stream_id;
                 }
             }
@@ -2221,20 +1796,17 @@ int picoquic_decode_max_stream_id_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * Sending of miscellaneous frames
  */
 
-int picoquic_prepare_misc_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_prepare_misc_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
-    picoquic_misc_frame_header_t * misc_frame = cnx->first_misc_frame;
+    picoquic_misc_frame_header_t* misc_frame = cnx->first_misc_frame;
 
-    if (misc_frame->length > bytes_max)
-    {
+    if (misc_frame->length > bytes_max) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         *consumed = 0;
-    }
-    else
-    {
-        uint8_t * frame = ((uint8_t *)misc_frame) + sizeof(picoquic_misc_frame_header_t);
+    } else {
+        uint8_t* frame = ((uint8_t*)misc_frame) + sizeof(picoquic_misc_frame_header_t);
         memcpy(bytes, frame, misc_frame->length);
         *consumed = misc_frame->length;
         cnx->first_misc_frame = misc_frame->next_misc_frame;
@@ -2248,22 +1820,19 @@ int picoquic_prepare_misc_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * Ping and Pong frames
  */
 
-int picoquic_decode_ping_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_ping_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t byte_index = 1;
     size_t ping_length = bytes[byte_index++];
 
-    if (byte_index + ping_length > bytes_max)
-    {
+    if (byte_index + ping_length > bytes_max) {
         byte_index = bytes_max;
 
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_ping));
-    }
-    else if (ping_length > 0)
-    {
+    } else if (ping_length > 0) {
         /*
          * Queue a Pong frame as response to Ping.
          */
@@ -2282,30 +1851,26 @@ int picoquic_decode_ping_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
     return ret;
 }
 
-int picoquic_decode_pong_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-    size_t bytes_max, size_t * consumed)
+int picoquic_decode_pong_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t byte_index = 1;
     size_t ping_length = bytes[byte_index++];
 
-    if (byte_index + ping_length > bytes_max)
-    {
+    if (byte_index + ping_length > bytes_max) {
         byte_index = bytes_max;
 
         ret = picoquic_connection_error(cnx,
             PICOQUIC_TRANSPORT_FRAME_ERROR(picoquic_frame_type_pong));
-    }
-    else if (ping_length > 0)
-    {
+    } else if (ping_length > 0) {
         /*
          * Submit the pong frame to the call back if there is one.
          */
 
         byte_index += ping_length;
 
-        if (cnx->callback_fn != NULL)
-        {
+        if (cnx->callback_fn != NULL) {
             cnx->callback_fn(cnx, 0, bytes, byte_index, 0, cnx->callback_ctx);
         }
     }
@@ -2321,122 +1886,111 @@ int picoquic_decode_pong_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
  * In some cases, the expected frames are "restricted" to only ACK, STREAM 0 and PADDING.
  */
 
-int picoquic_decode_frames(picoquic_cnx_t * cnx, uint8_t * bytes,
+int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
     size_t bytes_max, int restricted, uint64_t current_time)
 {
     int ret = 0;
     size_t byte_index = 0;
 
-    while (byte_index < bytes_max && ret == 0)
-    {
+    while (byte_index < bytes_max && ret == 0) {
         uint8_t first_byte = bytes[byte_index];
         size_t consumed = 0;
 
-        if (first_byte >= picoquic_frame_type_stream_range_min &&
-            first_byte <= picoquic_frame_type_stream_range_max)
-        {
+        if (first_byte >= picoquic_frame_type_stream_range_min && first_byte <= picoquic_frame_type_stream_range_max) {
             ret = picoquic_decode_stream_frame(cnx, bytes + byte_index,
                 bytes_max - byte_index, restricted, &consumed, current_time);
             cnx->ack_needed = 1;
             byte_index += consumed;
-        }
-        else if (first_byte == picoquic_frame_type_ack)
-        {
+        } else if (first_byte == picoquic_frame_type_ack) {
             ret = picoquic_decode_ack_frame(cnx, bytes + byte_index,
                 bytes_max - byte_index, &consumed, current_time, restricted);
             byte_index += consumed;
-        }
-        else
-        {
-            if (restricted && first_byte != picoquic_frame_type_padding &&
-                first_byte != picoquic_frame_type_connection_close)
-            {
+        } else {
+            if (restricted && first_byte != picoquic_frame_type_padding && first_byte != picoquic_frame_type_connection_close) {
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_FRAME_ERROR(first_byte));
-            }
-            else switch (first_byte)
-            {
-            case picoquic_frame_type_padding:
-                do {
+            } else
+                switch (first_byte) {
+                case picoquic_frame_type_padding:
+                    do {
+                        byte_index++;
+                    } while (byte_index < bytes_max && bytes[byte_index] == picoquic_frame_type_padding);
+                    break;
+                case picoquic_frame_type_reset_stream:
+                    ret = picoquic_decode_stream_reset_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_connection_close:
+                    ret = picoquic_decode_connection_close_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    break;
+                case picoquic_frame_type_application_close:
+                    ret = picoquic_decode_application_close_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    break;
+                case picoquic_frame_type_max_data:
+                    ret = picoquic_decode_max_data_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_max_stream_data:
+                    ret = picoquic_decode_max_stream_data_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_max_stream_id: /* MAX_STREAM_ID */
+                    ret = picoquic_decode_max_stream_id_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_ping: /* PING */
+                    ret = picoquic_decode_ping_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_blocked: /* BLOCKED */
                     byte_index++;
-                } while (byte_index < bytes_max &&
-                    bytes[byte_index] == picoquic_frame_type_padding);
-                break;
-            case picoquic_frame_type_reset_stream:
-                ret = picoquic_decode_stream_reset_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_connection_close:
-                ret = picoquic_decode_connection_close_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                break;
-            case picoquic_frame_type_application_close:
-                ret = picoquic_decode_application_close_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                break;
-            case picoquic_frame_type_max_data:
-                ret = picoquic_decode_max_data_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_max_stream_data:
-                ret = picoquic_decode_max_stream_data_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_max_stream_id: /* MAX_STREAM_ID */
-                ret = picoquic_decode_max_stream_id_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_ping: /* PING */
-                ret = picoquic_decode_ping_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_blocked: /* BLOCKED */
-                byte_index++;
-                /* Skip the max data offset */
-                byte_index += picoquic_varint_skip(&bytes[byte_index]);
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_stream_blocked: /* STREAM_BLOCKED */
-                byte_index += 1 + picoquic_varint_skip(bytes + byte_index + 1);
-                /* Skip the max data offset */
-                byte_index += picoquic_varint_skip(&bytes[byte_index]);
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_stream_id_needed: /* STREAM_ID_NEEDED */
-                byte_index++;
-                /* Skip the stream ID */
-                byte_index += picoquic_varint_skip(&bytes[byte_index]);
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_new_connection_id: /* NEW_CONNECTION_ID */
-                byte_index += 1;
-                /* Skip the sequence index */
-                byte_index += picoquic_varint_skip(&bytes[byte_index]);
-                /* Cnx ID & reset secret */
-                byte_index += 8 + 16;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_stop_sending:
-                ret = picoquic_decode_stop_sending_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            case picoquic_frame_type_pong:
-                ret = picoquic_decode_pong_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
-                byte_index += consumed;
-                cnx->ack_needed = 1;
-                break;
-            default:
-                /* Not implemented yet! */
-                ret = picoquic_connection_error(cnx,
-                    PICOQUIC_TRANSPORT_FRAME_ERROR(first_byte));
-                break;
-            }
+                    /* Skip the max data offset */
+                    byte_index += picoquic_varint_skip(&bytes[byte_index]);
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_stream_blocked: /* STREAM_BLOCKED */
+                    byte_index += 1 + picoquic_varint_skip(bytes + byte_index + 1);
+                    /* Skip the max data offset */
+                    byte_index += picoquic_varint_skip(&bytes[byte_index]);
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_stream_id_needed: /* STREAM_ID_NEEDED */
+                    byte_index++;
+                    /* Skip the stream ID */
+                    byte_index += picoquic_varint_skip(&bytes[byte_index]);
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_new_connection_id: /* NEW_CONNECTION_ID */
+                    byte_index += 1;
+                    /* Skip the sequence index */
+                    byte_index += picoquic_varint_skip(&bytes[byte_index]);
+                    /* Cnx ID & reset secret */
+                    byte_index += 8 + 16;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_stop_sending:
+                    ret = picoquic_decode_stop_sending_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                case picoquic_frame_type_pong:
+                    ret = picoquic_decode_pong_frame(cnx, bytes + byte_index, bytes_max - byte_index, &consumed);
+                    byte_index += consumed;
+                    cnx->ack_needed = 1;
+                    break;
+                default:
+                    /* Not implemented yet! */
+                    ret = picoquic_connection_error(cnx,
+                        PICOQUIC_TRANSPORT_FRAME_ERROR(first_byte));
+                    break;
+                }
         }
     }
     return ret;
@@ -2446,8 +2000,8 @@ int picoquic_decode_frames(picoquic_cnx_t * cnx, uint8_t * bytes,
 * The STREAM skipping function only supports the varint format.
 * The old "fixed int" versions are supported by code in the skip_frame function
 */
-static int picoquic_skip_stream_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed)
-{  
+static int picoquic_skip_stream_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed)
+{
     int ret = 0;
     int len = bytes[0] & 2;
     int off = bytes[0] & 4;
@@ -2457,43 +2011,32 @@ static int picoquic_skip_stream_frame(uint8_t * bytes, size_t bytes_max, size_t 
     size_t l_off = 0;
     size_t byte_index = 1;
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_stream = picoquic_varint_skip(bytes + byte_index);
         byte_index += l_stream;
     }
 
-    if (off != 0 && bytes_max > byte_index)
-    {
+    if (off != 0 && bytes_max > byte_index) {
         l_off = picoquic_varint_skip(bytes + byte_index);
         byte_index += l_off;
     }
 
-    if (bytes_max < byte_index || l_stream == 0 || (off != 0 && l_off == 0))
-    {
+    if (bytes_max < byte_index || l_stream == 0 || (off != 0 && l_off == 0)) {
         byte_index = bytes_max;
         ret = -1;
-    }
-    else if (len == 0)
-    {
-        byte_index = bytes_max;    
-    }
-    else
-    {
-        if (bytes_max > byte_index)
-        {
+    } else if (len == 0) {
+        byte_index = bytes_max;
+    } else {
+        if (bytes_max > byte_index) {
             l_len = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &length);
             byte_index += l_len;
         }
 
-        if (l_len == 0 || bytes_max < byte_index + length)
-        {
+        if (l_len == 0 || bytes_max < byte_index + length) {
             byte_index = bytes_max;
             ret = -1;
-        }
-        else
-        {
-            byte_index += (size_t) length;
+        } else {
+            byte_index += (size_t)length;
         }
     }
 
@@ -2506,7 +2049,7 @@ static int picoquic_skip_stream_frame(uint8_t * bytes, size_t bytes_max, size_t 
  * The ACK skipping function only supports the varint format.
  * The old "fixed int" versions are supported by code in the skip_frame function
  */
-static int picoquic_skip_ack_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed)
+static int picoquic_skip_ack_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
     size_t l_largest = 0;
@@ -2516,56 +2059,45 @@ static int picoquic_skip_ack_frame(uint8_t * bytes, size_t bytes_max, size_t * c
     size_t l_first_block = 0;
     size_t byte_index = 1;
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_largest = picoquic_varint_skip(bytes + byte_index);
         byte_index += l_largest;
     }
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_delay = picoquic_varint_skip(bytes + byte_index);
         byte_index += l_delay;
     }
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_blocks = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &nb_blocks);
         byte_index += l_blocks;
     }
 
-    if (bytes_max > byte_index)
-    {
+    if (bytes_max > byte_index) {
         l_first_block = picoquic_varint_skip(bytes + byte_index);
         byte_index += l_first_block;
     }
-    
-    if (l_largest == 0 || l_delay == 0 || l_blocks == 0 || l_first_block == 0 || bytes_max < byte_index)
-    {
+
+    if (l_largest == 0 || l_delay == 0 || l_blocks == 0 || l_first_block == 0 || bytes_max < byte_index) {
         byte_index = bytes_max;
         ret = -1;
-    }
-    else
-    {
-        for (uint64_t i = 0; i < nb_blocks; i++)
-        {
+    } else {
+        for (uint64_t i = 0; i < nb_blocks; i++) {
             size_t l_gap = 0;
             size_t l_ack_block = 0;
 
-            if (bytes_max > byte_index)
-            {
+            if (bytes_max > byte_index) {
                 l_gap = picoquic_varint_skip(bytes + byte_index);
                 byte_index += l_gap;
             }
 
-            if (bytes_max > byte_index)
-            {
+            if (bytes_max > byte_index) {
                 l_ack_block = picoquic_varint_skip(bytes + byte_index);
                 byte_index += l_ack_block;
             }
 
-            if (l_gap == 0 || l_ack_block == 0 || bytes_max < byte_index)
-            {
+            if (l_gap == 0 || l_ack_block == 0 || bytes_max < byte_index) {
                 byte_index = bytes_max;
                 ret = -1;
                 break;
@@ -2578,60 +2110,45 @@ static int picoquic_skip_ack_frame(uint8_t * bytes, size_t bytes_max, size_t * c
     return ret;
 }
 
-int picoquic_skip_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed,
-    int * pure_ack)
+int picoquic_skip_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed,
+    int* pure_ack)
 {
-	int ret = 0;
-	size_t byte_index = 0;
-	uint8_t first_byte = bytes[byte_index++];
+    int ret = 0;
+    size_t byte_index = 0;
+    uint8_t first_byte = bytes[byte_index++];
 
-	*pure_ack = 1;
-	*consumed = 0;
+    *pure_ack = 1;
+    *consumed = 0;
 
-    if (first_byte >= picoquic_frame_type_stream_range_min &&
-        first_byte <= picoquic_frame_type_stream_range_max)
-    {
+    if (first_byte >= picoquic_frame_type_stream_range_min && first_byte <= picoquic_frame_type_stream_range_max) {
         *pure_ack = 0;
         ret = picoquic_skip_stream_frame(bytes, bytes_max, consumed);
-    }
-    else if (first_byte == picoquic_frame_type_ack)
-    {
+    } else if (first_byte == picoquic_frame_type_ack) {
         ret = picoquic_skip_ack_frame(bytes, bytes_max, consumed);
-    }
-    else
-	{
-        switch (first_byte)
-		{
-		case picoquic_frame_type_padding:
-			/* Padding */
-            while (byte_index < bytes_max && bytes[byte_index] == picoquic_frame_type_padding)
-            {
-				byte_index++;
-			} 
+    } else {
+        switch (first_byte) {
+        case picoquic_frame_type_padding:
+            /* Padding */
+            while (byte_index < bytes_max && bytes[byte_index] == picoquic_frame_type_padding) {
+                byte_index++;
+            }
 
-			break;
-		case picoquic_frame_type_reset_stream: 
-            if (bytes_max > 2)
-            {
+            break;
+        case picoquic_frame_type_reset_stream:
+            if (bytes_max > 2) {
                 byte_index += picoquic_varint_skip(bytes + byte_index);
                 byte_index += 2;
-                if (bytes_max > byte_index + 1)
-                {
+                if (bytes_max > byte_index + 1) {
                     byte_index += picoquic_varint_skip(bytes + byte_index);
-                }
-                else
-                {
+                } else {
                     byte_index = bytes_max;
                 }
-            }
-            else
-            {
+            } else {
                 byte_index = bytes_max;
             }
-			*pure_ack = 0;
-			break;
-		case picoquic_frame_type_connection_close: 
-        {
+            *pure_ack = 0;
+            break;
+        case picoquic_frame_type_connection_close: {
             uint64_t reason_length_64;
             byte_index += 2;
             byte_index += picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &reason_length_64);
@@ -2640,8 +2157,7 @@ int picoquic_skip_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed,
             *pure_ack = 0;
             break;
         }
-		case picoquic_frame_type_application_close:
-        {
+        case picoquic_frame_type_application_close: {
             uint64_t reason_length_64;
             byte_index += 2;
             byte_index += picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &reason_length_64);
@@ -2649,47 +2165,48 @@ int picoquic_skip_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed,
             *pure_ack = 0;
             break;
         }
-		case picoquic_frame_type_max_data:
+        case picoquic_frame_type_max_data:
             byte_index += picoquic_varint_skip(bytes + byte_index);
-			*pure_ack = 0;
-			break;
-		case picoquic_frame_type_max_stream_data:
+            *pure_ack = 0;
+            break;
+        case picoquic_frame_type_max_stream_data:
             byte_index += picoquic_varint_skip(bytes + byte_index);
             byte_index += picoquic_varint_skip(bytes + byte_index);
-			*pure_ack = 0;
-			break;
-		case picoquic_frame_type_max_stream_id:
+            *pure_ack = 0;
+            break;
+        case picoquic_frame_type_max_stream_id:
             byte_index += picoquic_varint_skip(bytes + byte_index);
-			*pure_ack = 0;
-			break;
-		case picoquic_frame_type_ping:
-			*pure_ack = 0;
+            *pure_ack = 0;
+            break;
+        case picoquic_frame_type_ping:
+            *pure_ack = 0;
             {
                 size_t ping_length = bytes[byte_index++];
                 byte_index += ping_length;
             }
-			break;
-		case picoquic_frame_type_blocked:
+            break;
+        case picoquic_frame_type_blocked:
             *pure_ack = 0;
             /* Skip the max data offset */
             byte_index += picoquic_varint_skip(&bytes[byte_index]);
-			break;
-		case picoquic_frame_type_stream_blocked:
+            break;
+        case picoquic_frame_type_stream_blocked:
             byte_index += picoquic_varint_skip(bytes + byte_index);
             /* Skip the max stream data offset */
-            byte_index += picoquic_varint_skip(&bytes[byte_index]);;
+            byte_index += picoquic_varint_skip(&bytes[byte_index]);
+            ;
             *pure_ack = 0;
-			break;
-		case picoquic_frame_type_stream_id_needed:
-            byte_index += picoquic_varint_skip(&bytes[byte_index]);   
+            break;
+        case picoquic_frame_type_stream_id_needed:
+            byte_index += picoquic_varint_skip(&bytes[byte_index]);
             *pure_ack = 0;
-			break;
-		case picoquic_frame_type_new_connection_id:
+            break;
+        case picoquic_frame_type_new_connection_id:
             /* Skip the sequence */
             byte_index += picoquic_varint_skip(&bytes[byte_index]);
-			byte_index += 8 + 16;
-			*pure_ack = 0;
-			break;
+            byte_index += 8 + 16;
+            *pure_ack = 0;
+            break;
         case picoquic_frame_type_stop_sending:
             byte_index += picoquic_varint_skip(bytes + byte_index) + 2;
             *pure_ack = 0;
@@ -2702,40 +2219,35 @@ int picoquic_skip_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed,
             }
             break;
         default:
-			/* Not implemented yet! */
-			ret = -1;
-			break;
-		}
-		*consumed = byte_index;
-	}
+            /* Not implemented yet! */
+            ret = -1;
+            break;
+        }
+        *consumed = byte_index;
+    }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_decode_closing_frames(uint8_t * bytes,
-    size_t bytes_max, int *closing_received)
+int picoquic_decode_closing_frames(uint8_t* bytes,
+    size_t bytes_max, int* closing_received)
 {
 
     int ret = 0;
     size_t byte_index = 0;
 
     *closing_received = 0;
-    while (ret == 0 && byte_index < bytes_max)
-    {
+    while (ret == 0 && byte_index < bytes_max) {
         uint8_t first_byte = bytes[byte_index];
 
-        if (first_byte == picoquic_frame_type_connection_close ||
-            first_byte == picoquic_frame_type_application_close)
-        {
+        if (first_byte == picoquic_frame_type_connection_close || first_byte == picoquic_frame_type_application_close) {
             *closing_received = 1;
             break;
-        }
-        else
-        {
+        } else {
             size_t consumed = 0;
             int pure_ack = 0;
 
-            ret = picoquic_skip_frame(bytes + byte_index, 
+            ret = picoquic_skip_frame(bytes + byte_index,
                 bytes_max - byte_index, &consumed, &pure_ack);
             byte_index += consumed;
         }

--- a/picoquic/http0dot9.c
+++ b/picoquic/http0dot9.c
@@ -34,7 +34,7 @@ static uint64_t http09_rand(uint64_t seed)
 {
     const uint64_t a = 6364136223846793005ull;
     const uint64_t c = 1442695040888963407ull;
-    uint64_t x = seed*a + c;
+    uint64_t x = seed * a + c;
 
     return x;
 }
@@ -43,39 +43,36 @@ static uint64_t http09_rand(uint64_t seed)
  * The text in the OK text will be used as the basis for generating random text.
  * For now, the only things that matter is character frequency.
  */
-static char const * http09_ok_text = "The quick brown fox jumps over the lazy dog. 0123456789.,!?";
+static char const* http09_ok_text = "The quick brown fox jumps over the lazy dog. 0123456789.,!?";
 
-static uint64_t http09_random_chars(uint64_t seed, uint8_t * bytes, size_t bytes_max)
+static uint64_t http09_random_chars(uint64_t seed, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 0;
     uint8_t rchar = 0;
     size_t text_mod = strlen(http09_ok_text);
     uint64_t text_index = 0;
 
-    while (byte_index < bytes_max)
-    {
+    while (byte_index < bytes_max) {
         seed = http09_rand(seed);
         text_index = seed % text_mod;
 
         rchar = (uint8_t)http09_ok_text[text_index];
         bytes[byte_index++] = rchar;
 
-        if ((byte_index % 72) == 0 && byte_index < bytes_max)
-        {
-            bytes[byte_index++] = (uint8_t) '\n';
+        if ((byte_index % 72) == 0 && byte_index < bytes_max) {
+            bytes[byte_index++] = (uint8_t)'\n';
         }
     }
 
     return seed;
 }
 
-static int http09_random_txt(size_t doc_length, uint8_t * response, size_t response_max,
-    size_t *response_length)
+static int http09_random_txt(size_t doc_length, uint8_t* response, size_t response_max,
+    size_t* response_length)
 {
     uint64_t seed = 0x1234567890ull ^ doc_length;
 
-    if (doc_length > response_max)
-    {
+    if (doc_length > response_max) {
         doc_length = response_max;
     }
 
@@ -86,21 +83,19 @@ static int http09_random_txt(size_t doc_length, uint8_t * response, size_t respo
     return 0;
 }
 
+static char* const http09_head1 = "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n<HTML>\r\n<HEAD>\r\n<TITLE>";
+static char const* http09_head2 = "</TITLE>\r\n</HEAD><BODY>\r\n";
+static char const* http09_final = "</BODY></HTML>\r\n";
 
-static char * const http09_head1 =
-"<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n<HTML>\r\n<HEAD>\r\n<TITLE>";
-static char const * http09_head2 = "</TITLE>\r\n</HEAD><BODY>\r\n";
-static char const * http09_final = "</BODY></HTML>\r\n";
+static char const* http09_index_title = "PicoQuic HTTP 0.9 service";
 
-static char const *http09_index_title = "PicoQuic HTTP 0.9 service";
-
-static char const *http09_index_1 = "<h1>Simple HTTP 0.9 Responder</h1>\r\n";
-static char const *http09_index_2 = "<p>GET /, and GET index.html returns this text</p>\r\n";
-static char const *http09_index_3 = "<p>Get doc-NNNNN.html returns html document of length NNNNN bytes(decimal)</p>\r\n";
-static char const *http09_index_4 = "<p>Get doc-NNNNN also returns html document of length NNNNN bytes(decimal)</p>\r\n";
-static char const *http09_index_5 = "<p>Get doc-NNNNN.txt returns txt document of length NNNNN bytes(decimal)</p>\r\n";
-static char const *http09_index_6 = "<p>Any other command will result in an error, and an empty response.</p>\r\n";
-static char const *http09_index_7 = "<h1>Enjoy!</h1>\r\n";
+static char const* http09_index_1 = "<h1>Simple HTTP 0.9 Responder</h1>\r\n";
+static char const* http09_index_2 = "<p>GET /, and GET index.html returns this text</p>\r\n";
+static char const* http09_index_3 = "<p>Get doc-NNNNN.html returns html document of length NNNNN bytes(decimal)</p>\r\n";
+static char const* http09_index_4 = "<p>Get doc-NNNNN also returns html document of length NNNNN bytes(decimal)</p>\r\n";
+static char const* http09_index_5 = "<p>Get doc-NNNNN.txt returns txt document of length NNNNN bytes(decimal)</p>\r\n";
+static char const* http09_index_6 = "<p>Any other command will result in an error, and an empty response.</p>\r\n";
+static char const* http09_index_7 = "<h1>Enjoy!</h1>\r\n";
 
 static size_t http09_paragraph_min(size_t tag_length)
 {
@@ -108,14 +103,13 @@ static size_t http09_paragraph_min(size_t tag_length)
     return (2 * tag_length + 7);
 }
 
-
 static uint64_t http09_random_paragraph(uint64_t seed, size_t text_length,
-    char const * tag, size_t tag_length, uint8_t * bytes)
+    char const* tag, size_t tag_length, uint8_t* bytes)
 {
     size_t byte_index = 0;
     /* Copy opening tag */
     bytes[byte_index++] = '<';
-    memcpy(bytes + byte_index, tag, tag_length); 
+    memcpy(bytes + byte_index, tag, tag_length);
     byte_index += tag_length;
     bytes[byte_index++] = '>';
 
@@ -135,22 +129,20 @@ static uint64_t http09_random_paragraph(uint64_t seed, size_t text_length,
     return seed;
 }
 
-static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_max,
-    size_t *response_length)
+static int http09_random_html(size_t doc_length, uint8_t* bytes, size_t bytes_max,
+    size_t* response_length)
 {
     uint64_t seed = 0xDEADBEEFull ^ doc_length;
     size_t min_length = strlen(http09_head1) + 16 + strlen(http09_head2) + 16 + strlen(http09_final);
     size_t body_length = 0;
     size_t byte_index = 0;
 
-    if (bytes_max < min_length)
-    {
+    if (bytes_max < min_length) {
         *response_length = 0;
         return -1;
     }
 
-    if (doc_length > bytes_max)
-    {
+    if (doc_length > bytes_max) {
         doc_length = bytes_max;
     }
 
@@ -169,8 +161,7 @@ static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_m
     body_length = doc_length - byte_index - strlen(http09_final);
 
     /* Generate a series of sections and paragraphs */
-    while (body_length > 0)
-    {
+    while (body_length > 0) {
         /* Compute the number of paragraphs */
         size_t nb_paragraphs;
         size_t title_length;
@@ -181,12 +172,10 @@ static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_m
         title_length = (size_t)(seed & 15) + 5;
         nb_paragraphs = ((seed >> 4) & 7) + 1;
 
-        if (body_length > http09_paragraph_min(2))
-        {
+        if (body_length > http09_paragraph_min(2)) {
             body_length -= http09_paragraph_min(2);
 
-            if (title_length > body_length)
-            {
+            if (title_length > body_length) {
                 title_length = body_length;
             }
             body_length -= title_length;
@@ -196,17 +185,14 @@ static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_m
             byte_index += http09_paragraph_min(2) + title_length;
         }
 
-        while (nb_paragraphs > 0 && body_length > 0)
-        {
+        while (nb_paragraphs > 0 && body_length > 0) {
             seed = http09_rand(seed);
             para_length = (size_t)(seed & 511) + 13;
 
-            if (body_length > http09_paragraph_min(1))
-            {
+            if (body_length > http09_paragraph_min(1)) {
                 body_length -= http09_paragraph_min(1);
 
-                if (para_length > body_length)
-                {
+                if (para_length > body_length) {
                     para_length = body_length;
                 }
                 body_length -= para_length;
@@ -214,11 +200,8 @@ static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_m
                 seed = http09_random_paragraph(seed, para_length, "p", 1,
                     bytes + byte_index);
                 byte_index += http09_paragraph_min(1) + para_length;
-            }
-            else
-            {
-                while (body_length > 0)
-                {
+            } else {
+                while (body_length > 0) {
                     bytes[byte_index++] = ' ';
                     body_length--;
                 }
@@ -237,79 +220,60 @@ static int http09_random_html(size_t doc_length, uint8_t * bytes, size_t bytes_m
     return 0;
 }
 
-static int http09_index_html(uint8_t * bytes, size_t bytes_max,
-    size_t *response_length)
+static int http09_index_html(uint8_t* bytes, size_t bytes_max,
+    size_t* response_length)
 {
     int ret = 0;
-    char const * index_text[] = { http09_head1,
+    char const* index_text[] = { http09_head1,
         http09_index_title, http09_head2,
         http09_index_1, http09_index_2, http09_index_3,
         http09_index_4, http09_index_5, http09_index_6,
-        http09_index_7, http09_final};
-    size_t nb_index_blocks = sizeof(index_text) / sizeof(char * const);
+        http09_index_7, http09_final };
+    size_t nb_index_blocks = sizeof(index_text) / sizeof(char* const);
     size_t byte_index = 0;
 
-    for (size_t i = 0; i < nb_index_blocks; i++)
-    {
+    for (size_t i = 0; i < nb_index_blocks; i++) {
         size_t l = strlen(index_text[i]);
 
-        if (byte_index + l <= bytes_max)
-        {
+        if (byte_index + l <= bytes_max) {
             memcpy(bytes + byte_index, index_text[i], l);
             byte_index += l;
-        }
-        else
-        {
+        } else {
             ret = -1;
             break;
         }
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         *response_length = byte_index;
-    }
-    else
-    {
+    } else {
         *response_length = 0;
     }
 
     return ret;
 }
 
-static int http09_compare_name(uint8_t * command, size_t length, size_t byte_index, char * name)
+static int http09_compare_name(uint8_t* command, size_t length, size_t byte_index, char* name)
 {
     int ret = -1;
-    for (size_t i = 0;; i++, byte_index++)
-    {
-        if ((uint8_t)name[i] == 0)
-        {
-            if (byte_index == length)
-            {
+    for (size_t i = 0;; i++, byte_index++) {
+        if ((uint8_t)name[i] == 0) {
+            if (byte_index == length) {
                 ret = 0;
             }
             break;
-        }
-        else if (byte_index >= length)
-        {
+        } else if (byte_index >= length) {
             break;
-        }
-        else
-        {
+        } else {
             uint8_t c = (uint8_t)name[i];
-            
-            if (c != command[byte_index])
-            {
-                if (c >= 'a' && c <= 'z')
-                {
+
+            if (c != command[byte_index]) {
+                if (c >= 'a' && c <= 'z') {
                     c -= 'a' - 'A';
-                }
-                else if (c >= 'A' && c <= 'Z')
-                {
+                } else if (c >= 'A' && c <= 'Z') {
                     c += 'a' - 'A';
                 }
-                if (c != command[byte_index])
-                {
+                if (c != command[byte_index]) {
                     break;
                 }
             }
@@ -319,8 +283,8 @@ static int http09_compare_name(uint8_t * command, size_t length, size_t byte_ind
     return ret;
 }
 
-int http0dot9_get(uint8_t * command, size_t command_length,
-    uint8_t * response, size_t response_max, size_t *response_length)
+int http0dot9_get(uint8_t* command, size_t command_length,
+    uint8_t* response, size_t response_max, size_t* response_length)
 {
     int ret = 0;
     size_t byte_index = 3;
@@ -328,122 +292,75 @@ int http0dot9_get(uint8_t * command, size_t command_length,
 
     *response_length = 0;
     /* Strip white spaces at the end of the command */
-    while (command_length > 0){
+    while (command_length > 0) {
         int c = command[command_length - 1];
 
-        if (c == ' ' || c == '\n' || c == '\r' || c == '\t')
-        {
+        if (c == ' ' || c == '\n' || c == '\r' || c == '\t') {
             command_length--;
-        }
-        else
-        {
+        } else {
             break;
         }
     }
 
     /* Check whether someone added an HTTP/0.9 tag at the end of the command */
-    if (command_length > 8 &&
-        command[command_length - 1] == '9' &&
-        command[command_length - 2] == '.' &&
-        command[command_length - 3] == '0' &&
-        command[command_length - 4] == '/' &&
-        (command[command_length - 5] == 'p' || command[command_length - 5] == 'P') &&
-        (command[command_length - 6] == 't' || command[command_length - 6] == 'T') &&
-        (command[command_length - 7] == 't' || command[command_length - 7] == 'T') &&
-        (command[command_length - 8] == 'h' || command[command_length - 8] == 'H'))
-    {
+    if (command_length > 8 && command[command_length - 1] == '9' && command[command_length - 2] == '.' && command[command_length - 3] == '0' && command[command_length - 4] == '/' && (command[command_length - 5] == 'p' || command[command_length - 5] == 'P') && (command[command_length - 6] == 't' || command[command_length - 6] == 'T') && (command[command_length - 7] == 't' || command[command_length - 7] == 'T') && (command[command_length - 8] == 'h' || command[command_length - 8] == 'H')) {
         command_length -= 8;
 
-        while (command_length > 0 &&
-            (command[command_length - 1] == ' ' ||
-                command[command_length - 1] == '\t'))
-        {
+        while (command_length > 0 && (command[command_length - 1] == ' ' || command[command_length - 1] == '\t')) {
             command_length--;
         }
     }
 
     /* Parse the input. It should be "get <docname> */
-    if (command_length < 4 ||
-        (command[0] != 'G' && command[0] != 'g') ||
-        (command[1] != 'E' && command[1] != 'e') ||
-        (command[2] != 'T' && command[2] != 't'))
-    {
+    if (command_length < 4 || (command[0] != 'G' && command[0] != 'g') || (command[1] != 'E' && command[1] != 'e') || (command[2] != 'T' && command[2] != 't')) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         /* Skip at list one space */
-        while (command_length > byte_index &&
-            (command[byte_index] == ' ' || command[byte_index] == '\t'))
-        {
+        while (command_length > byte_index && (command[byte_index] == ' ' || command[byte_index] == '\t')) {
             byte_index++;
         }
 
-        if (byte_index == 3 || byte_index >= command_length)
-        {
+        if (byte_index == 3 || byte_index >= command_length) {
             ret = -1;
         }
     }
 
     /* if the input is in incorrect form, return 0 length error message */
-    if (ret == -1)
-    {
+    if (ret == -1) {
         *response_length = 0;
     }
     /* if the doc name  is a known value, return it */
-    else if (http09_compare_name(command, command_length, byte_index, "/") == 0)
-    {
+    else if (http09_compare_name(command, command_length, byte_index, "/") == 0) {
         ret = http09_index_html(response, response_max, response_length);
-    }
-    else
-    {
-        if (command[byte_index] == '/')
-        {
+    } else {
+        if (command[byte_index] == '/') {
             byte_index++;
         }
 
-        if (http09_compare_name(command, command_length, byte_index, "index.html") == 0)
-        {
+        if (http09_compare_name(command, command_length, byte_index, "index.html") == 0) {
             ret = http09_index_html(response, response_max, response_length);
-        }
-        else
-        {
+        } else {
             /* if the doc name is of form doc-NNNNNNNN.html,
              * generate the html text, stopping at response_length_max if the number is too long.
              */
-            if (command_length < byte_index + 9 ||
-                (command[byte_index + 0] != 'D' && command[byte_index + 0] != 'd') ||
-                (command[byte_index + 1] != 'O' && command[byte_index + 1] != 'o') ||
-                (command[byte_index + 2] != 'C' && command[byte_index + 2] != 'c') ||
-                (command[byte_index + 3] != '-'))
-            {
+            if (command_length < byte_index + 9 || (command[byte_index + 0] != 'D' && command[byte_index + 0] != 'd') || (command[byte_index + 1] != 'O' && command[byte_index + 1] != 'o') || (command[byte_index + 2] != 'C' && command[byte_index + 2] != 'c') || (command[byte_index + 3] != '-')) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 byte_index += 4;
 
-                while (byte_index < command_length &&
-                    command[byte_index] >= '0' && command[byte_index] <= '9')
-                {
+                while (byte_index < command_length && command[byte_index] >= '0' && command[byte_index] <= '9') {
                     doc_length *= 10;
                     doc_length += command[byte_index] - '0';
                     byte_index++;
                 }
 
-                if (doc_length == 0 ||
-                    http09_compare_name(command, command_length, byte_index, ".html") == 0)
-                {
+                if (doc_length == 0 || http09_compare_name(command, command_length, byte_index, ".html") == 0) {
                     /* HTML by default */
                     ret = http09_random_html(doc_length, response, response_max, response_length);
-                }
-                else if (http09_compare_name(command, command_length, byte_index, ".txt") == 0)
-                {
+                } else if (http09_compare_name(command, command_length, byte_index, ".txt") == 0) {
                     /* Random text */
                     ret = http09_random_txt(doc_length, response, response_max, response_length);
-                }
-                else
-                {
+                } else {
                     ret = -1;
                 }
             }
@@ -452,4 +369,3 @@ int http0dot9_get(uint8_t * command, size_t command_length,
 
     return ret;
 }
-

--- a/picoquic/intformat.c
+++ b/picoquic/intformat.c
@@ -24,13 +24,13 @@
 #include <sys/types.h>
 #endif
 
-void picoformat_16(uint8_t *bytes, uint16_t n16)
+void picoformat_16(uint8_t* bytes, uint16_t n16)
 {
     bytes[0] = (uint8_t)(n16 >> 8);
     bytes[1] = (uint8_t)(n16);
 }
 
-void picoformat_32(uint8_t *bytes, uint32_t n32)
+void picoformat_32(uint8_t* bytes, uint32_t n32)
 {
     bytes[0] = (uint8_t)(n32 >> 24);
     bytes[1] = (uint8_t)(n32 >> 16);
@@ -38,7 +38,7 @@ void picoformat_32(uint8_t *bytes, uint32_t n32)
     bytes[3] = (uint8_t)(n32);
 }
 
-void picoformat_64(uint8_t *bytes, uint64_t n64)
+void picoformat_64(uint8_t* bytes, uint64_t n64)
 {
     bytes[0] = (uint8_t)(n64 >> 56);
     bytes[1] = (uint8_t)(n64 >> 48);
@@ -59,42 +59,30 @@ void picoformat_64(uint8_t *bytes, uint64_t n64)
  * 11       8       62       0-4611686018427387903
  */
 
-size_t picoquic_varint_encode(uint8_t *bytes, size_t max_bytes, uint64_t n64)
+size_t picoquic_varint_encode(uint8_t* bytes, size_t max_bytes, uint64_t n64)
 {
-    uint8_t *x = bytes;
+    uint8_t* x = bytes;
 
-    if (n64 < 16384)
-    {
-        if (n64 < 64)
-        {
-            if (max_bytes > 0)
-            {
+    if (n64 < 16384) {
+        if (n64 < 64) {
+            if (max_bytes > 0) {
                 *x++ = (uint8_t)(n64);
             }
-        }
-        else
-        {
-            if (max_bytes >= 2)
-            {
+        } else {
+            if (max_bytes >= 2) {
                 *x++ = (uint8_t)((n64 >> 8) | 0x40);
                 *x++ = (uint8_t)(n64);
             }
         }
-    }
-    else if (n64 < 1073741824)
-    {
-        if (max_bytes >= 4)
-        {
+    } else if (n64 < 1073741824) {
+        if (max_bytes >= 4) {
             *x++ = (uint8_t)((n64 >> 24) | 0x80);
             *x++ = (uint8_t)(n64 >> 16);
             *x++ = (uint8_t)(n64 >> 8);
             *x++ = (uint8_t)(n64);
         }
-    }
-    else
-    {
-        if (max_bytes >= 8)
-        {
+    } else {
+        if (max_bytes >= 8) {
             *x++ = (uint8_t)((n64 >> 56) | 0xC0);
             *x++ = (uint8_t)(n64 >> 48);
             *x++ = (uint8_t)(n64 >> 40);
@@ -109,21 +97,17 @@ size_t picoquic_varint_encode(uint8_t *bytes, size_t max_bytes, uint64_t n64)
     return (x - bytes);
 }
 
-size_t picoquic_varint_decode(const uint8_t *bytes, size_t max_bytes, uint64_t * n64)
+size_t picoquic_varint_decode(const uint8_t* bytes, size_t max_bytes, uint64_t* n64)
 {
     size_t length = 1 << ((bytes[0] & 0xC0) >> 6);
 
-    if (length > max_bytes)
-    {
+    if (length > max_bytes) {
         length = 0;
         *n64 = 0;
-    }
-    else
-    {
+    } else {
         uint64_t v = *bytes++ & 0x3F;
 
-        for (size_t i = 1; i < length; i++)
-        {
+        for (size_t i = 1; i < length; i++) {
             v <<= 8;
             v += *bytes++;
         }
@@ -134,7 +118,7 @@ size_t picoquic_varint_decode(const uint8_t *bytes, size_t max_bytes, uint64_t *
     return length;
 }
 
-size_t picoquic_varint_skip(uint8_t *bytes)
+size_t picoquic_varint_skip(uint8_t* bytes)
 {
     size_t length = 1 << ((bytes[0] & 0xC0) >> 6);
 

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -22,13 +22,13 @@
 /*
 * Packet logging.
 */
-#include <string.h>
-#include <stdio.h>
-#include "picoquic_internal.h"
 #include "fnv1a.h"
+#include "picoquic_internal.h"
 #include "tls_api.h"
+#include <stdio.h>
+#include <string.h>
 
-static char const * picoquic_ptype_names[] = {
+static char const* picoquic_ptype_names[] = {
     "error",
     "version negotiation",
     "client initial",
@@ -41,9 +41,9 @@ static char const * picoquic_ptype_names[] = {
     "public reset"
 };
 
-static const size_t picoquic_nb_ptype_names = sizeof(picoquic_ptype_names) / sizeof(char const *);
+static const size_t picoquic_nb_ptype_names = sizeof(picoquic_ptype_names) / sizeof(char const*);
 
-static char const * picoquic_log_state_name[] = {
+static char const* picoquic_log_state_name[] = {
     "client_init",
     "client_init_sent",
     "client_renegotiate",
@@ -65,10 +65,9 @@ static char const * picoquic_log_state_name[] = {
     "send_hrr"
 };
 
-static const size_t picoquic_nb_log_state_name = sizeof(picoquic_log_state_name) / sizeof(char const *);
+static const size_t picoquic_nb_log_state_name = sizeof(picoquic_log_state_name) / sizeof(char const*);
 
-static char const * picoquic_log_frame_names[] =
-{
+static char const* picoquic_log_frame_names[] = {
     "Padding",
     "RST_STREAM",
     "CONNECTION_CLOSE",
@@ -86,160 +85,144 @@ static char const * picoquic_log_frame_names[] =
     "ACK"
 };
 
-void picoquic_log_error_packet(FILE * F, uint8_t * bytes, size_t bytes_max, int ret)
+void picoquic_log_error_packet(FILE* F, uint8_t* bytes, size_t bytes_max, int ret)
 {
-	fprintf(F, "Packet length %d caused error: %d\n", (int)bytes_max, ret);
+    fprintf(F, "Packet length %d caused error: %d\n", (int)bytes_max, ret);
 
-	for (size_t i = 0; i < bytes_max;)
-	{
-		fprintf(F, "%04x:  ", (int)i);
+    for (size_t i = 0; i < bytes_max;) {
+        fprintf(F, "%04x:  ", (int)i);
 
-		for (int j = 0; j < 16 && i < bytes_max; j++, i++)
-		{
-			fprintf(F, "%02x ", bytes[i]);
-		}
-		fprintf(F, "\n");
-	}
-	fprintf(F, "\n");
+        for (int j = 0; j < 16 && i < bytes_max; j++, i++) {
+            fprintf(F, "%02x ", bytes[i]);
+        }
+        fprintf(F, "\n");
+    }
+    fprintf(F, "\n");
 }
 
-void picoquic_log_time(FILE* F, picoquic_cnx_t * cnx, uint64_t current_time, 
-    const char * label1, const char * label2)
+void picoquic_log_time(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time,
+    const char* label1, const char* label2)
 {
-    uint64_t delta_t = (cnx == NULL)? current_time: current_time - cnx->start_time;
+    uint64_t delta_t = (cnx == NULL) ? current_time : current_time - cnx->start_time;
     uint64_t time_sec = delta_t / 1000000;
     uint32_t time_usec = (uint32_t)(delta_t % 1000000);
 
     fprintf(F, "%s%llu.%06d%s", label1,
-        (unsigned long long) time_sec, time_usec, label2);
+        (unsigned long long)time_sec, time_usec, label2);
 }
 
-void picoquic_log_packet_address(FILE* F, picoquic_cnx_t * cnx,
-	struct sockaddr * addr_peer, int receiving, size_t length, uint64_t current_time)
+void picoquic_log_packet_address(FILE* F, picoquic_cnx_t* cnx,
+    struct sockaddr* addr_peer, int receiving, size_t length, uint64_t current_time)
 {
-    uint64_t delta_t = 0;  
+    uint64_t delta_t = 0;
     uint64_t time_sec = 0;
     uint32_t time_usec = 0;
 
-	fprintf(F, (receiving)? "Receiving %d bytes from ":"Sending %d bytes to ",
-		(int)length);
+    fprintf(F, (receiving) ? "Receiving %d bytes from " : "Sending %d bytes to ",
+        (int)length);
 
-	if (addr_peer->sa_family == AF_INET)
-	{
-		struct sockaddr_in * s4 = (struct sockaddr_in *)addr_peer;
-                uint8_t * addr = (uint8_t *) &s4->sin_addr;
+    if (addr_peer->sa_family == AF_INET) {
+        struct sockaddr_in* s4 = (struct sockaddr_in*)addr_peer;
+        uint8_t* addr = (uint8_t*)&s4->sin_addr;
 
-		fprintf(F, "%d.%d.%d.%d:%d",
-			addr[0], addr[1], addr[2], addr[3],
-			ntohs(s4->sin_port));
-	}
-	else
-	{
-		struct sockaddr_in6 * s6 = (struct sockaddr_in6 *)addr_peer;
-                uint8_t * addr = (uint8_t *) &s6->sin6_addr;
+        fprintf(F, "%d.%d.%d.%d:%d",
+            addr[0], addr[1], addr[2], addr[3],
+            ntohs(s4->sin_port));
+    } else {
+        struct sockaddr_in6* s6 = (struct sockaddr_in6*)addr_peer;
+        uint8_t* addr = (uint8_t*)&s6->sin6_addr;
 
-		for (int i = 0; i < 8; i++)
-		{
-			if (i != 0)
-			{
-				fprintf(F, ":");
-			}
+        for (int i = 0; i < 8; i++) {
+            if (i != 0) {
+                fprintf(F, ":");
+            }
 
-			if (addr[2 * i] != 0)
-			{
-				fprintf(F, "%x%02x", addr[2 * i], addr[(2 * i) + 1]);
-			}
-			else
-			{
-				fprintf(F, "%x", addr[(2 * i) + 1]);
-			}
-		}
-	}
+            if (addr[2 * i] != 0) {
+                fprintf(F, "%x%02x", addr[2 * i], addr[(2 * i) + 1]);
+            } else {
+                fprintf(F, "%x", addr[(2 * i) + 1]);
+            }
+        }
+    }
 
-    if (cnx != NULL)
-    {
+    if (cnx != NULL) {
         delta_t = current_time - cnx->start_time;
         time_sec = delta_t / 1000000;
         time_usec = (uint32_t)(delta_t % 1000000);
     }
 
     fprintf(F, "\n at T=%llu.%06d (%llx)\n",
-        (unsigned long long) time_sec, time_usec,
-        (unsigned long long) current_time);
+        (unsigned long long)time_sec, time_usec,
+        (unsigned long long)current_time);
 }
 
-char const * picoquic_log_ptype_name(picoquic_packet_type_enum ptype)
+char const* picoquic_log_ptype_name(picoquic_packet_type_enum ptype)
 {
-	if (((size_t)ptype) < picoquic_nb_ptype_names)
-	{
-		return picoquic_ptype_names[ptype];
-	}
-	else
-	{
-		return "unknown";
-	}
+    if (((size_t)ptype) < picoquic_nb_ptype_names) {
+        return picoquic_ptype_names[ptype];
+    } else {
+        return "unknown";
+    }
 }
 
-void picoquic_log_packet_header(FILE* F, picoquic_cnx_t * cnx, picoquic_packet_header * ph)
+void picoquic_log_packet_header(FILE* F, picoquic_cnx_t* cnx, picoquic_packet_header* ph)
 {
-	fprintf(F, "    Type: %d (%s), CnxID: %llx%s, Seq: %x (%llx), Version %x\n",
-		ph->ptype, picoquic_log_ptype_name(ph->ptype),
-                (unsigned long long)ph->cnx_id,
-		(cnx == NULL) ? " (unknown)" : "",
-		ph->pn, (unsigned long long)ph->pn64, ph->vn);
+    fprintf(F, "    Type: %d (%s), CnxID: %llx%s, Seq: %x (%llx), Version %x\n",
+        ph->ptype, picoquic_log_ptype_name(ph->ptype),
+        (unsigned long long)ph->cnx_id,
+        (cnx == NULL) ? " (unknown)" : "",
+        ph->pn, (unsigned long long)ph->pn64, ph->vn);
 }
 
-void picoquic_log_negotiation_packet(FILE* F, 
-	uint8_t * bytes, size_t length, picoquic_packet_header * ph)
+void picoquic_log_negotiation_packet(FILE* F,
+    uint8_t* bytes, size_t length, picoquic_packet_header* ph)
 {
-	size_t byte_index = ph->offset;
-	uint32_t vn = 0;
+    size_t byte_index = ph->offset;
+    uint32_t vn = 0;
 
-	fprintf(F, "    versions: ");
+    fprintf(F, "    versions: ");
 
-	while (byte_index + 4 <= length)
-	{
-		vn = PICOPARSE_32(bytes + byte_index);
-		byte_index += 4;
-		fprintf(F, "%x, ", vn);
-	}
-	fprintf(F, "\n");
+    while (byte_index + 4 <= length) {
+        vn = PICOPARSE_32(bytes + byte_index);
+        byte_index += 4;
+        fprintf(F, "%x, ", vn);
+    }
+    fprintf(F, "\n");
 }
 
-size_t picoquic_log_stream_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_stream_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
-	size_t byte_index;
-	uint64_t stream_id;
-	size_t data_length;
-	uint64_t offset;
+    size_t byte_index;
+    uint64_t stream_id;
+    size_t data_length;
+    uint64_t offset;
     int fin;
     int ret = 0;
 
-	debug_printf_push_stream(F);
+    debug_printf_push_stream(F);
     ret = picoquic_parse_stream_header(bytes, bytes_max,
-            &stream_id, &offset, &data_length, &fin, &byte_index);
+        &stream_id, &offset, &data_length, &fin, &byte_index);
 
-	debug_printf_pop_stream();
+    debug_printf_pop_stream();
 
-	if (ret != 0)
-		return bytes_max;
+    if (ret != 0)
+        return bytes_max;
 
-	fprintf(F, "    Stream %" PRIu64 ", offset %" PRIu64 ", length %d, fin = %d", stream_id,
-			offset, (int)data_length, fin);
+    fprintf(F, "    Stream %" PRIu64 ", offset %" PRIu64 ", length %d, fin = %d", stream_id,
+        offset, (int)data_length, fin);
 
-	fprintf(F, ": ");
-	for (size_t i = 0; i < 8 && i < data_length; i++)
-	{
-		fprintf(F, "%02x", bytes[byte_index + i]);
-	}
-	fprintf(F, "%s\n", (data_length > 8)?"...":"");
+    fprintf(F, ": ");
+    for (size_t i = 0; i < 8 && i < data_length; i++) {
+        fprintf(F, "%02x", bytes[byte_index + i]);
+    }
+    fprintf(F, "%s\n", (data_length > 8) ? "..." : "");
 
-	return byte_index + data_length;
+    return byte_index + data_length;
 }
 
-size_t picoquic_log_ack_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
-    size_t   byte_index;
+    size_t byte_index;
     uint64_t num_block;
     uint64_t largest;
     uint64_t ack_delay;
@@ -260,35 +243,29 @@ size_t picoquic_log_ack_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
     /* decoding the acks */
     unsigned extra_ack = 1;
 
-    while (ret == 0)
-    {
+    while (ret == 0) {
         uint64_t range;
         uint64_t block_to_block;
 
-        if (byte_index >= bytes_max)
-        {
+        if (byte_index >= bytes_max) {
             fprintf(F, "    Malformed ACK RANGE, %d blocks remain.\n", (int)num_block);
             ret = -1;
             break;
         }
 
         size_t l_range = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &range);
-        if (l_range == 0)
-        {
+        if (l_range == 0) {
             byte_index = bytes_max;
             ret = -1;
             fprintf(F, "    Malformed ACK RANGE, requires %d bytes out of %d", (int)picoquic_varint_skip(bytes),
                 (int)(bytes_max - byte_index));
             break;
-        }
-        else
-        {
+        } else {
             byte_index += l_range;
         }
 
         range += extra_ack;
-        if (largest + 1 < range)
-        {
+        if (largest + 1 < range) {
             fprintf(F, "ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
             byte_index = bytes_max;
             ret = -1;
@@ -307,33 +284,26 @@ size_t picoquic_log_ack_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
 
         /* Skip the gap */
 
-        if (byte_index >= bytes_max)
-        {
+        if (byte_index >= bytes_max) {
             fprintf(F, "\n    Malformed ACK GAP, %d blocks remain.", (int)num_block);
             byte_index = bytes_max;
             ret = -1;
             break;
-        }
-        else
-        {
+        } else {
             size_t l_gap = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &block_to_block);
-            if (l_gap == 0)
-            {
+            if (l_gap == 0) {
                 byte_index = bytes_max;
                 ret = -1;
                 fprintf(F, "\n    Malformed ACK GAP, requires %d bytes out of %d", (int)picoquic_varint_skip(bytes),
                     (int)(bytes_max - byte_index));
                 break;
-            }
-            else
-            {
+            } else {
                 byte_index += l_gap;
                 block_to_block += range;
             }
         }
 
-        if (largest < block_to_block)
-        {
+        if (largest < block_to_block) {
             fprintf(F, "\n    ack gap error: largest=%" PRIx64 ", range=%" PRIx64 ", gap=%" PRIu64,
                 largest, range, block_to_block - range);
             byte_index = bytes_max;
@@ -350,7 +320,7 @@ size_t picoquic_log_ack_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
     return byte_index;
 }
 
-size_t picoquic_log_reset_stream_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_reset_stream_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     uint64_t stream_id = 0;
@@ -358,12 +328,10 @@ size_t picoquic_log_reset_stream_frame(FILE * F, uint8_t * bytes, size_t bytes_m
     uint64_t offset = 0;
 
     size_t l1 = 0, l2 = 0;
-    if (bytes_max > 2)
-    {
+    if (bytes_max > 2) {
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &stream_id);
         byte_index += l1;
-        if (l1 > 0 && bytes_max >= byte_index + 3)
-        {
+        if (l1 > 0 && bytes_max >= byte_index + 3) {
             error_code = PICOPARSE_16(bytes + byte_index);
             byte_index += 2;
             l2 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &offset);
@@ -371,31 +339,26 @@ size_t picoquic_log_reset_stream_frame(FILE * F, uint8_t * bytes, size_t bytes_m
         }
     }
 
-    if (l1 == 0 || l2 == 0)
-    {
-        fprintf(F, "    Malformed RESET STREAM, requires %d bytes out of %d\n", (int)(byte_index +
-            ((l1 == 0) ? (picoquic_varint_skip(bytes + 1) + 3) : picoquic_varint_skip(bytes + byte_index))),
+    if (l1 == 0 || l2 == 0) {
+        fprintf(F, "    Malformed RESET STREAM, requires %d bytes out of %d\n", (int)(byte_index + ((l1 == 0) ? (picoquic_varint_skip(bytes + 1) + 3) : picoquic_varint_skip(bytes + byte_index))),
             (int)bytes_max);
         byte_index = bytes_max;
-    }
-    else
-    {
+    } else {
         fprintf(F, "    RESET STREAM %llu, Error 0x%08x, Offset 0x%llx.\n",
-            (unsigned long long)stream_id, error_code, (unsigned long long) offset);
+            (unsigned long long)stream_id, error_code, (unsigned long long)offset);
     }
 
     return byte_index;
 }
 
-size_t picoquic_log_stop_sending_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_stop_sending_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     const size_t min_size = 1 + picoquic_varint_skip(bytes + 1) + 2;
     uint64_t stream_id;
     uint32_t error_code;
 
-    if (min_size > bytes_max)
-    {
+    if (min_size > bytes_max) {
         fprintf(F, "    Malformed STOP SENDING, requires %d bytes out of %d\n", (int)min_size, (int)bytes_max);
         return bytes_max;
     }
@@ -411,41 +374,34 @@ size_t picoquic_log_stop_sending_frame(FILE * F, uint8_t * bytes, size_t bytes_m
     return byte_index;
 }
 
-size_t picoquic_log_connection_close_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_connection_close_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     uint32_t error_code = 0;
     uint64_t string_length = 0;
 
     size_t l1 = 0;
-    if (bytes_max >= 4)
-    {
+    if (bytes_max >= 4) {
         error_code = PICOPARSE_16(bytes + byte_index);
         byte_index += 2;
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &string_length);
     }
 
-    if (l1 == 0)
-    {
+    if (l1 == 0) {
         fprintf(F, "    Malformed CONNECTION CLOSE, requires %d bytes out of %d\n",
             (int)(byte_index + picoquic_varint_skip(bytes + 3)), (int)bytes_max);
         return bytes_max;
-    }
-    else
-    {
+    } else {
         byte_index += l1;
     }
 
     fprintf(F, "    CONNECTION CLOSE, Error 0x%04x, Reason length %llu\n",
-        error_code, (unsigned long long) string_length);
-    if (byte_index + string_length > bytes_max)
-    {
+        error_code, (unsigned long long)string_length);
+    if (byte_index + string_length > bytes_max) {
         fprintf(F, "    Malformed CONNECTION CLOSE, requires %llu bytes out of %llu\n",
-            (unsigned long long)(byte_index + string_length), (unsigned long long) bytes_max);
+            (unsigned long long)(byte_index + string_length), (unsigned long long)bytes_max);
         byte_index = bytes_max;
-    }
-    else
-    {
+    } else {
         /* TODO: print the UTF8 string */
         byte_index += (size_t)string_length;
     }
@@ -453,41 +409,34 @@ size_t picoquic_log_connection_close_frame(FILE * F, uint8_t * bytes, size_t byt
     return byte_index;
 }
 
-size_t picoquic_log_application_close_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_application_close_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     uint32_t error_code = 0;
     uint64_t string_length = 0;
 
     size_t l1 = 0;
-    if (bytes_max >= 4)
-    {
+    if (bytes_max >= 4) {
         error_code = PICOPARSE_16(bytes + byte_index);
         byte_index += 2;
         l1 = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &string_length);
     }
 
-    if (l1 == 0)
-    {
+    if (l1 == 0) {
         fprintf(F, "    Malformed APPLICATION CLOSE, requires %d bytes out of %d\n",
             (int)(byte_index + picoquic_varint_skip(bytes + 3)), (int)bytes_max);
         return bytes_max;
-    }
-    else
-    {
+    } else {
         byte_index += l1;
     }
 
     fprintf(F, "    APPLICATION CLOSE, Error 0x%04x, Reason length %d (0x%04x):\n",
         error_code, (uint16_t)string_length, (uint16_t)string_length);
-    if (byte_index + string_length > bytes_max)
-    {
+    if (byte_index + string_length > bytes_max) {
         fprintf(F, "    Malformed APPLICATION CLOSE, requires %d bytes out of %d\n",
             (int)(byte_index + string_length), (int)bytes_max);
         byte_index = bytes_max;
-    }
-    else
-    {
+    } else {
         /* TODO: print the UTF8 string */
         byte_index += (size_t)string_length;
     }
@@ -495,83 +444,74 @@ size_t picoquic_log_application_close_frame(FILE * F, uint8_t * bytes, size_t by
     return byte_index;
 }
 
-size_t picoquic_log_max_data_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_max_data_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     uint64_t max_data;
 
     size_t l1 = picoquic_varint_decode(bytes + 1, bytes_max - 1, &max_data);
 
-    if (1 + l1 > bytes_max)
-    {
+    if (1 + l1 > bytes_max) {
         fprintf(F, "    Malformed MAX DATA, requires %d bytes out of %d\n", (int)(1 + l1), (int)bytes_max);
         return bytes_max;
-    }
-    else
-    {
+    } else {
         byte_index = 1 + l1;
     }
 
-    fprintf(F, "    MAX DATA: 0x%llx.\n", (unsigned long long) max_data);
+    fprintf(F, "    MAX DATA: 0x%llx.\n", (unsigned long long)max_data);
 
     return byte_index;
 }
 
-size_t picoquic_log_max_stream_data_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_max_stream_data_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     uint64_t stream_id;
     uint64_t max_data;
 
-
     size_t l1 = picoquic_varint_decode(bytes + 1, bytes_max - 1, &stream_id);
     size_t l2 = picoquic_varint_decode(bytes + 1 + l1, bytes_max - 1 - l1, &max_data);
 
-    if (l1 == 0 || l2 == 0)
-    {
+    if (l1 == 0 || l2 == 0) {
         fprintf(F, "    Malformed MAX STREAM DATA, requires %d bytes out of %d\n",
             (int)(1 + l1 + l2), (int)bytes_max);
         return bytes_max;
-    }
-    else
-    {
+    } else {
         byte_index = 1 + l1 + l2;
     }
 
     fprintf(F, "    MAX STREAM DATA, Stream: %" PRIu64 ", max data: 0x%llx.\n",
-        stream_id, (unsigned long long) max_data);
+        stream_id, (unsigned long long)max_data);
 
     return byte_index;
 }
 
-size_t picoquic_log_max_stream_id_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_max_stream_id_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
-	size_t byte_index = 1;
+    size_t byte_index = 1;
     const size_t min_size = 1 + picoquic_varint_skip(bytes + 1);
-	uint64_t max_stream_id;
+    uint64_t max_stream_id;
 
-	if (min_size > bytes_max)
-	{
-		fprintf(F, "    Malformed MAX STREAM ID, requires %d bytes out of %d\n", (int) min_size, (int) bytes_max);
-		return bytes_max;
-	}
+    if (min_size > bytes_max) {
+        fprintf(F, "    Malformed MAX STREAM ID, requires %d bytes out of %d\n", (int)min_size, (int)bytes_max);
+        return bytes_max;
+    }
 
-	/* Now that the size is good, parse and print it */
+    /* Now that the size is good, parse and print it */
     byte_index += picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &max_stream_id);
 
-	fprintf(F, "    MAX STREAM ID: %" PRIu64 ".\n", max_stream_id);
+    fprintf(F, "    MAX STREAM ID: %" PRIu64 ".\n", max_stream_id);
 
-	return byte_index;
+    return byte_index;
 }
 
-size_t picoquic_log_blocked_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_blocked_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     const size_t min_size = 1 + picoquic_varint_skip(bytes + 1);
     uint64_t blocked_offset = 0;
 
-    if (min_size > bytes_max)
-    {
+    if (min_size > bytes_max) {
         fprintf(F, "    Malformed BLOCKED, requires %d bytes out of %d\n", (int)min_size, (int)bytes_max);
         return bytes_max;
     }
@@ -586,101 +526,87 @@ size_t picoquic_log_blocked_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
     return byte_index;
 }
 
-size_t picoquic_log_stream_blocked_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_stream_blocked_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
-	size_t byte_index = 1;
-	const size_t min_size =  1 + picoquic_varint_skip(bytes+1);
-	uint64_t blocked_stream_id;
+    size_t byte_index = 1;
+    const size_t min_size = 1 + picoquic_varint_skip(bytes + 1);
+    uint64_t blocked_stream_id;
 
-	if (min_size > bytes_max)
-	{
-		fprintf(F, "    Malformed STREAM BLOCKED, requires %d bytes out of %d\n", (int) min_size, (int) bytes_max);
-		return bytes_max;
-	}
+    if (min_size > bytes_max) {
+        fprintf(F, "    Malformed STREAM BLOCKED, requires %d bytes out of %d\n", (int)min_size, (int)bytes_max);
+        return bytes_max;
+    }
 
-	/* Now that the size is good, parse and print it */   
+    /* Now that the size is good, parse and print it */
     byte_index += picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &blocked_stream_id);
     byte_index += picoquic_varint_skip(&bytes[byte_index]);
-    
 
-	fprintf(F, "    STREAM BLOCKED: %" PRIu64 ".\n",
-		blocked_stream_id);
+    fprintf(F, "    STREAM BLOCKED: %" PRIu64 ".\n",
+        blocked_stream_id);
 
-	return byte_index;
+    return byte_index;
 }
 
-size_t picoquic_log_new_connection_id_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_new_connection_id_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
-	size_t byte_index = 1;
-	size_t min_size = 1 + 8 + 16;
-	uint64_t new_cnx_id;
+    size_t byte_index = 1;
+    size_t min_size = 1 + 8 + 16;
+    uint64_t new_cnx_id;
     size_t l_seq = 2;
 
     l_seq = picoquic_varint_skip(&bytes[byte_index]);
 
     min_size += l_seq;
 
-	if (min_size > bytes_max)
-	{
-		fprintf(F, "    Malformed NEW CONNECTION ID, requires %d bytes out of %d\n", (int) min_size, (int) bytes_max);
-		return bytes_max;
-	}
+    if (min_size > bytes_max) {
+        fprintf(F, "    Malformed NEW CONNECTION ID, requires %d bytes out of %d\n", (int)min_size, (int)bytes_max);
+        return bytes_max;
+    }
 
     byte_index += l_seq;
-	/* Now that the size is good, parse and print it */
-	new_cnx_id = PICOPARSE_64(bytes + byte_index);
-	byte_index += 8;
+    /* Now that the size is good, parse and print it */
+    new_cnx_id = PICOPARSE_64(bytes + byte_index);
+    byte_index += 8;
 
-	fprintf(F, "    NEW CONNECTION ID: 0x%016llx, ",
-		(unsigned long long) new_cnx_id);
+    fprintf(F, "    NEW CONNECTION ID: 0x%016llx, ",
+        (unsigned long long)new_cnx_id);
 
-    for (size_t i = 0; i < 16; i++)
-    {
+    for (size_t i = 0; i < 16; i++) {
         fprintf(F, "%02x", bytes[byte_index++]);
     }
 
     fprintf(F, "\n");
 
-	return byte_index;
+    return byte_index;
 }
 
-size_t picoquic_log_ping_pong_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
+size_t picoquic_log_ping_pong_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
 {
     size_t byte_index = 1;
     size_t ping_length = bytes[byte_index++];
 
-    if (byte_index + ping_length > bytes_max)
-    {
+    if (byte_index + ping_length > bytes_max) {
         fprintf(F, "    Malformed %s frame, length %d, %d bytes needed, %d available\n",
             picoquic_log_frame_names[bytes[0]], (int)ping_length,
             (int)(ping_length + 2), (int)bytes_max);
         byte_index = bytes_max;
-    }
-    else if (ping_length == 0)
-    {
-        if (bytes[0] == picoquic_frame_type_ping)
-        {
+    } else if (ping_length == 0) {
+        if (bytes[0] == picoquic_frame_type_ping) {
             fprintf(F, "    %s frame, length = 0.\n",
                 picoquic_log_frame_names[bytes[0]]);
-        }
-        else
-        {
+        } else {
             fprintf(F, "    Unexpected empty %s frame.\n",
                 picoquic_log_frame_names[bytes[0]]);
             byte_index = bytes_max;
         }
-    }
-    else
-    {
+    } else {
         fprintf(F, "    %s length %d: ", picoquic_log_frame_names[bytes[0]], (int)ping_length);
 
-        for (size_t i = 0; i < ping_length && i < 16; i++)
-        {
+        for (size_t i = 0; i < ping_length && i < 16; i++) {
             fprintf(F, "%02x", bytes[byte_index + i]);
         }
 
-        if (ping_length > 16)
-        {
+        if (ping_length > 16) {
             fprintf(F, " ...");
         }
         fprintf(F, "\n");
@@ -691,47 +617,35 @@ size_t picoquic_log_ping_pong_frame(FILE * F, uint8_t * bytes, size_t bytes_max)
     return byte_index;
 }
 
-void picoquic_log_frames(FILE* F, uint8_t * bytes, size_t length)
+void picoquic_log_frames(FILE* F, uint8_t* bytes, size_t length)
 {
-	size_t byte_index = 0;
+    size_t byte_index = 0;
 
-    while (byte_index < length)
-    {
+    while (byte_index < length) {
         int ack_or_data = 0;
 
-        if (bytes[byte_index] >= picoquic_frame_type_stream_range_min &&
-            bytes[byte_index] <= picoquic_frame_type_stream_range_max)
-        {
+        if (bytes[byte_index] >= picoquic_frame_type_stream_range_min && bytes[byte_index] <= picoquic_frame_type_stream_range_max) {
             ack_or_data = 1;
             byte_index += picoquic_log_stream_frame(F, bytes + byte_index, length - byte_index);
-        }
-        else if (bytes[byte_index] == picoquic_frame_type_ack)
-        {
+        } else if (bytes[byte_index] == picoquic_frame_type_ack) {
             ack_or_data = 1;
             byte_index += picoquic_log_ack_frame(F, bytes + byte_index, length - byte_index);
         }
-        
 
-        if (ack_or_data == 0)
-        {
-            if (bytes[byte_index] == 0)
-            {
+        if (ack_or_data == 0) {
+            if (bytes[byte_index] == 0) {
                 int nb_pad = 0;
 
-                while (bytes[byte_index] == 0 && byte_index < length)
-                {
+                while (bytes[byte_index] == 0 && byte_index < length) {
                     byte_index++;
                     nb_pad++;
                 }
 
                 fprintf(F, "    Padding, %d bytes\n", nb_pad);
-            }
-            else
-            {
+            } else {
                 uint32_t frame_id = bytes[byte_index];
 
-                switch (frame_id)
-                {
+                switch (frame_id) {
                 case picoquic_frame_type_reset_stream: /* RST_STREAM */
                     byte_index += picoquic_log_reset_stream_frame(F, bytes + byte_index,
                         length - byte_index);
@@ -798,73 +712,61 @@ void picoquic_log_frames(FILE* F, uint8_t * bytes, size_t length)
     }
 }
 
-uint32_t picoquic_log_decrypt_clear_text(FILE* F, 
-	uint8_t * bytes, size_t length)
+uint32_t picoquic_log_decrypt_clear_text(FILE* F,
+    uint8_t* bytes, size_t length)
 {
-	/* Verify the checksum */
-	uint32_t decoded_length = (uint32_t) fnv1a_check(bytes, length);
-	if (decoded_length == 0)
-	{
-		/* Incorrect checksum, drop and log. */
-		fprintf(F, "    Error: cannot verify the FNV1A checksum.\n");
-	}
-	else
-	{
-		fprintf(F, "    FNV1A checksum is correct (%d bytes).\n", decoded_length);
-	}
+    /* Verify the checksum */
+    uint32_t decoded_length = (uint32_t)fnv1a_check(bytes, length);
+    if (decoded_length == 0) {
+        /* Incorrect checksum, drop and log. */
+        fprintf(F, "    Error: cannot verify the FNV1A checksum.\n");
+    } else {
+        fprintf(F, "    FNV1A checksum is correct (%d bytes).\n", decoded_length);
+    }
 
-	return decoded_length;
+    return decoded_length;
 }
 
 void picoquic_log_decrypt_encrypted(FILE* F,
-	picoquic_cnx_t * cnx, int receiving,
-	uint8_t * bytes, size_t length, picoquic_packet_header * ph)
+    picoquic_cnx_t* cnx, int receiving,
+    uint8_t* bytes, size_t length, picoquic_packet_header* ph)
 {
-	/* decrypt in a separate copy */
-	uint8_t decrypted[PICOQUIC_MAX_PACKET_SIZE];
+    /* decrypt in a separate copy */
+    uint8_t decrypted[PICOQUIC_MAX_PACKET_SIZE];
     size_t decrypted_length = 0;
-    int cmp_reset_secret = 0;  
+    int cmp_reset_secret = 0;
     int cmp_reset_secret_old = 0;
 
     /* Check first whether this could be a reset packet */
-    if (length > PICOQUIC_RESET_SECRET_SIZE + 10)
-    {
+    if (length > PICOQUIC_RESET_SECRET_SIZE + 10) {
         cmp_reset_secret = (memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE,
-            cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0);
+                                cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE)
+            == 0);
 
-        if (cmp_reset_secret == 0)
-        {
+        if (cmp_reset_secret == 0) {
             cmp_reset_secret = (memcmp(bytes + 9, cnx->reset_secret,
-                PICOQUIC_RESET_SECRET_SIZE) == 0);
+                                    PICOQUIC_RESET_SECRET_SIZE)
+                == 0);
             cmp_reset_secret_old = cmp_reset_secret;
         }
     }
 
-    if (cmp_reset_secret != 0)
-    {
-        fprintf(F, "    Stateless reset packet%s, %d bytes\n", 
-            (cmp_reset_secret_old == 0)?"":" (old format)",
+    if (cmp_reset_secret != 0) {
+        fprintf(F, "    Stateless reset packet%s, %d bytes\n",
+            (cmp_reset_secret_old == 0) ? "" : " (old format)",
             (int)length);
-    }
-    else
-    {
-        if (receiving)
-        {
+    } else {
+        if (receiving) {
             decrypted_length = picoquic_aead_decrypt(cnx, decrypted,
                 bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
-        }
-        else
-        {
+        } else {
             decrypted_length = picoquic_aead_de_encrypt(cnx, decrypted,
                 bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
         }
 
-        if (decrypted_length > length)
-        {
+        if (decrypted_length > length) {
             fprintf(F, "    Decryption failed!\n");
-        }
-        else
-        {
+        } else {
             fprintf(F, "    Decrypted %d bytes\n", (int)decrypted_length);
             picoquic_log_frames(F, decrypted, decrypted_length);
         }
@@ -872,7 +774,7 @@ void picoquic_log_decrypt_encrypted(FILE* F,
 }
 
 void picoquic_log_decrypt_0rtt(FILE* F,
-    picoquic_cnx_t * cnx, uint8_t * bytes, size_t length, picoquic_packet_header * ph)
+    picoquic_cnx_t* cnx, uint8_t* bytes, size_t length, picoquic_packet_header* ph)
 {
     /* decrypt in a separate copy */
     uint8_t decrypted[PICOQUIC_MAX_PACKET_SIZE];
@@ -881,235 +783,186 @@ void picoquic_log_decrypt_0rtt(FILE* F,
     decrypted_length = picoquic_aead_0rtt_decrypt(cnx, decrypted,
         bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
 
-    if (decrypted_length > length)
-    {
+    if (decrypted_length > length) {
         fprintf(F, "    Decryption failed!\n");
-    }
-    else
-    {
+    } else {
         fprintf(F, "    Decrypted %d bytes\n", (int)decrypted_length);
         picoquic_log_frames(F, decrypted, decrypted_length);
     }
 }
 
 void picoquic_log_decrypt_encrypted_cleartext(FILE* F,
-    picoquic_cnx_t * cnx, int receiving,
-    uint8_t * bytes, size_t length, picoquic_packet_header * ph)
+    picoquic_cnx_t* cnx, int receiving,
+    uint8_t* bytes, size_t length, picoquic_packet_header* ph)
 {
     /* decrypt in a separate copy */
     uint8_t decrypted[PICOQUIC_MAX_PACKET_SIZE];
     size_t decrypted_length = 0;
 
-    if (receiving)
-    {
+    if (receiving) {
         decrypted_length = picoquic_aead_cleartext_decrypt(cnx, decrypted,
             bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
-    }
-    else
-    {
+    } else {
         decrypted_length = picoquic_aead_cleartext_de_encrypt(cnx, decrypted,
             bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
     }
 
-    if (decrypted_length > length)
-    {
+    if (decrypted_length > length) {
         fprintf(F, "    Decryption failed!\n");
-    }
-    else
-    {
+    } else {
         fprintf(F, "    Decrypted %d bytes\n", (int)decrypted_length);
         picoquic_log_frames(F, decrypted, decrypted_length);
     }
 }
 
-
-void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx,
-	struct sockaddr * addr_peer, int receiving,
-	uint8_t * bytes,  size_t length, uint64_t current_time)
+void picoquic_log_packet(FILE* F, picoquic_quic_t* quic, picoquic_cnx_t* cnx,
+    struct sockaddr* addr_peer, int receiving,
+    uint8_t* bytes, size_t length, uint64_t current_time)
 {
-	int ret = 0;
-	picoquic_packet_header ph;
-    picoquic_cnx_t * pcnx = cnx;
+    int ret = 0;
+    picoquic_packet_header ph;
+    picoquic_cnx_t* pcnx = cnx;
 
-	/* first log line */
-	picoquic_log_packet_address(F, cnx, addr_peer, receiving, length, current_time);
+    /* first log line */
+    picoquic_log_packet_address(F, cnx, addr_peer, receiving, length, current_time);
 
-	/* Parse the clear text header */
+    /* Parse the clear text header */
     ret = picoquic_parse_packet_header(quic, bytes, (uint32_t)length, NULL, &ph, &pcnx);
 
-	if (ret != 0)
-	{
-		/* packet does not even parse */
-		fprintf(F, "   Cannot parse the packet header.\n");
-	}
-	else
-	{
-        if (cnx == NULL)
-        {
+    if (ret != 0) {
+        /* packet does not even parse */
+        fprintf(F, "   Cannot parse the packet header.\n");
+    } else {
+        if (cnx == NULL) {
             cnx = picoquic_cnx_by_net(quic, addr_peer);
         }
 
-		if (cnx == NULL && ph.cnx_id != 0)
-		{
-			cnx = picoquic_cnx_by_id(quic, ph.cnx_id);
-		}
+        if (cnx == NULL && ph.cnx_id != 0) {
+            cnx = picoquic_cnx_by_id(quic, ph.cnx_id);
+        }
 
-		if (cnx != NULL)
-		{
-			ph.pn64 = picoquic_get_packet_number64(
-                (receiving == 0)?cnx->send_sequence:cnx->first_sack_item.end_of_sack_range,
+        if (cnx != NULL) {
+            ph.pn64 = picoquic_get_packet_number64(
+                (receiving == 0) ? cnx->send_sequence : cnx->first_sack_item.end_of_sack_range,
                 ph.pnmask, ph.pn);
-		}
-		else
-		{
-			ph.pn64 = ph.pn;
-		}
+        } else {
+            ph.pn64 = ph.pn;
+        }
 
-		picoquic_log_packet_header(F, cnx, &ph);
+        picoquic_log_packet_header(F, cnx, &ph);
 
-		switch (ph.ptype)
-		{
-		case picoquic_packet_version_negotiation:
-			/* log version negotiation */
-			picoquic_log_negotiation_packet(F, bytes, length, &ph);
-			break;
-		case picoquic_packet_server_stateless:
-		case picoquic_packet_client_initial:
-		case picoquic_packet_server_cleartext:
-		case picoquic_packet_client_cleartext:
-            if (cnx != NULL)
-            {
+        switch (ph.ptype) {
+        case picoquic_packet_version_negotiation:
+            /* log version negotiation */
+            picoquic_log_negotiation_packet(F, bytes, length, &ph);
+            break;
+        case picoquic_packet_server_stateless:
+        case picoquic_packet_client_initial:
+        case picoquic_packet_server_cleartext:
+        case picoquic_packet_client_cleartext:
+            if (cnx != NULL) {
                 picoquic_log_decrypt_encrypted_cleartext(F, cnx, receiving, bytes, length, &ph);
             }
-			break;
-		case picoquic_packet_0rtt_protected:
-			/* log 0-rtt packet */
+            break;
+        case picoquic_packet_0rtt_protected:
+            /* log 0-rtt packet */
             picoquic_log_decrypt_0rtt(F, cnx, bytes, length, &ph);
-			break;
-		case picoquic_packet_1rtt_protected_phi0:
-		case picoquic_packet_1rtt_protected_phi1:
+            break;
+        case picoquic_packet_1rtt_protected_phi0:
+        case picoquic_packet_1rtt_protected_phi1:
             picoquic_log_decrypt_encrypted(F, cnx, receiving, bytes, length, &ph);
-			break;
-		default:
-			/* Packet type error. Log and ignore */
-			break;
-		}
-	}
-	fprintf(F, "\n");
+            break;
+        default:
+            /* Packet type error. Log and ignore */
+            break;
+        }
+    }
+    fprintf(F, "\n");
 }
 
-void picoquic_log_processing(FILE* F, picoquic_cnx_t * cnx, size_t length, int ret)
+void picoquic_log_processing(FILE* F, picoquic_cnx_t* cnx, size_t length, int ret)
 {
-	fprintf(F, "Processed %d bytes, state = %d (%s), return %d\n\n",
-		(int) length, cnx->cnx_state,
-		(((size_t)cnx->cnx_state) < picoquic_nb_log_state_name) ?
-		picoquic_log_state_name[(size_t)cnx->cnx_state] : "unknown",
-		ret);
+    fprintf(F, "Processed %d bytes, state = %d (%s), return %d\n\n",
+        (int)length, cnx->cnx_state,
+        (((size_t)cnx->cnx_state) < picoquic_nb_log_state_name) ? picoquic_log_state_name[(size_t)cnx->cnx_state] : "unknown",
+        ret);
 }
 
-void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t * cnx, int log_cnxid)
+void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int log_cnxid)
 {
-	uint8_t * bytes = NULL;
-	size_t bytes_max = 0;
-	int ext_received_return = 0;
-	int client_mode = 1;
-	int ret = 0;
-	size_t byte_index = 0;
-	char const * sni = picoquic_tls_get_sni(cnx);
-	char const * alpn = picoquic_tls_get_negotiated_alpn(cnx);
+    uint8_t* bytes = NULL;
+    size_t bytes_max = 0;
+    int ext_received_return = 0;
+    int client_mode = 1;
+    int ret = 0;
+    size_t byte_index = 0;
+    char const* sni = picoquic_tls_get_sni(cnx);
+    char const* alpn = picoquic_tls_get_negotiated_alpn(cnx);
 
-    if (log_cnxid != 0)
-    {
+    if (log_cnxid != 0) {
         printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
     }
-	if (sni == NULL)
-	{
-		fprintf(F, "SNI not received.\n");
-	}
-	else
-	{
-		fprintf(F, "Received SNI: %s\n", sni);
-	}
+    if (sni == NULL) {
+        fprintf(F, "SNI not received.\n");
+    } else {
+        fprintf(F, "Received SNI: %s\n", sni);
+    }
 
-
-    if (log_cnxid != 0)
-    {
+    if (log_cnxid != 0) {
         printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
     }
-	if (alpn == NULL)
-	{
-		fprintf(F, "ALPN not received.\n");
-	}
-	else
-	{
-		fprintf(F, "Received ALPN: %s\n", alpn);
-	}
-	picoquic_provide_received_transport_extensions(cnx,
-		&bytes, &bytes_max, &ext_received_return, &client_mode);
+    if (alpn == NULL) {
+        fprintf(F, "ALPN not received.\n");
+    } else {
+        fprintf(F, "Received ALPN: %s\n", alpn);
+    }
+    picoquic_provide_received_transport_extensions(cnx,
+        &bytes, &bytes_max, &ext_received_return, &client_mode);
 
-	if (bytes_max == 0)
-	{
-        if (log_cnxid != 0)
-        {
+    if (bytes_max == 0) {
+        if (log_cnxid != 0) {
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         }
-		fprintf(F, "Did not receive transport parameter TLS extension.\n");
-	}
-	else if (bytes_max < 128)
-	{
-        if (log_cnxid != 0)
-        {
+        fprintf(F, "Did not receive transport parameter TLS extension.\n");
+    } else if (bytes_max < 128) {
+        if (log_cnxid != 0) {
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         }
-		fprintf(F, "Received transport parameter TLS extension (%d bytes):\n", (uint32_t)bytes_max);
-		switch (client_mode)
-		{
-		case 0: // Client hello
-            if (bytes_max < 4)
-            {
-                if (log_cnxid != 0)
-                {
+        fprintf(F, "Received transport parameter TLS extension (%d bytes):\n", (uint32_t)bytes_max);
+        switch (client_mode) {
+        case 0: // Client hello
+            if (bytes_max < 4) {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
-				fprintf(F, "Malformed extension\n");
-				ret = -1;
-			}
-            else
-            {
+                fprintf(F, "Malformed extension\n");
+                ret = -1;
+            } else {
                 uint32_t proposed_version;
                 proposed_version = PICOPARSE_32(bytes + byte_index);
                 byte_index += 4;
-                if (log_cnxid != 0)
-                {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
                 fprintf(F, "Proposed version: %08x\n", proposed_version);
             }
-			break;
-		case 1: // Server encrypted extension
-		{
-			if (bytes_max < 1)
-			{
-                if (log_cnxid != 0)
-                {
+            break;
+        case 1: // Server encrypted extension
+        {
+            if (bytes_max < 1) {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
-				fprintf(F, "Malformed extension\n");
-				ret = -1;
-			}
-			else
-			{
-                if (log_cnxid != 0)
-                {
+                fprintf(F, "Malformed extension\n");
+                ret = -1;
+            } else {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
-                if (bytes_max < byte_index + 4)
-                {
+                if (bytes_max < byte_index + 4) {
                     fprintf(F, "Malformed extension\n");
                     ret = -1;
-                }
-                else
-                {
+                } else {
                     uint32_t version;
 
                     version = PICOPARSE_32(bytes + byte_index);
@@ -1118,14 +971,11 @@ void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t * cnx, int log_cnx
                     fprintf(F, "Version: %08x\n", version);
                 }
 
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     size_t supported_versions_size = bytes[byte_index++];
 
-                    if ((supported_versions_size & 3) != 0)
-                    {
-                        if (log_cnxid != 0)
-                        {
+                    if ((supported_versions_size & 3) != 0) {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
                         fprintf(F,
@@ -1133,183 +983,140 @@ void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t * cnx, int log_cnx
                             (uint32_t)supported_versions_size);
                         ret = -1;
 
-                    }
-                    else if (supported_versions_size > 252 ||
-                        byte_index + supported_versions_size > bytes_max)
-                    {
-                        if (log_cnxid != 0)
-                        {
+                    } else if (supported_versions_size > 252 || byte_index + supported_versions_size > bytes_max) {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
                         fprintf(F, "    Malformed extension, supported version size = %d, max %d or 252\n",
                             (uint32_t)supported_versions_size, (uint32_t)(bytes_max - byte_index));
                         ret = -1;
-                    }
-                    else
-                    {
+                    } else {
                         size_t nb_supported_versions = supported_versions_size / 4;
 
-                        if (log_cnxid != 0)
-                        {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
                         fprintf(F, "    Supported version (%d bytes):\n", (int)supported_versions_size);
 
-                        for (size_t i = 0; i < nb_supported_versions; i++)
-                        {
+                        for (size_t i = 0; i < nb_supported_versions; i++) {
                             uint32_t supported_version = PICOPARSE_32(bytes + byte_index);
 
                             byte_index += 4;
-                            if (log_cnxid != 0)
-                            {
+                            if (log_cnxid != 0) {
                                 printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                             }
-                            if (supported_version == cnx->proposed_version &&
-                                cnx->proposed_version !=
-                                picoquic_supported_versions[cnx->version_index].version)
-                            {
+                            if (supported_version == cnx->proposed_version && cnx->proposed_version != picoquic_supported_versions[cnx->version_index].version) {
                                 fprintf(F, "        %08x (same as proposed!)\n", supported_version);
-                            }
-                            else
-                            {
+                            } else {
                                 fprintf(F, "        %08x\n", supported_version);
                             }
                         }
                     }
                 }
-			}
-			break;
-		}
-		default: // New session ticket
-			break;
-		}
+            }
+            break;
+        }
+        default: // New session ticket
+            break;
+        }
 
-		if (ret == 0 && byte_index + 2 > bytes_max)
-		{
-            if (log_cnxid != 0)
-            {
+        if (ret == 0 && byte_index + 2 > bytes_max) {
+            if (log_cnxid != 0) {
                 printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
             }
-			fprintf(F, "    Malformed extension list\n");
-			ret = -1;
-		}
-		else
-		{
-			uint16_t extensions_size = PICOPARSE_16(bytes + byte_index);
-			size_t extensions_end;
-			byte_index += 2;
-			extensions_end = byte_index + extensions_size;
+            fprintf(F, "    Malformed extension list\n");
+            ret = -1;
+        } else {
+            uint16_t extensions_size = PICOPARSE_16(bytes + byte_index);
+            size_t extensions_end;
+            byte_index += 2;
+            extensions_end = byte_index + extensions_size;
 
-			if (extensions_end > bytes_max)
-			{
-                if (log_cnxid != 0)
-                {
+            if (extensions_end > bytes_max) {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
-				fprintf(F, "    Extension list too long (%d bytes vs %d)\n",
-					(uint32_t)extensions_size, (uint32_t)(bytes_max - byte_index));
-			}
-			else
-			{
-                if (log_cnxid != 0)
-                {
+                fprintf(F, "    Extension list too long (%d bytes vs %d)\n",
+                    (uint32_t)extensions_size, (uint32_t)(bytes_max - byte_index));
+            } else {
+                if (log_cnxid != 0) {
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 }
-				fprintf(F, "    Extension list (%d bytes):\n",
-					(uint32_t)extensions_size);
-				while (ret == 0 && byte_index < extensions_end)
-				{
-					if (byte_index + 6 > extensions_end)
-					{
-                        if (log_cnxid != 0)
-                        {
+                fprintf(F, "    Extension list (%d bytes):\n",
+                    (uint32_t)extensions_size);
+                while (ret == 0 && byte_index < extensions_end) {
+                    if (byte_index + 6 > extensions_end) {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
-						fprintf(F, "        Malformed extension.\n");
-						ret = -1;
-					}
-					else
-					{
-						uint16_t extension_type = PICOPARSE_16(bytes + byte_index);
-						uint16_t extension_length = PICOPARSE_16(bytes + byte_index + 2);
-						byte_index += 4;
+                        fprintf(F, "        Malformed extension.\n");
+                        ret = -1;
+                    } else {
+                        uint16_t extension_type = PICOPARSE_16(bytes + byte_index);
+                        uint16_t extension_length = PICOPARSE_16(bytes + byte_index + 2);
+                        byte_index += 4;
 
-                        if (log_cnxid != 0)
-                        {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
-						fprintf(F, "        Extension type: %d, length %d (0x%04x / 0x%04x), ",
-							extension_type, extension_length, extension_type, extension_length);
+                        fprintf(F, "        Extension type: %d, length %d (0x%04x / 0x%04x), ",
+                            extension_type, extension_length, extension_type, extension_length);
 
-                        if (log_cnxid != 0)
-                        {
+                        if (log_cnxid != 0) {
                             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                         }
-						if (byte_index + extension_length > extensions_end)
-						{
-							fprintf(F, "Malformed extension.\n");
-							ret = -1;
-						}
-						else
-						{
-							for (uint16_t i = 0; i < extension_length; i++)
-							{
-								fprintf(F, "%02x", bytes[byte_index++]);
-							}
-							fprintf(F, "\n");
-						}
-					}
-				}
-			}
-		}
-		if (byte_index < bytes_max)
-		{
-            if (log_cnxid != 0)
-            {
+                        if (byte_index + extension_length > extensions_end) {
+                            fprintf(F, "Malformed extension.\n");
+                            ret = -1;
+                        } else {
+                            for (uint16_t i = 0; i < extension_length; i++) {
+                                fprintf(F, "%02x", bytes[byte_index++]);
+                            }
+                            fprintf(F, "\n");
+                        }
+                    }
+                }
+            }
+        }
+        if (byte_index < bytes_max) {
+            if (log_cnxid != 0) {
                 printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
             }
-			fprintf(F, "    Remaining bytes (%d)\n", (uint32_t)(bytes_max - byte_index));
-		}
-	}
-	else
-	{
-        if (log_cnxid != 0)
-        {
+            fprintf(F, "    Remaining bytes (%d)\n", (uint32_t)(bytes_max - byte_index));
+        }
+    } else {
+        if (log_cnxid != 0) {
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         }
-		fprintf(F, "Received transport parameter TLS extension (%d bytes):\n", (uint32_t)bytes_max);
-        if (log_cnxid != 0)
-        {
+        fprintf(F, "Received transport parameter TLS extension (%d bytes):\n", (uint32_t)bytes_max);
+        if (log_cnxid != 0) {
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         }
-		fprintf(F, "    First 128 received bytes (%d):\n", (uint32_t)(bytes_max - byte_index));
-	}
+        fprintf(F, "    First 128 received bytes (%d):\n", (uint32_t)(bytes_max - byte_index));
+    }
 
-	while (byte_index < bytes_max && byte_index < 128)
-	{
-        if (log_cnxid != 0)
-        {
+    while (byte_index < bytes_max && byte_index < 128) {
+        if (log_cnxid != 0) {
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         }
-		fprintf(F, "        ");
-		for (int i = 0; i < 32 && byte_index < bytes_max && byte_index < 128; i++)
-		{
-			fprintf(F, "%02x", bytes[byte_index++]);
-		}
-		fprintf(F, "\n");
-	}
-    if (log_cnxid == 0)
-    {
+        fprintf(F, "        ");
+        for (int i = 0; i < 32 && byte_index < bytes_max && byte_index < 128; i++) {
+            fprintf(F, "%02x", bytes[byte_index++]);
+        }
+        fprintf(F, "\n");
+    }
+    if (log_cnxid == 0) {
         fprintf(F, "\n");
     }
 }
 
-void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t * cnx, uint64_t current_time)
+void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time)
 {
     fprintf(F, "%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
     picoquic_log_time(F, cnx, current_time, "T= ", ", ");
     fprintf(F, "cwin: %d,", (int)cnx->cwin);
-    fprintf(F, "flight: %d,", (int)cnx->bytes_in_transit);;
+    fprintf(F, "flight: %d,", (int)cnx->bytes_in_transit);
+    ;
     fprintf(F, "nb_ret: %d,", (int)cnx->nb_retransmission_total);
     fprintf(F, "rtt_min: %d,", (int)cnx->rtt_min);
     fprintf(F, "rtt: %d,", (int)cnx->smoothed_rtt);
@@ -1334,65 +1141,52 @@ void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t * cnx, uint64_t curre
    } Extension;
 */
 void picoquic_log_tls_ticket(FILE* F, uint64_t cnx_id,
-    uint8_t * ticket, uint16_t ticket_length)
+    uint8_t* ticket, uint16_t ticket_length)
 {
     uint32_t lifetime = 0;
     uint32_t age_add = 0;
     uint8_t nonce_length = 0;
-    uint8_t * nonce_ptr = NULL;
+    uint8_t* nonce_ptr = NULL;
     uint16_t ticket_val_length = 0;
-    uint8_t * ticket_val_ptr = NULL;
+    uint8_t* ticket_val_ptr = NULL;
     uint16_t extension_length = 0;
-    uint8_t * extension_ptr = NULL;
+    uint8_t* extension_ptr = NULL;
     uint16_t byte_index = 0;
     uint16_t min_length = 4 + 4 + 1 + 2 + 2;
     int ret = 0;
 
-    if (ticket_length < min_length)
-    {
+    if (ticket_length < min_length) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         lifetime = PICOPARSE_32(ticket);
         byte_index += 4;
         age_add = PICOPARSE_32(ticket + byte_index);
         byte_index += 4;
         nonce_length = ticket[byte_index++];
         min_length += nonce_length;
-        if (ticket_length < min_length)
-        {
+        if (ticket_length < min_length) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             nonce_ptr = &ticket[byte_index];
             byte_index += nonce_length;
 
             ticket_val_length = PICOPARSE_16(ticket + byte_index);
             byte_index += 2;
             min_length += ticket_val_length;
-            if (ticket_length < min_length)
-            {
+            if (ticket_length < min_length) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 ticket_val_ptr = &ticket[byte_index];
                 byte_index += ticket_val_length;
 
                 extension_length = PICOPARSE_16(ticket + byte_index);
                 byte_index += 2;
                 min_length += extension_length;
-                if (ticket_length < min_length)
-                {
+                if (ticket_length < min_length) {
                     ret = -1;
-                }
-                else
-                {
+                } else {
                     extension_ptr = &ticket[byte_index];
-                    if (min_length > ticket_length)
-                    {
+                    if (min_length > ticket_length) {
                         ret = -2;
                     }
                 }
@@ -1400,38 +1194,31 @@ void picoquic_log_tls_ticket(FILE* F, uint64_t cnx_id,
         }
     }
 
-    if (ret == -1)
-    {
+    if (ret == -1) {
         fprintf(F, "%llu: Malformed ticket, length = %d, at least %d required.\n",
             (unsigned long long)cnx_id, ticket_length, min_length);
     }
     fprintf(F, "%llu: lifetime = %d, age_add = %x, %d nonce, %d ticket, %d extensions.\n",
         (unsigned long long)cnx_id, lifetime, age_add, nonce_length, ticket_val_length, extension_length);
 
-    if (extension_ptr != NULL)
-    {
+    if (extension_ptr != NULL) {
         uint16_t x_index = 0;
 
         fprintf(F, "%llu: ticket extensions: ", (unsigned long long)cnx_id);
 
-        while (x_index + 4 < extension_length)
-        {
+        while (x_index + 4 < extension_length) {
             uint16_t x_type = PICOPARSE_16(extension_ptr + x_index);
             uint16_t x_len = PICOPARSE_16(extension_ptr + x_index + 2);
             x_index += 4 + x_len;
 
-            if (x_type == 42 && x_len == 4)
-            {
+            if (x_type == 42 && x_len == 4) {
                 uint32_t ed_len = PICOPARSE_32(extension_ptr + x_index - 4);
                 fprintf(F, "%d(ED: %x),", x_type, ed_len);
-            }
-            else
-            {
+            } else {
                 fprintf(F, "%d (%d bytes),", x_type, x_len);
             }
 
-            if (x_index > extension_length)
-            {
+            if (x_index > extension_length) {
                 fprintf(F, "\n%llu: malformed extensions, require %d bytes, not just %d",
                     (unsigned long long)cnx_id, x_index, extension_length);
             }
@@ -1439,19 +1226,16 @@ void picoquic_log_tls_ticket(FILE* F, uint64_t cnx_id,
 
         fprintf(F, "\n");
 
-        if (x_index < extension_length)
-        {
+        if (x_index < extension_length) {
             fprintf(F, "\n%llu: %d extra bytes at the end of the extensions\n",
                 (unsigned long long)cnx_id, extension_length - x_index);
         }
     }
 
-    if (ret == -2)
-    {
+    if (ret == -2) {
         fprintf(F, "%llu: Malformed TLS ticket, %d extra bytes.\n",
             (unsigned long long)cnx_id, ticket_length - min_length);
     }
-
 }
 
 /*
@@ -1467,24 +1251,21 @@ uint16_t cipher_suite;
  */
 
 void picoquic_log_picotls_ticket(FILE* F, uint64_t cnx_id,
-    uint8_t * ticket, uint16_t ticket_length)
+    uint8_t* ticket, uint16_t ticket_length)
 {
     uint64_t ticket_time = 0;
     uint16_t suite_id = 0;
     uint32_t tls_ticket_length = 0;
-    uint8_t * tls_ticket_ptr = NULL;
+    uint8_t* tls_ticket_ptr = NULL;
     uint16_t secret_length = 0;
-    uint8_t * secret_ptr = NULL;
+    uint8_t* secret_ptr = NULL;
     uint16_t byte_index = 0;
     uint32_t min_length = 8 + 2 + 3 + 2;
     int ret = 0;
 
-    if (ticket_length < min_length)
-    {
+    if (ticket_length < min_length) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         ticket_time = PICOPARSE_64(ticket);
         byte_index += 8;
         suite_id = PICOPARSE_16(ticket + byte_index);
@@ -1492,29 +1273,22 @@ void picoquic_log_picotls_ticket(FILE* F, uint64_t cnx_id,
         tls_ticket_length = PICOPARSE_24(ticket + byte_index);
         byte_index += 3;
         min_length += tls_ticket_length;
-        if (ticket_length < min_length)
-        {
+        if (ticket_length < min_length) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             tls_ticket_ptr = &ticket[byte_index];
             byte_index += tls_ticket_length;
 
             secret_length = PICOPARSE_16(ticket + byte_index);
             byte_index += 2;
             min_length += secret_length;
-            if (ticket_length < min_length)
-            {
+            if (ticket_length < min_length) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 secret_ptr = &ticket[byte_index];
                 byte_index += secret_length;
-                
-                if (min_length > ticket_length)
-                {
+
+                if (min_length > ticket_length) {
                     ret = -2;
                 }
             }
@@ -1525,21 +1299,16 @@ void picoquic_log_picotls_ticket(FILE* F, uint64_t cnx_id,
         (unsigned long long)cnx_id, (unsigned long long)ticket_time,
         suite_id, tls_ticket_length, secret_length);
 
-    if (ret == -1)
-    {
+    if (ret == -1) {
         fprintf(F, "%llu: Malformed PTLS ticket, length = %d, at least %d required.\n",
             (unsigned long long)cnx_id, ticket_length, min_length);
-    }
-    else
-    {
-        if (tls_ticket_length > 0 && tls_ticket_ptr != NULL)
-        {
+    } else {
+        if (tls_ticket_length > 0 && tls_ticket_ptr != NULL) {
             picoquic_log_tls_ticket(F, cnx_id, tls_ticket_ptr, tls_ticket_length);
         }
     }
 
-    if (ret == -2)
-    {
+    if (ret == -2) {
         fprintf(F, "%llu: Malformed PTLS ticket, %d extra bytes.\n",
             (unsigned long long)cnx_id, ticket_length - min_length);
     }

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -19,64 +19,58 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdlib.h>
 #include "picoquic_internal.h"
+#include <stdlib.h>
 
-typedef enum
-{
-	picoquic_newreno_alg_slow_start = 0,
-	picoquic_newreno_alg_recovery,
-	picoquic_newreno_alg_congestion_avoidance
+typedef enum {
+    picoquic_newreno_alg_slow_start = 0,
+    picoquic_newreno_alg_recovery,
+    picoquic_newreno_alg_congestion_avoidance
 } picoquic_newreno_alg_state_t;
 
 typedef struct st_picoquic_newreno_state_t {
-	picoquic_newreno_alg_state_t alg_state;
-	uint64_t residual_ack;
-	uint64_t ssthresh;
-	uint64_t recovery_start;
+    picoquic_newreno_alg_state_t alg_state;
+    uint64_t residual_ack;
+    uint64_t ssthresh;
+    uint64_t recovery_start;
 } picoquic_newreno_state_t;
 
-void picoquic_newreno_init(picoquic_cnx_t * cnx)
+void picoquic_newreno_init(picoquic_cnx_t* cnx)
 {
-	/* Initialize the state of the congestion control algorithm */
-	picoquic_newreno_state_t * nr_state = (picoquic_newreno_state_t *)malloc(sizeof(picoquic_newreno_state_t));
-	cnx->congestion_alg_state = (void *)nr_state;
+    /* Initialize the state of the congestion control algorithm */
+    picoquic_newreno_state_t* nr_state = (picoquic_newreno_state_t*)malloc(sizeof(picoquic_newreno_state_t));
+    cnx->congestion_alg_state = (void*)nr_state;
 
-	if (cnx->congestion_alg_state != NULL)
-	{
-		nr_state->alg_state = picoquic_newreno_alg_slow_start;
-		cnx->cwin = PICOQUIC_CWIN_INITIAL;
-		nr_state->residual_ack = 0;
-	}
+    if (cnx->congestion_alg_state != NULL) {
+        nr_state->alg_state = picoquic_newreno_alg_slow_start;
+        cnx->cwin = PICOQUIC_CWIN_INITIAL;
+        nr_state->residual_ack = 0;
+    }
 }
 
 /* The recovery state last 1 RTT, during which parameters will be frozen
  */
-static void picoquic_newreno_enter_recovery(picoquic_cnx_t * cnx,
-	picoquic_congestion_notification_t notification,
-	picoquic_newreno_state_t * nr_state,
-	uint64_t current_time)
+static void picoquic_newreno_enter_recovery(picoquic_cnx_t* cnx,
+    picoquic_congestion_notification_t notification,
+    picoquic_newreno_state_t* nr_state,
+    uint64_t current_time)
 {
-	nr_state->ssthresh = cnx->cwin / 2;
-	if (nr_state->ssthresh < PICOQUIC_CWIN_MINIMUM)
-	{
-		nr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
-	}
+    nr_state->ssthresh = cnx->cwin / 2;
+    if (nr_state->ssthresh < PICOQUIC_CWIN_MINIMUM) {
+        nr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
+    }
 
-	if (notification == picoquic_congestion_notification_timeout)
-	{
-		cnx->cwin = PICOQUIC_CWIN_MINIMUM;
-	}
-	else
-	{
-		cnx->cwin = nr_state->ssthresh;
-	}
+    if (notification == picoquic_congestion_notification_timeout) {
+        cnx->cwin = PICOQUIC_CWIN_MINIMUM;
+    } else {
+        cnx->cwin = nr_state->ssthresh;
+    }
 
-	nr_state->recovery_start = current_time;
+    nr_state->recovery_start = current_time;
 
-	nr_state->residual_ack = 0;
+    nr_state->residual_ack = 0;
 
-	nr_state->alg_state = picoquic_newreno_alg_recovery;
+    nr_state->alg_state = picoquic_newreno_alg_recovery;
 }
 
 /*
@@ -85,118 +79,108 @@ static void picoquic_newreno_enter_recovery(picoquic_cnx_t * cnx,
  * to condensate all that in a single API, which could be shared
  * by many different congestion control algorithms.
  */
-void picoquic_newreno_notify(picoquic_cnx_t * cnx,
-	picoquic_congestion_notification_t notification,
-	uint64_t rtt_measurement,
-	uint64_t nb_bytes_acknowledged,
-	uint64_t lost_packet_number,
-	uint64_t current_time)
+void picoquic_newreno_notify(picoquic_cnx_t* cnx,
+    picoquic_congestion_notification_t notification,
+    uint64_t rtt_measurement,
+    uint64_t nb_bytes_acknowledged,
+    uint64_t lost_packet_number,
+    uint64_t current_time)
 {
-	picoquic_newreno_state_t * nr_state = (picoquic_newreno_state_t *)cnx->congestion_alg_state;
+    picoquic_newreno_state_t* nr_state = (picoquic_newreno_state_t*)cnx->congestion_alg_state;
 
-	if (nr_state != NULL)
-	{
-		switch (nr_state->alg_state)
-		{
-		case picoquic_newreno_alg_slow_start:
-			switch (notification)
-			{
-			case picoquic_congestion_notification_acknowledgement:
-				cnx->cwin += nb_bytes_acknowledged;
-				/* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
-				if (cnx->cwin >= nr_state->ssthresh)
-				{
-					nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;
-				}
-				break;
-			case picoquic_congestion_notification_repeat:
-			case picoquic_congestion_notification_timeout:
-				/* enter recovery */
-				picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
-				break;
-			case picoquic_congestion_notification_spurious_repeat:
-				break;
-			case picoquic_congestion_notification_rtt_measurement:
-				/* TODO: consider using RTT increases as signal to get out of slow start */
-				break;
-			default:
-				/* ignore */
-				break;
-			}
-			break;
-		case picoquic_newreno_alg_recovery:
-			/* If the notification is coming less than 1RTT after start,
+    if (nr_state != NULL) {
+        switch (nr_state->alg_state) {
+        case picoquic_newreno_alg_slow_start:
+            switch (notification) {
+            case picoquic_congestion_notification_acknowledgement:
+                cnx->cwin += nb_bytes_acknowledged;
+                /* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
+                if (cnx->cwin >= nr_state->ssthresh) {
+                    nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;
+                }
+                break;
+            case picoquic_congestion_notification_repeat:
+            case picoquic_congestion_notification_timeout:
+                /* enter recovery */
+                picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
+                break;
+            case picoquic_congestion_notification_spurious_repeat:
+                break;
+            case picoquic_congestion_notification_rtt_measurement:
+                /* TODO: consider using RTT increases as signal to get out of slow start */
+                break;
+            default:
+                /* ignore */
+                break;
+            }
+            break;
+        case picoquic_newreno_alg_recovery:
+            /* If the notification is coming less than 1RTT after start,
 			 * ignore it. */
-			if (current_time - nr_state->recovery_start > cnx->rtt_min)
-			{
-				switch (notification)
-				{
-				case picoquic_congestion_notification_acknowledgement:
-					/* exit recovery, move to CA or SS, depending on CWIN */
-					nr_state->alg_state = picoquic_newreno_alg_slow_start;
-					cnx->cwin += nb_bytes_acknowledged;
-					/* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
-					if (cnx->cwin >= nr_state->ssthresh)
-					{
-						nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;
-					}
-					break;
-				case picoquic_congestion_notification_repeat:
-				case picoquic_congestion_notification_timeout:
-					/* re-enter recovery */
-					picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
-					break;
-				case picoquic_congestion_notification_spurious_repeat:
-					/* To do: if spurious repeat of initial loss detected,
+            if (current_time - nr_state->recovery_start > cnx->rtt_min) {
+                switch (notification) {
+                case picoquic_congestion_notification_acknowledgement:
+                    /* exit recovery, move to CA or SS, depending on CWIN */
+                    nr_state->alg_state = picoquic_newreno_alg_slow_start;
+                    cnx->cwin += nb_bytes_acknowledged;
+                    /* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
+                    if (cnx->cwin >= nr_state->ssthresh) {
+                        nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;
+                    }
+                    break;
+                case picoquic_congestion_notification_repeat:
+                case picoquic_congestion_notification_timeout:
+                    /* re-enter recovery */
+                    picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
+                    break;
+                case picoquic_congestion_notification_spurious_repeat:
+                    /* To do: if spurious repeat of initial loss detected,
 					 * exit recovery and reset threshold to pre-entry cwin.
 					 */
-					break;
-				case picoquic_congestion_notification_rtt_measurement:
-				default:
-					/* ignore */
-					break;
-				}
-			}
-			break;
-		case picoquic_newreno_alg_congestion_avoidance:
-			switch (notification)
-			{
-			case picoquic_congestion_notification_acknowledgement:
-			{
-				uint64_t complete_ack = nb_bytes_acknowledged + nr_state->residual_ack;
-				nr_state->residual_ack = complete_ack % cnx->cwin;
-				cnx->cwin += complete_ack / cnx->cwin;
-				break;
-			}
-			case picoquic_congestion_notification_repeat:
-			case picoquic_congestion_notification_timeout:
-				/* re-enter recovery */
-				picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
-				break;
-			case picoquic_congestion_notification_spurious_repeat:
-			case picoquic_congestion_notification_rtt_measurement:
-			default:
-				/* ignore */
-				break;
-			}
-			break;
-		default:
-			break;
-		}
+                    break;
+                case picoquic_congestion_notification_rtt_measurement:
+                default:
+                    /* ignore */
+                    break;
+                }
+            }
+            break;
+        case picoquic_newreno_alg_congestion_avoidance:
+            switch (notification) {
+            case picoquic_congestion_notification_acknowledgement: {
+                uint64_t complete_ack = nb_bytes_acknowledged + nr_state->residual_ack;
+                nr_state->residual_ack = complete_ack % cnx->cwin;
+                cnx->cwin += complete_ack / cnx->cwin;
+                break;
+            }
+            case picoquic_congestion_notification_repeat:
+            case picoquic_congestion_notification_timeout:
+                /* re-enter recovery */
+                picoquic_newreno_enter_recovery(cnx, notification, nr_state, current_time);
+                break;
+            case picoquic_congestion_notification_spurious_repeat:
+            case picoquic_congestion_notification_rtt_measurement:
+            default:
+                /* ignore */
+                break;
+            }
+            break;
+        default:
+            break;
+        }
 
         /* Compute pacing data */
         picoquic_update_pacing_data(cnx);
-	}
+    }
 }
 
 /* Release the state of the congestion control algorithm */
-void picoquic_newreno_delete (picoquic_cnx_t * cnx)
+void picoquic_newreno_delete(picoquic_cnx_t* cnx)
 {
-	if (cnx->congestion_alg_state != NULL)
-	{
-		free(cnx->congestion_alg_state);
-		cnx->congestion_alg_state = NULL;
-	}
+    if (cnx->congestion_alg_state != NULL) {
+        free(cnx->congestion_alg_state);
+        cnx->congestion_alg_state = NULL;
+    }
 }
 
 /* Definition record for the New Reno algorithm */
@@ -204,10 +188,10 @@ void picoquic_newreno_delete (picoquic_cnx_t * cnx)
 #define PICOQUIC_NEWRENO_ID 0x4E523838 /* NR88 */
 
 picoquic_congestion_algorithm_t picoquic_newreno_algorithm_struct = {
-	PICOQUIC_NEWRENO_ID,
-	picoquic_newreno_init,
-	picoquic_newreno_notify,
-	picoquic_newreno_delete
+    PICOQUIC_NEWRENO_ID,
+    picoquic_newreno_init,
+    picoquic_newreno_notify,
+    picoquic_newreno_delete
 };
 
-picoquic_congestion_algorithm_t * picoquic_newreno_algorithm = &picoquic_newreno_algorithm_struct;
+picoquic_congestion_algorithm_t* picoquic_newreno_algorithm = &picoquic_newreno_algorithm_struct;

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -27,42 +27,37 @@
  * - For initial packets, has to perform version checks.
  */
 
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
-#include "picoquic_internal.h"
 #include "fnv1a.h"
+#include "picoquic_internal.h"
 #include "tls_api.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 /*
  * The new packet header parsing is version dependent
  */
 
 int picoquic_parse_packet_header(
-    picoquic_quic_t * quic,
-    uint8_t * bytes,
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
     uint32_t length,
-    struct sockaddr * addr_from,
-    picoquic_packet_header * ph,
-    picoquic_cnx_t ** pcnx)
+    struct sockaddr* addr_from,
+    picoquic_packet_header* ph,
+    picoquic_cnx_t** pcnx)
 {
     int ret = 0;
 
     /* Is this a long header of a short header? */
-    if ((bytes[0] & 0x80) == 0x80)
-    {
-        if (length < 17)
-        {
+    if ((bytes[0] & 0x80) == 0x80) {
+        if (length < 17) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             /* If this is a long header, the bytes at position 9--12 describe the version */
             ph->cnx_id = PICOPARSE_64(bytes + 1);
             ph->vn = PICOPARSE_32(bytes + 9);
 
-            if (ph->vn == 0)
-            {
+            if (ph->vn == 0) {
                 /* VN = zero identifies a version negotiation packet */
                 ph->ptype = picoquic_packet_version_negotiation;
                 ph->pn = 0;
@@ -70,40 +65,31 @@ int picoquic_parse_packet_header(
                 ph->pnmask = 0;
                 ph->version_index = -1;
 
-                if (*pcnx == NULL)
-                {
+                if (*pcnx == NULL) {
                     *pcnx = picoquic_cnx_by_id(quic, ph->cnx_id);
 
-                    if (*pcnx == NULL)
-                    {
+                    if (*pcnx == NULL) {
                         *pcnx = picoquic_cnx_by_net(quic, addr_from);
                     }
                 }
-            }
-            else
-            {
+            } else {
                 ph->pn = PICOPARSE_32(bytes + 13);
                 ph->version_index = picoquic_get_version_index(ph->vn);
 
-                if (ph->version_index < 0)
-                {
+                if (ph->version_index < 0) {
                     ph->offset = 17;
                     ph->ptype = picoquic_packet_error;
-                }
-                else
-                {
+                } else {
                     /* Is the context found by using the `addr_from`? */
                     char context_by_addr = 0;
                     char is_client = 0;
 
                     /* Retrieve the connection context */
-                    if (*pcnx == NULL)
-                    {
+                    if (*pcnx == NULL) {
                         *pcnx = picoquic_cnx_by_id(quic, ph->cnx_id);
 
                         /* TODO: something for the case of client initial, e.g. source IP + initial CNX_ID */
-                        if (*pcnx == NULL)
-                        {
+                        if (*pcnx == NULL) {
                             *pcnx = picoquic_cnx_by_net(quic, addr_from);
                             context_by_addr = 1;
                         }
@@ -113,13 +99,11 @@ int picoquic_parse_packet_header(
 
                     /* If the version is supported now, the format field in the version table
                      * describes the encoding. */
-                    switch (picoquic_supported_versions[ph->version_index].version_header_encoding)
-                    {
+                    switch (picoquic_supported_versions[ph->version_index].version_header_encoding) {
                     case picoquic_version_header_08:
                         ph->offset = 17;
                         ph->pnmask = 0xFFFFFFFF00000000ull;
-                        switch (bytes[0])
-                        {
+                        switch (bytes[0]) {
                         case 0xFF:
                             ph->ptype = picoquic_packet_client_initial;
                             break;
@@ -140,19 +124,13 @@ int picoquic_parse_packet_header(
 
                     /* If the context was found by using `addr_from`, but the packet type
                      * does not allow that, reset the context to NULL. */
-                    if (context_by_addr && !(
-                        ph->ptype == picoquic_packet_server_cleartext ||
-                        ph->ptype == picoquic_packet_server_stateless ||
-                        ph->ptype == picoquic_packet_0rtt_protected))
-                    {
+                    if (context_by_addr && !(ph->ptype == picoquic_packet_server_cleartext || ph->ptype == picoquic_packet_server_stateless || ph->ptype == picoquic_packet_0rtt_protected)) {
                         *pcnx = NULL;
                     }
                 }
             }
         }
-    }
-    else
-    {
+    } else {
         /* If this is a short header, it should be possible to retrieve the connection
          * context. First check by address and port, and then by connection ID if
          * present. */
@@ -162,13 +140,11 @@ int picoquic_parse_packet_header(
         ph->vn = 0;
         ph->pn = 0;
 
-        if (*pcnx == NULL)
-        {
+        if (*pcnx == NULL) {
             *pcnx = picoquic_cnx_by_net(quic, addr_from);
         }
 
-        if (*pcnx == NULL && length >= 9)
-        {
+        if (*pcnx == NULL && length >= 9) {
             /* Assume that we can identify the connection by its value */
             assume_cnx_id_present = 1;
             ph->cnx_id = PICOPARSE_64(bytes + 1);
@@ -176,42 +152,33 @@ int picoquic_parse_packet_header(
             *pcnx = picoquic_cnx_by_id(quic, ph->cnx_id);
         }
 
-        if (*pcnx != NULL)
-        {
+        if (*pcnx != NULL) {
             ph->version_index = (*pcnx)->version_index;
             /* If the connection is identified, decode the short header per version ID */
-            switch (picoquic_supported_versions[ph->version_index].version_header_encoding)
-            {
+            switch (picoquic_supported_versions[ph->version_index].version_header_encoding) {
             case picoquic_version_header_08:
 
                 /* short format */
                 ph->vn = 0;
 
-                if ((bytes[0] & 0x40) == 0)
-                {
+                if ((bytes[0] & 0x40) == 0) {
                     ph->cnx_id = PICOPARSE_64(&bytes[1]);
                     ph->offset = 9;
                     /* may identify CNX by CNX_ID */
-                }
-                else
-                {
+                } else {
                     /* need to identify CNX by socket ID */
                     ph->cnx_id = 0;
                     ph->offset = 1;
                 }
 
-                if ((bytes[0] & 0x20) == 0)
-                {
+                if ((bytes[0] & 0x20) == 0) {
                     ph->ptype = picoquic_packet_1rtt_protected_phi0;
-                }
-                else
-                {
+                } else {
                     ph->ptype = picoquic_packet_1rtt_protected_phi1;
                 }
 
                 /* TODO: Get the length of pn from the CNX */
-                switch (bytes[0] & 0x1F)
-                {
+                switch (bytes[0] & 0x1F) {
                 case 0x1F:
                     ph->pn = bytes[ph->offset];
                     ph->pnmask = 0xFFFFFFFFFFFFFF00ull;
@@ -233,19 +200,15 @@ int picoquic_parse_packet_header(
                 }
             }
 
-            if (ph->cnx_id == 0 && assume_cnx_id_present != 0)
-            {
+            if (ph->cnx_id == 0 && assume_cnx_id_present != 0) {
                 ph->ptype = picoquic_packet_error;
                 *pcnx = NULL;
             }
 
-            if (length < ph->offset)
-            {
+            if (length < ph->offset) {
                 ret = -1;
             }
-        }
-        else
-        {
+        } else {
             /* If the connection is not identified, classify the packet as unknown.
              * it may trigger a retry */
             ph->ptype = picoquic_packet_error;
@@ -257,19 +220,16 @@ int picoquic_parse_packet_header(
 
 /* Check whether a packet was sent in clear text */
 int picoquic_is_packet_encrypted(
-    picoquic_cnx_t * cnx,
+    picoquic_cnx_t* cnx,
     uint8_t byte_zero)
 {
     int ret = 0;
 
     /* Is this a long header of a short header? */
-    if ((byte_zero & 0x80) == 0x80)
-    {
-        switch (picoquic_supported_versions[cnx->version_index].version_header_encoding)
-        {
+    if ((byte_zero & 0x80) == 0x80) {
+        switch (picoquic_supported_versions[cnx->version_index].version_header_encoding) {
         case picoquic_version_header_08:
-            switch (byte_zero)
-            {
+            switch (byte_zero) {
             case 0xFC: /* picoquic_packet_0rtt_protected*/
                 ret = 1;
                 break;
@@ -277,9 +237,7 @@ int picoquic_is_packet_encrypted(
                 break;
             }
         }
-    }
-    else
-    {
+    } else {
         /* If this is a short header, weknow that the packet is encrypted  */
         ret = 1;
     }
@@ -287,36 +245,29 @@ int picoquic_is_packet_encrypted(
     return ret;
 }
 
-
 /* The packet number logic */
 uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t pn)
 {
     uint64_t expected = highest + 1;
     uint64_t not_mask_plus_one = (~mask) + 1;
-    uint64_t pn64 = (expected&mask) | pn;
+    uint64_t pn64 = (expected & mask) | pn;
 
-    if (pn64 < expected)
-    {
+    if (pn64 < expected) {
         uint64_t delta1 = expected - pn64;
         uint64_t delta2 = not_mask_plus_one - delta1;
-        if (delta2 < delta1)
-        {
+        if (delta2 < delta1) {
             pn64 += not_mask_plus_one;
         }
-    }
-    else
-    {
+    } else {
         uint64_t delta1 = pn64 - expected;
         uint64_t delta2 = not_mask_plus_one - delta1;
 
-        if (delta2 <= delta1 &&
-            (pn64&mask) > 0)
-        {
+        if (delta2 <= delta1 && (pn64 & mask) > 0) {
             /* Out of sequence packet from previous roll */
             pn64 -= not_mask_plus_one;
         }
     }
-    
+
     return pn64;
 }
 
@@ -324,19 +275,16 @@ uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t 
  * Decode an incoming clear text packet.
  * This is done "in place"
  */
-size_t picoquic_decrypt_cleartext(picoquic_cnx_t * cnx,
-    uint8_t * bytes, size_t length, picoquic_packet_header * ph)
+size_t picoquic_decrypt_cleartext(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t length, picoquic_packet_header* ph)
 {
     size_t decoded_length = picoquic_aead_cleartext_decrypt(cnx, bytes + ph->offset,
         bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
 
-    if (decoded_length > (length - ph->offset))
-    {
+    if (decoded_length > (length - ph->offset)) {
         /* detect an error */
         decoded_length = 0;
-    }
-    else
-    {
+    } else {
         decoded_length += ph->offset;
     }
 
@@ -355,31 +303,27 @@ size_t picoquic_decrypt_cleartext(picoquic_cnx_t * cnx,
  * and MUST include the new negotiated protocol version.
  */
 int picoquic_incoming_version_negotiation(
-	picoquic_cnx_t * cnx,
-	uint8_t * bytes,
-	uint32_t length,
-	struct sockaddr * addr_from,
-	picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
+    uint32_t length,
+    struct sockaddr* addr_from,
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
-	/* Parse the content */
-	int ret = -1;
+    /* Parse the content */
+    int ret = -1;
 
-    
-    if (ph->cnx_id != cnx->initial_cnxid ||
-        ph->vn != 0)
-    {
+    if (ph->cnx_id != cnx->initial_cnxid || ph->vn != 0) {
         /* Packet that do not match the "echo" checks should be logged and ignored */
         ret = 0;
     }
 
-	if (ret != 0)
-	{
-		/* Trying to renegotiate the version, just ignore the packet if not good. */
-		ret = picoquic_reset_cnx_version( cnx, bytes + ph->offset, length - ph->offset, current_time);
-	}
+    if (ret != 0) {
+        /* Trying to renegotiate the version, just ignore the packet if not good. */
+        ret = picoquic_reset_cnx_version(cnx, bytes + ph->offset, length - ph->offset, current_time);
+    }
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -388,18 +332,17 @@ int picoquic_incoming_version_negotiation(
  */
 
 int picoquic_prepare_version_negotiation(
-    picoquic_quic_t * quic,
-    struct sockaddr * addr_from,
-    struct sockaddr * addr_to,
+    picoquic_quic_t* quic,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
     unsigned long if_index_to,
-    picoquic_packet_header * ph)
+    picoquic_packet_header* ph)
 {
     int ret = -1;
-    picoquic_stateless_packet_t * sp = picoquic_create_stateless_packet(quic);
+    picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(quic);
 
-    if (sp != NULL)
-    {
-        uint8_t * bytes = sp->bytes;
+    if (sp != NULL) {
+        uint8_t* bytes = sp->bytes;
         size_t byte_index = 0;
         /* Packet type set to version negotiation */
 
@@ -412,8 +355,7 @@ int picoquic_prepare_version_negotiation(
         byte_index += 4;
 
         /* Set the payload to the list of versions */
-        for (size_t i = 0; i < picoquic_nb_supported_versions; i++)
-        {
+        for (size_t i = 0; i < picoquic_nb_supported_versions; i++) {
             picoformat_32(bytes + byte_index, picoquic_supported_versions[i].version);
             byte_index += 4;
         }
@@ -428,10 +370,9 @@ int picoquic_prepare_version_negotiation(
         sp->if_index_local = if_index_to;
         picoquic_queue_stateless_packet(quic, sp);
     }
-    
+
     return ret;
 }
-
 
 /*
  * Process an unexpected connection ID. This could be an old packet from a 
@@ -439,64 +380,59 @@ int picoquic_prepare_version_negotiation(
  * the server can respond with a public reset
  */
 void picoquic_process_unexpected_cnxid(
-	picoquic_quic_t * quic,
-	uint32_t length,
-	struct sockaddr * addr_from,
-    struct sockaddr * addr_to,
+    picoquic_quic_t* quic,
+    uint32_t length,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
     unsigned long if_index_to,
-	picoquic_packet_header * ph)
+    picoquic_packet_header* ph)
 {
-	if ((ph->ptype == picoquic_packet_1rtt_protected_phi0 ||
-		 ph->ptype == picoquic_packet_1rtt_protected_phi1) &&
-		length > 26)
-	{
-		picoquic_stateless_packet_t * sp = picoquic_create_stateless_packet(quic);
+    if ((ph->ptype == picoquic_packet_1rtt_protected_phi0 || ph->ptype == picoquic_packet_1rtt_protected_phi1) && length > 26) {
+        picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(quic);
 
-		if (sp != NULL)
-		{
-			uint8_t * bytes = sp->bytes;
-			size_t byte_index = 0;
-			size_t pad_size = (size_t)(picoquic_public_uniform_random(length - 26) + 26 - 17);
-			/* Packet type set to short header, with cnxid, key phase 0, 1 byte seq */
-			bytes[byte_index++] = 0x41;
-			/* Copy the connection ID */
-			picoformat_64(bytes + byte_index, ph->cnx_id);
-			byte_index += 8;
+        if (sp != NULL) {
+            uint8_t* bytes = sp->bytes;
+            size_t byte_index = 0;
+            size_t pad_size = (size_t)(picoquic_public_uniform_random(length - 26) + 26 - 17);
+            /* Packet type set to short header, with cnxid, key phase 0, 1 byte seq */
+            bytes[byte_index++] = 0x41;
+            /* Copy the connection ID */
+            picoformat_64(bytes + byte_index, ph->cnx_id);
+            byte_index += 8;
             /* Add some random bytes to look good. */
             picoquic_public_random(bytes + byte_index, pad_size);
             byte_index += pad_size;
-			/* Add the public reset secret */
-			(void)picoquic_create_cnxid_reset_secret(quic, ph->cnx_id, bytes + byte_index);
-			byte_index += PICOQUIC_RESET_SECRET_SIZE;
-			sp->length = byte_index;
-			memset(&sp->addr_to, 0, sizeof(sp->addr_to));
-			memcpy(&sp->addr_to, addr_from,
-				(addr_from->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+            /* Add the public reset secret */
+            (void)picoquic_create_cnxid_reset_secret(quic, ph->cnx_id, bytes + byte_index);
+            byte_index += PICOQUIC_RESET_SECRET_SIZE;
+            sp->length = byte_index;
+            memset(&sp->addr_to, 0, sizeof(sp->addr_to));
+            memcpy(&sp->addr_to, addr_from,
+                (addr_from->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
             memset(&sp->addr_local, 0, sizeof(sp->addr_local));
             memcpy(&sp->addr_local, addr_to,
                 (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
             sp->if_index_local = if_index_to;
-			picoquic_queue_stateless_packet(quic, sp);
-		}
-	}
+            picoquic_queue_stateless_packet(quic, sp);
+        }
+    }
 }
 
 /*
  * Queue a stateless reset packet
  */
 
-void picoquic_queue_stateless_reset(picoquic_cnx_t * cnx,
-    picoquic_packet_header * ph, struct sockaddr* addr_from,
-    struct sockaddr * addr_to,
+void picoquic_queue_stateless_reset(picoquic_cnx_t* cnx,
+    picoquic_packet_header* ph, struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
     unsigned long if_index_to)
 {
-    picoquic_stateless_packet_t * sp = picoquic_create_stateless_packet(cnx->quic);
+    picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(cnx->quic);
     size_t checksum_length = 8;
     uint8_t cleartext[PICOQUIC_MAX_PACKET_SIZE];
 
-    if (sp != NULL)
-    {
-        uint8_t * bytes = cleartext;
+    if (sp != NULL) {
+        uint8_t* bytes = cleartext;
         size_t byte_index = 0;
         size_t data_bytes = 0;
         size_t header_length = 0;
@@ -517,8 +453,8 @@ void picoquic_queue_stateless_reset(picoquic_cnx_t * cnx,
 
         /* Copy the stream zero data */
         if (picoquic_prepare_stream_frame(cnx, &cnx->first_stream, bytes + byte_index,
-            PICOQUIC_MAX_PACKET_SIZE - byte_index - checksum_length, &data_bytes) == 0)
-        {
+                PICOQUIC_MAX_PACKET_SIZE - byte_index - checksum_length, &data_bytes)
+            == 0) {
 
             byte_index += data_bytes;
 
@@ -537,82 +473,67 @@ void picoquic_queue_stateless_reset(picoquic_cnx_t * cnx,
                 (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
             sp->if_index_local = if_index_to;
             picoquic_queue_stateless_packet(cnx->quic, sp);
-        }
-        else
-        {
+        } else {
             picoquic_delete_stateless_packet(sp);
         }
     }
 }
-
 
 /*
  * Processing of an incoming client initial packet,
  * on an unknown connection context.
  */
 
-picoquic_cnx_t * picoquic_incoming_initial(
-    picoquic_quic_t * quic,
-    uint8_t * bytes,
+picoquic_cnx_t* picoquic_incoming_initial(
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
     uint32_t length,
-    struct sockaddr * addr_from,
-    struct sockaddr * addr_to,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
     unsigned long if_index_to,
-    picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
-    picoquic_cnx_t * cnx = NULL;
+    picoquic_cnx_t* cnx = NULL;
     size_t decoded_length = 0;
 
-    if (length < PICOQUIC_ENFORCED_INITIAL_MTU)
-	{
+    if (length < PICOQUIC_ENFORCED_INITIAL_MTU) {
         /* Unexpected packet. Reject, drop and log. */
-    }
-    else
-    {
+    } else {
         /* if listening is OK, listen */
         cnx = picoquic_create_cnx(quic, ph->cnx_id, addr_from, current_time, ph->vn, NULL, NULL, 0);
 
-        if (cnx != NULL)
-        {
+        if (cnx != NULL) {
             decoded_length = picoquic_decrypt_cleartext(cnx, bytes, length, ph);
 
-            if (decoded_length == 0)
-            {
+            if (decoded_length == 0) {
                 /* Incorrect checksum, drop and log. */
                 picoquic_delete_cnx(cnx);
                 cnx = NULL;
-            }
-            else
-            {
+            } else {
                 int ret = 0;
 
                 ret = picoquic_decode_frames(cnx,
                     bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
 
                 /* processing of client initial packet */
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     /* initialization of context & creation of data */
                     /* TODO: find path to send data produced by TLS. */
                     ret = picoquic_tlsinput_stream_zero(cnx);
 
-                    if (cnx->cnx_state == picoquic_state_server_send_hrr)
-                    {
+                    if (cnx->cnx_state == picoquic_state_server_send_hrr) {
                         picoquic_queue_stateless_reset(cnx, ph, addr_from, addr_to, if_index_to);
                         cnx->cnx_state = picoquic_state_disconnected;
                     }
                 }
 
-                if (ret != 0 || cnx->cnx_state == picoquic_state_disconnected)
-                {
+                if (ret != 0 || cnx->cnx_state == picoquic_state_disconnected) {
                     /* This is bad. should just delete the context, log the packet, etc */
                     picoquic_delete_cnx(cnx);
                     cnx = NULL;
                     ret = 0;
-                }
-                else
-                {
+                } else {
                     /* remember the local address on which the initial packet arrived. */
                     cnx->if_index_dest = if_index_to;
                     cnx->dest_addr_len = (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
@@ -648,65 +569,51 @@ picoquic_cnx_t * picoquic_incoming_initial(
  */
 
 int picoquic_incoming_server_stateless(
-	picoquic_cnx_t * cnx,
-	uint8_t * bytes,
-	uint32_t length,
-	picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
+    uint32_t length,
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
-	int ret = 0;
-	size_t decoded_length = 0;
+    int ret = 0;
+    size_t decoded_length = 0;
 
-	if (cnx->cnx_state != picoquic_state_client_init_sent &&
-		cnx->cnx_state != picoquic_state_client_init_resent)
-	{
-		ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
-	}
-	else
-	{
-		/* Verify the checksum */
+    if (cnx->cnx_state != picoquic_state_client_init_sent && cnx->cnx_state != picoquic_state_client_init_resent) {
+        ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
+    } else {
+        /* Verify the checksum */
         decoded_length = picoquic_decrypt_cleartext(cnx, bytes, length, ph);
-		if (decoded_length == 0)
-		{
-			/* Incorrect checksum, drop and log. */
-			ret = PICOQUIC_ERROR_FNV1A_CHECK;
-		}
-		else
-		{
-			/* Verify that the header is a proper echo of what was sent */
-			if (ph->cnx_id != cnx->initial_cnxid ||
-				ph->vn != picoquic_supported_versions[cnx->version_index].version ||
-				(cnx->retransmit_newest == NULL || ph->pn64 > cnx->retransmit_newest->sequence_number) ||
-				(cnx->retransmit_oldest == NULL || ph->pn64 < cnx->retransmit_oldest->sequence_number))
-			{
-				/* Packet that do not match the "echo" checks should be logged and ignored */
-				ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
-			}
-		}
+        if (decoded_length == 0) {
+            /* Incorrect checksum, drop and log. */
+            ret = PICOQUIC_ERROR_FNV1A_CHECK;
+        } else {
+            /* Verify that the header is a proper echo of what was sent */
+            if (ph->cnx_id != cnx->initial_cnxid || ph->vn != picoquic_supported_versions[cnx->version_index].version || (cnx->retransmit_newest == NULL || ph->pn64 > cnx->retransmit_newest->sequence_number) || (cnx->retransmit_oldest == NULL || ph->pn64 < cnx->retransmit_oldest->sequence_number)) {
+                /* Packet that do not match the "echo" checks should be logged and ignored */
+                ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
+            }
+        }
 
-		if (ret == 0)
-		{
-			/* Accept the incoming frames */
-			ret = picoquic_decode_frames(cnx,
-				bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
-		}
+        if (ret == 0) {
+            /* Accept the incoming frames */
+            ret = picoquic_decode_frames(cnx,
+                bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
+        }
 
-		/* processing of the TLS message */
-		if (ret == 0)
-		{
-			/* set the state to HRR received, will trigger behavior when processing stream zero */
-			cnx->cnx_state = picoquic_state_client_hrr_received;
-			/* submit the embedded message (presumably HRR) to stream zero */
-			ret = picoquic_tlsinput_stream_zero(cnx);
-		}
-		if (ret == 0)
-		{
-			/* Mark the packet as not required for ack */
-			ret = PICOQUIC_ERROR_HRR;
-		}
-	}
+        /* processing of the TLS message */
+        if (ret == 0) {
+            /* set the state to HRR received, will trigger behavior when processing stream zero */
+            cnx->cnx_state = picoquic_state_client_hrr_received;
+            /* submit the embedded message (presumably HRR) to stream zero */
+            ret = picoquic_tlsinput_stream_zero(cnx);
+        }
+        if (ret == 0) {
+            /* Mark the packet as not required for ack */
+            ret = PICOQUIC_ERROR_HRR;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -714,74 +621,58 @@ int picoquic_incoming_server_stateless(
  */
 
 int picoquic_incoming_server_cleartext(
-    picoquic_cnx_t * cnx,
-    uint8_t * bytes,
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
     uint32_t length,
-    struct sockaddr * addr_to,
+    struct sockaddr* addr_to,
     unsigned long if_index_to,
-    picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
     int ret = 0;
     size_t decoded_length = 0;
 
-    if (cnx->cnx_state == picoquic_state_client_init_sent ||
-		cnx->cnx_state == picoquic_state_client_init_resent)
-    {
+    if (cnx->cnx_state == picoquic_state_client_init_sent || cnx->cnx_state == picoquic_state_client_init_resent) {
         cnx->cnx_state = picoquic_state_client_handshake_start;
     }
 
-    if (cnx->cnx_state == picoquic_state_client_handshake_start ||
-        cnx->cnx_state == picoquic_state_client_handshake_progress)
-    {
+    if (cnx->cnx_state == picoquic_state_client_handshake_start || cnx->cnx_state == picoquic_state_client_handshake_progress) {
         /* Verify the checksum */
         decoded_length = picoquic_decrypt_cleartext(cnx, bytes, length, ph);
-        if (decoded_length == 0)
-        {
+        if (decoded_length == 0) {
             /* Incorrect checksum, drop and log. */
-			ret = PICOQUIC_ERROR_FNV1A_CHECK;
-        }
-        else
-        {
-			/* Check the server cnx id */
-			if (cnx->server_cnxid == 0)
-			{
+            ret = PICOQUIC_ERROR_FNV1A_CHECK;
+        } else {
+            /* Check the server cnx id */
+            if (cnx->server_cnxid == 0) {
                 /* On first response from the server, copy the cnx ID and the incoming address */
-				cnx->server_cnxid = ph->cnx_id;
+                cnx->server_cnxid = ph->cnx_id;
                 cnx->dest_addr_len = (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
                 memcpy(&cnx->dest_addr, addr_to, cnx->dest_addr_len);
 
                 (void)picoquic_register_cnx_id(cnx->quic, cnx, cnx->server_cnxid);
-			}
-			else if (cnx->server_cnxid != ph->cnx_id)
-			{
-				ret = PICOQUIC_ERROR_CNXID_CHECK; /* protocol error */
-			}
+            } else if (cnx->server_cnxid != ph->cnx_id) {
+                ret = PICOQUIC_ERROR_CNXID_CHECK; /* protocol error */
+            }
 
-
-			if (ret == 0)
-			{
-				/* Accept the incoming frames */
-				ret = picoquic_decode_frames(cnx,
-					bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
-			}
+            if (ret == 0) {
+                /* Accept the incoming frames */
+                ret = picoquic_decode_frames(cnx,
+                    bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
+            }
 
             /* processing of client initial packet */
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 /* initialization of context & creation of data */
                 /* TODO: find path to send data produced by TLS. */
                 ret = picoquic_tlsinput_stream_zero(cnx);
             }
 
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 /* This is bad. should just delete the context, log the packet, etc */
             }
         }
-    }
-    else
-    {
+    } else {
         /* Not expected. Log and ignore. */
         ret = PICOQUIC_ERROR_SPURIOUS_REPEAT;
     }
@@ -793,51 +684,40 @@ int picoquic_incoming_server_cleartext(
  * Processing of client clear text packet.
  */
 int picoquic_incoming_client_cleartext(
-    picoquic_cnx_t * cnx,
-    uint8_t * bytes,
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
     uint32_t length,
-    picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
     int ret = 0;
     size_t decoded_length = 0;
 
-    if (cnx->cnx_state == picoquic_state_server_almost_ready ||
-        cnx->cnx_state == picoquic_state_server_ready)
-    {
+    if (cnx->cnx_state == picoquic_state_server_almost_ready || cnx->cnx_state == picoquic_state_server_ready) {
         /* Verify the checksum */
         decoded_length = picoquic_decrypt_cleartext(cnx, bytes, length, ph);
-        if (decoded_length == 0)
-        {
+        if (decoded_length == 0) {
             /* Incorrect checksum, drop and log. */
-			ret = PICOQUIC_ERROR_FNV1A_CHECK;
-        }
-		else if (ph->cnx_id != cnx->server_cnxid)
-		{
-			ret = PICOQUIC_ERROR_CNXID_CHECK;
-		}
-		else
-        {
+            ret = PICOQUIC_ERROR_FNV1A_CHECK;
+        } else if (ph->cnx_id != cnx->server_cnxid) {
+            ret = PICOQUIC_ERROR_CNXID_CHECK;
+        } else {
             /* Accept the incoming frames */
             ret = picoquic_decode_frames(cnx,
                 bytes + ph->offset, decoded_length - ph->offset, 1, current_time);
 
             /* processing of client clear text packet */
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 /* initialization of context & creation of data */
                 /* TODO: find path to send data produced by TLS. */
                 ret = picoquic_tlsinput_stream_zero(cnx);
             }
 
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 /* This is bad. should just delete the context, log the packet, etc */
             }
         }
-    }
-    else
-    {
+    } else {
         /* Not expected. Log and ignore. */
         ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
     }
@@ -849,13 +729,12 @@ int picoquic_incoming_client_cleartext(
 * Processing of stateless reset packet.
 */
 int picoquic_incoming_stateless_reset(
-    picoquic_cnx_t * cnx)
+    picoquic_cnx_t* cnx)
 {
     /* Stateless reset. The connection should be abandonned */
     cnx->cnx_state = picoquic_state_disconnected;
 
-    if (cnx->callback_fn)
-    {
+    if (cnx->callback_fn) {
         (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
     }
 
@@ -867,55 +746,41 @@ int picoquic_incoming_stateless_reset(
  */
 
 int picoquic_incoming_0rtt(
-    picoquic_cnx_t * cnx,
-    uint8_t * bytes,
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
     uint32_t length,
-    picoquic_packet_header * ph,
+    picoquic_packet_header* ph,
     uint64_t current_time)
 {
     int ret = 0;
     size_t decoded_length = 0;
 
-
-    if (ph->cnx_id != cnx->initial_cnxid)
-    {
+    if (ph->cnx_id != cnx->initial_cnxid) {
         ret = PICOQUIC_ERROR_CNXID_CHECK;
-    }
-    else if (cnx->cnx_state == picoquic_state_server_almost_ready ||
-            cnx->cnx_state == picoquic_state_server_ready)
-    {
+    } else if (cnx->cnx_state == picoquic_state_server_almost_ready || cnx->cnx_state == picoquic_state_server_ready) {
         /* AEAD Decrypt, in place */
         decoded_length = picoquic_aead_0rtt_decrypt(cnx, bytes + ph->offset,
             bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
 
-        if (decoded_length > (length - ph->offset))
-        {
+        if (decoded_length > (length - ph->offset)) {
             ret = PICOQUIC_ERROR_AEAD_CHECK;
-        }
-        else if (ph->vn != picoquic_supported_versions[cnx->version_index].version)
-        {
+        } else if (ph->vn != picoquic_supported_versions[cnx->version_index].version) {
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-        }
-        else
-        {
+        } else {
             /* Accept the incoming frames */
             ret = picoquic_decode_frames(cnx,
                 bytes + ph->offset, decoded_length, 0, current_time);
 
             /* Yell if there is data coming on stream zero */
-            if (ret == 0)
-            {
-                picoquic_stream_data * data = cnx->first_stream.stream_data;
+            if (ret == 0) {
+                picoquic_stream_data* data = cnx->first_stream.stream_data;
 
-                if (data != NULL && data->offset < cnx->first_stream.consumed_offset)
-                {
+                if (data != NULL && data->offset < cnx->first_stream.consumed_offset) {
                     ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
                 }
             }
         }
-    }
-    else
-    {
+    } else {
         /* Not expected. Log and ignore. */
         ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
     }
@@ -927,110 +792,78 @@ int picoquic_incoming_0rtt(
  * Processing of client encrypted packet.
  */
 int picoquic_incoming_encrypted(
-	picoquic_cnx_t * cnx,
-	uint8_t * bytes,
-	uint32_t length,
-	picoquic_packet_header * ph,
-	uint64_t current_time)
+    picoquic_cnx_t* cnx,
+    uint8_t* bytes,
+    uint32_t length,
+    picoquic_packet_header* ph,
+    uint64_t current_time)
 {
-	int ret = 0;
-	size_t decoded_length = 0;
+    int ret = 0;
+    size_t decoded_length = 0;
 
-
-	if (ph->cnx_id != cnx->server_cnxid &&
-		(ph->cnx_id != 0 ||
-			cnx->local_parameters.omit_connection_id == 0))
-	{
-		ret = PICOQUIC_ERROR_CNXID_CHECK;
-	}
-	else if (
-		cnx->cnx_state >= picoquic_state_client_almost_ready &&
-        cnx->cnx_state <= picoquic_state_closing)
-    {
+    if (ph->cnx_id != cnx->server_cnxid && (ph->cnx_id != 0 || cnx->local_parameters.omit_connection_id == 0)) {
+        ret = PICOQUIC_ERROR_CNXID_CHECK;
+    } else if (
+        cnx->cnx_state >= picoquic_state_client_almost_ready && cnx->cnx_state <= picoquic_state_closing) {
         /* TODO: supporting two variants for now. Will need to focus on just one. */
-		/* Check the possible reset before performaing in place AEAD decrypt */
-		int cmp_reset_secret = memcmp(bytes + 9, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
+        /* Check the possible reset before performaing in place AEAD decrypt */
+        int cmp_reset_secret = memcmp(bytes + 9, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
         /* Allow for test at the end as well. */
-        if (cmp_reset_secret != 0)
-        {
-            cmp_reset_secret = memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE, 
+        if (cmp_reset_secret != 0) {
+            cmp_reset_secret = memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE,
                 cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
         }
         /* AEAD Decrypt, in place */
         decoded_length = picoquic_aead_decrypt(cnx, bytes + ph->offset,
             bytes + ph->offset, length - ph->offset, ph->pn64, bytes, ph->offset);
 
-        if (decoded_length > (length - ph->offset))
-        {
+        if (decoded_length > (length - ph->offset)) {
             /* Bad packet should be ignored -- unless it is actually a server reset */
-            if (ph->vn == 0 && length >= (9 + PICOQUIC_RESET_SECRET_SIZE) &&
-                cmp_reset_secret == 0)
-            {
+            if (ph->vn == 0 && length >= (9 + PICOQUIC_RESET_SECRET_SIZE) && cmp_reset_secret == 0) {
                 ret = picoquic_incoming_stateless_reset(cnx);
-            }
-            else
-            {
+            } else {
                 ret = PICOQUIC_ERROR_AEAD_CHECK;
             }
-        }
-        else
-        {
+        } else {
             /* only look for closing frames in closing mode */
-            if (cnx->cnx_state == picoquic_state_closing)
-            {
+            if (cnx->cnx_state == picoquic_state_closing) {
                 int closing_received = 0;
 
                 ret = picoquic_decode_closing_frames(
                     bytes + ph->offset, decoded_length, &closing_received);
 
-                if (ret == 0)
-                {
-                    if (closing_received)
-                    {
-                        if (cnx->client_mode)
-                        {
+                if (ret == 0) {
+                    if (closing_received) {
+                        if (cnx->client_mode) {
                             cnx->cnx_state = picoquic_state_disconnected;
-                        }
-                        else
-                        {
+                        } else {
                             cnx->cnx_state = picoquic_state_draining;
                         }
-                    }
-                    else
-                    {
+                    } else {
                         cnx->ack_needed = 1;
                     }
                 }
-            }
-            else
-            /* all frames are ignored in draining mode, or after receiving a closing frame */
-            if (cnx->cnx_state == picoquic_state_draining ||
-                cnx->cnx_state == picoquic_state_closing_received)
-            {
+            } else
+                /* all frames are ignored in draining mode, or after receiving a closing frame */
+                if (cnx->cnx_state == picoquic_state_draining || cnx->cnx_state == picoquic_state_closing_received) {
             }
             /* VN = 0 indicates "long" header encoding, which is now banned.
              * The error is only generated if the packet can be properly
              * decrypted. */
-            else if (ph->vn != 0)
-            {
+            else if (ph->vn != 0) {
                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-            }
-            else
-            {
+            } else {
                 /* Accept the incoming frames */
                 ret = picoquic_decode_frames(cnx,
                     bytes + ph->offset, decoded_length, 0, current_time);
             }
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 /* Processing of TLS messages  */
                 ret = picoquic_tlsinput_stream_zero(cnx);
             }
         }
-    }
-    else
-    {
+    } else {
         /* Not expected. Log and ignore. */
         ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
     }
@@ -1043,88 +876,66 @@ int picoquic_incoming_encrypted(
 */
 
 int picoquic_incoming_packet(
-    picoquic_quic_t * quic,
-    uint8_t * bytes,
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
     uint32_t length,
-    struct sockaddr * addr_from,
-    struct sockaddr * addr_to,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
     int if_index_to,
     uint64_t current_time)
 {
     int ret = 0;
-    picoquic_cnx_t * cnx = NULL;
+    picoquic_cnx_t* cnx = NULL;
     picoquic_packet_header ph;
 
     /* Parse the clear text header. Ret == 0 means an incorrect packet that could not be parsed */
     ret = picoquic_parse_packet_header(quic, bytes, length, addr_from, &ph, &cnx);
 
-    if (ret == 0)
-    {
-        if (cnx == NULL)
-        {
-            if (ph.ptype == picoquic_packet_client_initial)
-            {
+    if (ret == 0) {
+        if (cnx == NULL) {
+            if (ph.ptype == picoquic_packet_client_initial) {
                 ph.pn64 = ph.pn;
                 cnx = picoquic_incoming_initial(quic, bytes, length, addr_from, addr_to, if_index_to, &ph, current_time);
-            }
-            else if (ph.version_index < 0 && ph.vn != 0)
-            {
+            } else if (ph.version_index < 0 && ph.vn != 0) {
                 /* use the result of parsing to consider version negotiation */
                 picoquic_prepare_version_negotiation(quic, addr_from, addr_to, if_index_to, &ph);
-            }
-            else
-            {
+            } else {
                 /* Unexpected packet. Reject, drop and log. */
-                if (ph.cnx_id != 0)
-                {
+                if (ph.cnx_id != 0) {
                     picoquic_process_unexpected_cnxid(quic, length, addr_from, addr_to, if_index_to, &ph);
                 }
                 ret = PICOQUIC_ERROR_DETECTED;
             }
-        }
-        else
-        {
+        } else {
             /* Build a packet number to 64 bits */
             ph.pn64 = picoquic_get_packet_number64(
                 cnx->first_sack_item.end_of_sack_range, ph.pnmask, ph.pn);
 
             /* verify that the packet is new */
-            if (picoquic_is_pn_already_received(cnx, ph.pn64) != 0)
-            {
+            if (picoquic_is_pn_already_received(cnx, ph.pn64) != 0) {
                 /* TODO: supporting two variants for now. Need to clean up later */
                 /* Check the possible reset which may be hiding under the duplicate */
-                if (ph.vn == 0 && (ph.ptype == picoquic_packet_1rtt_protected_phi0 ||
-                    ph.ptype == picoquic_packet_1rtt_protected_phi1) &&
-                    length >= (9 + PICOQUIC_RESET_SECRET_SIZE) &&
-                    ((memcmp(bytes + 9, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0) ||
-                    (memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE,
-                        cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0)))
-                {
+                if (ph.vn == 0 && (ph.ptype == picoquic_packet_1rtt_protected_phi0 || ph.ptype == picoquic_packet_1rtt_protected_phi1) && length >= (9 + PICOQUIC_RESET_SECRET_SIZE) && ((memcmp(bytes + 9, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0) || (memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE,
+                                                                                                                                                                                                                                                                         cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE)
+                                                                                                                                                                                                                                                                        == 0))) {
                     ret = picoquic_incoming_stateless_reset(cnx);
-                }
-                else
-                {
+                } else {
                     ret = PICOQUIC_ERROR_DUPLICATE;
                 }
             }
 
             /* Verify that the packet decrypts correctly */
-            if (ret == 0)
-            {
-                switch (ph.ptype)
-                {
+            if (ret == 0) {
+                switch (ph.ptype) {
                 case picoquic_packet_version_negotiation:
-                    if (cnx->cnx_state == picoquic_state_client_init_sent)
-                    {
+                    if (cnx->cnx_state == picoquic_state_client_init_sent) {
                         /* Verify the checksum */
                         /* Proceed with version negotiation*/
                         /* Process version negotiation */
                         /* Schedule repeat of initial message */
                         ret = picoquic_incoming_version_negotiation(
                             cnx, bytes, length, addr_from, &ph, current_time);
-                    }
-                    else
-                    {
+                    } else {
                         /* This is an unexpected packet. Log and drop.*/
                         ret = PICOQUIC_ERROR_DETECTED;
                     }
@@ -1166,32 +977,20 @@ int picoquic_incoming_packet(
         }
     }
 
-    if (ret == 0 || ret == PICOQUIC_ERROR_SPURIOUS_REPEAT)
-    {
-        if (cnx != NULL && ph.ptype != picoquic_packet_version_negotiation)
-        {
+    if (ret == 0 || ret == PICOQUIC_ERROR_SPURIOUS_REPEAT) {
+        if (cnx != NULL && ph.ptype != picoquic_packet_version_negotiation) {
             /* Mark the sequence number as received */
             ret = picoquic_record_pn_received(cnx, ph.pn64, current_time);
         }
-    }
-    else if (ret == PICOQUIC_ERROR_AEAD_CHECK ||
-        ret == PICOQUIC_ERROR_DUPLICATE ||
-        ret == PICOQUIC_ERROR_UNEXPECTED_PACKET ||
-        ret == PICOQUIC_ERROR_FNV1A_CHECK ||
-        ret == PICOQUIC_ERROR_CNXID_CHECK ||
-        ret == PICOQUIC_ERROR_HRR ||
-        ret == PICOQUIC_ERROR_DETECTED)
-    {
+    } else if (ret == PICOQUIC_ERROR_AEAD_CHECK || ret == PICOQUIC_ERROR_DUPLICATE || ret == PICOQUIC_ERROR_UNEXPECTED_PACKET || ret == PICOQUIC_ERROR_FNV1A_CHECK || ret == PICOQUIC_ERROR_CNXID_CHECK || ret == PICOQUIC_ERROR_HRR || ret == PICOQUIC_ERROR_DETECTED) {
         /* Bad packets are dropped silently, but duplicates should be acknowledged */
-        if (cnx != NULL && ret == PICOQUIC_ERROR_DUPLICATE)
-        {
+        if (cnx != NULL && ret == PICOQUIC_ERROR_DUPLICATE) {
             cnx->ack_needed = 1;
         }
         ret = 0;
     }
 
-    if (cnx != NULL)
-    {
+    if (cnx != NULL) {
         picoquic_cnx_set_next_wake_time(cnx, current_time);
     }
 

--- a/picoquic/picohash.c
+++ b/picoquic/picohash.c
@@ -22,28 +22,23 @@
 /*
  * Basic hash implementation, like we have seen tons off already.
  */
+#include "picohash.h"
 #include <stdlib.h>
 #include <string.h>
-#include "picohash.h"
 
-
-picohash_table * picohash_create(size_t nb_bin,
-    uint64_t(*picohash_hash) (void *),
-    int(*picohash_compare)(void *, void *))
+picohash_table* picohash_create(size_t nb_bin,
+    uint64_t (*picohash_hash)(void*),
+    int (*picohash_compare)(void*, void*))
 {
-    picohash_table * t = (picohash_table *)malloc(sizeof(picohash_table));
-    if (t != NULL)
-    {
-        t->hash_bin = (picohash_item **)malloc(sizeof(picohash_item *)*nb_bin);
+    picohash_table* t = (picohash_table*)malloc(sizeof(picohash_table));
+    if (t != NULL) {
+        t->hash_bin = (picohash_item**)malloc(sizeof(picohash_item*) * nb_bin);
 
-        if (t->hash_bin == NULL)
-        {
+        if (t->hash_bin == NULL) {
             free(t);
             t = NULL;
-        }
-        else
-        {
-            (void)memset(t->hash_bin, 0, sizeof(picohash_item *)*nb_bin);
+        } else {
+            (void)memset(t->hash_bin, 0, sizeof(picohash_item*) * nb_bin);
             t->nb_bin = nb_bin;
             t->count = 0;
             t->picohash_hash = picohash_hash;
@@ -54,20 +49,16 @@ picohash_table * picohash_create(size_t nb_bin,
     return t;
 }
 
-picohash_item * picohash_retrieve(picohash_table * hash_table, void * key)
+picohash_item* picohash_retrieve(picohash_table* hash_table, void* key)
 {
     uint64_t hash = hash_table->picohash_hash(key);
     uint32_t bin = hash % hash_table->nb_bin;
-    picohash_item * item = hash_table->hash_bin[bin];
+    picohash_item* item = hash_table->hash_bin[bin];
 
-    while (item != NULL)
-    {
-        if (hash_table->picohash_compare(key, item->key) == 0)
-        {
+    while (item != NULL) {
+        if (hash_table->picohash_compare(key, item->key) == 0) {
             break;
-        }
-        else
-        {
+        } else {
             item = item->next_in_bin;
         }
     }
@@ -75,65 +66,54 @@ picohash_item * picohash_retrieve(picohash_table * hash_table, void * key)
     return item;
 }
 
-int picohash_insert(picohash_table * hash_table, void* key)
+int picohash_insert(picohash_table* hash_table, void* key)
 {
     uint64_t hash = hash_table->picohash_hash(key);
     uint32_t bin = hash % hash_table->nb_bin;
     int ret = 0;
-    picohash_item * item = (picohash_item *)malloc(sizeof(picohash_item));
-    
-    if (item == NULL)
-    {
+    picohash_item* item = (picohash_item*)malloc(sizeof(picohash_item));
+
+    if (item == NULL) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         item->hash = hash;
         item->key = key;
         item->next_in_bin = hash_table->hash_bin[bin];
         hash_table->hash_bin[bin] = item;
         hash_table->count++;
     }
-    
+
     return ret;
 }
 
-void picohash_item_delete(picohash_table * hash_table, picohash_item * item, int delete_key_too)
+void picohash_item_delete(picohash_table* hash_table, picohash_item* item, int delete_key_too)
 {
     uint32_t bin = item->hash % hash_table->nb_bin;
-    picohash_item * previous = hash_table->hash_bin[bin];
-    
-    if (previous == item)
-    {
-        hash_table->hash_bin[bin] = item->next_in_bin;
-    }
-    else while (previous != NULL)
-    {
-        if (previous->next_in_bin == item)
-        {
-            previous->next_in_bin = item->next_in_bin;
-            break;
-        }
-        else
-        {
-            previous = previous->next_in_bin;
-        }
-    }
+    picohash_item* previous = hash_table->hash_bin[bin];
 
-    if (delete_key_too)
-    {
+    if (previous == item) {
+        hash_table->hash_bin[bin] = item->next_in_bin;
+    } else
+        while (previous != NULL) {
+            if (previous->next_in_bin == item) {
+                previous->next_in_bin = item->next_in_bin;
+                break;
+            } else {
+                previous = previous->next_in_bin;
+            }
+        }
+
+    if (delete_key_too) {
         free(item->key);
     }
 
     free(item);
 }
 
-void picohash_delete(picohash_table * hash_table, int delete_key_too)
+void picohash_delete(picohash_table* hash_table, int delete_key_too)
 {
-    for (uint32_t i = 0; i < hash_table->nb_bin; i++)
-    {
-        while (hash_table->hash_bin[i] != NULL)
-        {
+    for (uint32_t i = 0; i < hash_table->nb_bin; i++) {
+        while (hash_table->hash_bin[i] != NULL) {
             /* TODO: could be faster */
             picohash_item_delete(hash_table, hash_table->hash_bin[i], delete_key_too);
         }
@@ -143,13 +123,11 @@ void picohash_delete(picohash_table * hash_table, int delete_key_too)
     free(hash_table);
 }
 
-
-uint64_t picohash_bytes(uint8_t * key, uint32_t length)
+uint64_t picohash_bytes(uint8_t* key, uint32_t length)
 {
     uint64_t hash = 0xDEADBEEF;
 
-    for (uint32_t i = 0; i < length; i++)
-    {
+    for (uint32_t i = 0; i < length; i++) {
         hash ^= key[i];
         hash ^= ((hash << 31) ^ (hash >> 17));
     }

--- a/picoquic/picohash.h
+++ b/picoquic/picohash.h
@@ -26,48 +26,43 @@
  */
 #ifndef PICOHASH_H
 #define PICOHASH_H
+#include <stddef.h>
 #include <stdint.h>
 
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
+typedef struct _picohash_item {
+    uint64_t hash;
+    struct _picohash_item* next_in_bin;
+    void* key;
+} picohash_item;
 
-    typedef struct _picohash_item
-    {
-        uint64_t hash;
-        struct _picohash_item * next_in_bin;
-        void * key;
-    } picohash_item;
+typedef struct picohash_table {
+    /* TODO: lock ! */
+    picohash_item** hash_bin;
+    size_t nb_bin;
+    size_t count;
+    uint64_t (*picohash_hash)(void*);
+    int (*picohash_compare)(void*, void*);
+} picohash_table;
 
+picohash_table* picohash_create(size_t nb_bin,
+    uint64_t (*picohash_hash)(void*),
+    int (*picohash_compute)(void*, void*));
 
-    typedef struct picohash_table
-    {
-        /* TODO: lock ! */
-        picohash_item ** hash_bin;
-        size_t nb_bin;
-        size_t count;
-        uint64_t(*picohash_hash) (void *);
-        int(*picohash_compare)(void *, void *);
-    } picohash_table;
+picohash_item* picohash_retrieve(picohash_table* hash_table, void* key);
 
-    picohash_table * picohash_create(size_t nb_bin,
-        uint64_t(*picohash_hash) (void *),
-        int(*picohash_compute)(void *, void *));
+int picohash_insert(picohash_table* hash_table, void* key);
 
-    picohash_item * picohash_retrieve(picohash_table * hash_table, void * key);
+void picohash_item_delete(picohash_table* hash_table, picohash_item* item, int delete_key_too);
 
-    int picohash_insert(picohash_table * hash_table, void* key);
+void picohash_delete(picohash_table* hash_table, int delete_key_too);
 
-    void picohash_item_delete(picohash_table * hash_table, picohash_item * item, int delete_key_too);
+uint64_t picohash_bytes(uint8_t* key, uint32_t length);
 
-    void picohash_delete(picohash_table * hash_table, int delete_key_too);
-
-    uint64_t picohash_bytes(uint8_t * key, uint32_t length);
-
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -24,50 +24,50 @@
 
 #include <stdint.h>
 #ifdef _WINDOWS
-#include <winsock2.h>
-#include <Ws2def.h>
 #include <WS2tcpip.h>
+#include <Ws2def.h>
+#include <winsock2.h>
 #else
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
 #endif
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 #define PICOQUIC_ERROR_CLASS 0x400
-#define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS  + 1)
-#define PICOQUIC_ERROR_FNV1A_CHECK (PICOQUIC_ERROR_CLASS  + 2)
-#define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS  + 3)
-#define PICOQUIC_ERROR_UNEXPECTED_PACKET (PICOQUIC_ERROR_CLASS  + 4)
-#define PICOQUIC_ERROR_MEMORY (PICOQUIC_ERROR_CLASS  + 5)
-#define PICOQUIC_ERROR_SPURIOUS_REPEAT (PICOQUIC_ERROR_CLASS  + 6)
-#define PICOQUIC_ERROR_CNXID_CHECK (PICOQUIC_ERROR_CLASS  + 7)
-#define PICOQUIC_ERROR_INITIAL_TOO_SHORT (PICOQUIC_ERROR_CLASS  + 8)
-#define PICOQUIC_ERROR_VERSION_NEGOTIATION_SPOOFED (PICOQUIC_ERROR_CLASS  + 9)
-#define PICOQUIC_ERROR_MALFORMED_TRANSPORT_EXTENSION (PICOQUIC_ERROR_CLASS  + 10)
-#define PICOQUIC_ERROR_EXTENSION_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS  + 11)
-#define PICOQUIC_ERROR_ILLEGAL_TRANSPORT_EXTENSION (PICOQUIC_ERROR_CLASS  + 12)
-#define PICOQUIC_ERROR_CANNOT_RESET_STREAM_ZERO (PICOQUIC_ERROR_CLASS  + 13)
-#define PICOQUIC_ERROR_INVALID_STREAM_ID (PICOQUIC_ERROR_CLASS  + 14)
-#define PICOQUIC_ERROR_STREAM_ALREADY_CLOSED (PICOQUIC_ERROR_CLASS  + 15)
-#define PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS  + 16)
-#define PICOQUIC_ERROR_INVALID_FRAME (PICOQUIC_ERROR_CLASS  + 17)
-#define PICOQUIC_ERROR_CANNOT_CONTROL_STREAM_ZERO (PICOQUIC_ERROR_CLASS  + 18)
-#define PICOQUIC_ERROR_HRR (PICOQUIC_ERROR_CLASS  + 19)
-#define PICOQUIC_ERROR_DISCONNECTED (PICOQUIC_ERROR_CLASS  + 20)
-#define PICOQUIC_ERROR_DETECTED (PICOQUIC_ERROR_CLASS  + 21)
-#define PICOQUIC_ERROR_CANNOT_STOP_STREAM_ZERO (PICOQUIC_ERROR_CLASS  + 22)
-#define PICOQUIC_ERROR_INVALID_TICKET (PICOQUIC_ERROR_CLASS  + 23)
-#define PICOQUIC_ERROR_INVALID_FILE (PICOQUIC_ERROR_CLASS  + 24)
-#define PICOQUIC_ERROR_SEND_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS  + 25)
-#define PICOQUIC_ERROR_UNEXPECTED_STATE (PICOQUIC_ERROR_CLASS  + 26)
-#define PICOQUIC_ERROR_UNEXPECTED_ERROR (PICOQUIC_ERROR_CLASS  + 27)
-#define PICOQUIC_ERROR_TLS_SERVER_CON_WITHOUT_CERT (PICOQUIC_ERROR_CLASS  + 28)
+#define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
+#define PICOQUIC_ERROR_FNV1A_CHECK (PICOQUIC_ERROR_CLASS + 2)
+#define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
+#define PICOQUIC_ERROR_UNEXPECTED_PACKET (PICOQUIC_ERROR_CLASS + 4)
+#define PICOQUIC_ERROR_MEMORY (PICOQUIC_ERROR_CLASS + 5)
+#define PICOQUIC_ERROR_SPURIOUS_REPEAT (PICOQUIC_ERROR_CLASS + 6)
+#define PICOQUIC_ERROR_CNXID_CHECK (PICOQUIC_ERROR_CLASS + 7)
+#define PICOQUIC_ERROR_INITIAL_TOO_SHORT (PICOQUIC_ERROR_CLASS + 8)
+#define PICOQUIC_ERROR_VERSION_NEGOTIATION_SPOOFED (PICOQUIC_ERROR_CLASS + 9)
+#define PICOQUIC_ERROR_MALFORMED_TRANSPORT_EXTENSION (PICOQUIC_ERROR_CLASS + 10)
+#define PICOQUIC_ERROR_EXTENSION_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS + 11)
+#define PICOQUIC_ERROR_ILLEGAL_TRANSPORT_EXTENSION (PICOQUIC_ERROR_CLASS + 12)
+#define PICOQUIC_ERROR_CANNOT_RESET_STREAM_ZERO (PICOQUIC_ERROR_CLASS + 13)
+#define PICOQUIC_ERROR_INVALID_STREAM_ID (PICOQUIC_ERROR_CLASS + 14)
+#define PICOQUIC_ERROR_STREAM_ALREADY_CLOSED (PICOQUIC_ERROR_CLASS + 15)
+#define PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS + 16)
+#define PICOQUIC_ERROR_INVALID_FRAME (PICOQUIC_ERROR_CLASS + 17)
+#define PICOQUIC_ERROR_CANNOT_CONTROL_STREAM_ZERO (PICOQUIC_ERROR_CLASS + 18)
+#define PICOQUIC_ERROR_HRR (PICOQUIC_ERROR_CLASS + 19)
+#define PICOQUIC_ERROR_DISCONNECTED (PICOQUIC_ERROR_CLASS + 20)
+#define PICOQUIC_ERROR_DETECTED (PICOQUIC_ERROR_CLASS + 21)
+#define PICOQUIC_ERROR_CANNOT_STOP_STREAM_ZERO (PICOQUIC_ERROR_CLASS + 22)
+#define PICOQUIC_ERROR_INVALID_TICKET (PICOQUIC_ERROR_CLASS + 23)
+#define PICOQUIC_ERROR_INVALID_FILE (PICOQUIC_ERROR_CLASS + 24)
+#define PICOQUIC_ERROR_SEND_BUFFER_TOO_SMALL (PICOQUIC_ERROR_CLASS + 25)
+#define PICOQUIC_ERROR_UNEXPECTED_STATE (PICOQUIC_ERROR_CLASS + 26)
+#define PICOQUIC_ERROR_UNEXPECTED_ERROR (PICOQUIC_ERROR_CLASS + 27)
+#define PICOQUIC_ERROR_TLS_SERVER_CON_WITHOUT_CERT (PICOQUIC_ERROR_CLASS + 28)
 
 /*
  * Protocol errors defined in the QUIC spec
@@ -82,218 +82,216 @@ extern "C" {
 #define PICOQUIC_TRANSPORT_VERSION_NEGOTIATION_ERROR (0x9)
 #define PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION (0xA)
 #define PICOQUIC_TRANSPORT_UNSOLICITED_PONG (0xB)
-#define PICOQUIC_TRANSPORT_FRAME_ERROR(FrameType) (0x100|((int)FrameType)) 
+#define PICOQUIC_TRANSPORT_FRAME_ERROR(FrameType) (0x100 | ((int)FrameType))
 
 #define PICOQUIC_MAX_PACKET_SIZE 1536
 #define PICOQUIC_RESET_SECRET_SIZE 16
 
-	/*
+/*
 	 * Connection states, useful to expose the state to the application.
 	 */
-    typedef enum
-    {
-        picoquic_state_client_init,
-        picoquic_state_client_init_sent,
-        picoquic_state_client_renegotiate,
-        picoquic_state_client_hrr_received,
-        picoquic_state_client_init_resent,
-        picoquic_state_server_init,
-        picoquic_state_client_handshake_start,
-        picoquic_state_client_handshake_progress,
-        picoquic_state_client_almost_ready,
-        picoquic_state_handshake_failure,
-        picoquic_state_client_ready,
-        picoquic_state_server_almost_ready,
-        picoquic_state_server_ready,
-        picoquic_state_disconnecting,
-        picoquic_state_closing_received,
-        picoquic_state_closing,
-        picoquic_state_draining,
-        picoquic_state_disconnected,
-        picoquic_state_server_send_hrr
-	} picoquic_state_enum;
+typedef enum {
+    picoquic_state_client_init,
+    picoquic_state_client_init_sent,
+    picoquic_state_client_renegotiate,
+    picoquic_state_client_hrr_received,
+    picoquic_state_client_init_resent,
+    picoquic_state_server_init,
+    picoquic_state_client_handshake_start,
+    picoquic_state_client_handshake_progress,
+    picoquic_state_client_almost_ready,
+    picoquic_state_handshake_failure,
+    picoquic_state_client_ready,
+    picoquic_state_server_almost_ready,
+    picoquic_state_server_ready,
+    picoquic_state_disconnecting,
+    picoquic_state_closing_received,
+    picoquic_state_closing,
+    picoquic_state_draining,
+    picoquic_state_disconnected,
+    picoquic_state_server_send_hrr
+} picoquic_state_enum;
 
-	/*
+/*
 	 * The stateless packet structure is used to temporarily store
 	 * stateless packets before they can be sent by servers.
 	 */
 
-	typedef struct st_picoquic_stateless_packet_t {
-            struct st_picoquic_stateless_packet_t * next_packet;
-            struct sockaddr_storage addr_to;
-            struct sockaddr_storage addr_local;
-            unsigned long if_index_local;
-            size_t length;
+typedef struct st_picoquic_stateless_packet_t {
+    struct st_picoquic_stateless_packet_t* next_packet;
+    struct sockaddr_storage addr_to;
+    struct sockaddr_storage addr_local;
+    unsigned long if_index_local;
+    size_t length;
 
-            uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
-	} picoquic_stateless_packet_t;
+    uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
+} picoquic_stateless_packet_t;
 
-	/*
+/*
 	 * The simple packet structure is used to store packets that
 	 * have been sent but are not yet acknowledged.
 	 * Packets are stored in unencrypted format.
 	 * The checksum length is the difference between encrypted and unencrypted.
 	 */
-	typedef struct _picoquic_packet {
-		struct _picoquic_packet * previous_packet;
-		struct _picoquic_packet * next_packet;
+typedef struct _picoquic_packet {
+    struct _picoquic_packet* previous_packet;
+    struct _picoquic_packet* next_packet;
 
-		uint64_t sequence_number;
-		uint64_t send_time;
-		size_t length;
-		size_t checksum_overhead;
+    uint64_t sequence_number;
+    uint64_t send_time;
+    size_t length;
+    size_t checksum_overhead;
 
-		uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
-	} picoquic_packet;
+    uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
+} picoquic_packet;
 
-	typedef struct st_picoquic_quic_t picoquic_quic_t;
-	typedef struct st_picoquic_cnx_t picoquic_cnx_t;
+typedef struct st_picoquic_quic_t picoquic_quic_t;
+typedef struct st_picoquic_cnx_t picoquic_cnx_t;
 
-	typedef enum {
-		picoquic_callback_no_event = 0,
-		picoquic_callback_stream_fin,
-		picoquic_callback_stream_reset,
-        picoquic_callback_stop_sending,
-        picoquic_callback_close,
-        picoquic_callback_application_close
-	} picoquic_call_back_event_t;
+typedef enum {
+    picoquic_callback_no_event = 0,
+    picoquic_callback_stream_fin,
+    picoquic_callback_stream_reset,
+    picoquic_callback_stop_sending,
+    picoquic_callback_close,
+    picoquic_callback_application_close
+} picoquic_call_back_event_t;
 
-	/* Callback function for providing stream data to the application.
+/* Callback function for providing stream data to the application.
      * If stream_id is zero, this delivers misc frames or changes in
      * connection state.
      */
-	typedef void(*picoquic_stream_data_cb_fn) (picoquic_cnx_t * cnx,
-		uint64_t stream_id, uint8_t * bytes, size_t length, 
-		picoquic_call_back_event_t fin_or_event, void * callback_ctx);
+typedef void (*picoquic_stream_data_cb_fn)(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
 
-	typedef uint64_t (*cnx_id_cb_fn)(uint64_t cnx_id_local,
-			uint64_t cnx_id_remote, void *cnx_id_cb_data);
+typedef uint64_t (*cnx_id_cb_fn)(uint64_t cnx_id_local,
+    uint64_t cnx_id_remote, void* cnx_id_cb_data);
 
-	/* QUIC context create and dispose */
-	picoquic_quic_t * picoquic_create(uint32_t nb_connections,
-		char const * cert_file_name, char const * key_file_name,
-		char const * default_alpn,
-		picoquic_stream_data_cb_fn default_callback_fn,
-		void * default_callback_ctx,
-		cnx_id_cb_fn cnx_id_callback,
-		void * cnx_id_callback_data,
-		uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
-        uint64_t current_time,
-        uint64_t * p_simulated_time,
-        char const * ticket_file_name,
-        const uint8_t * ticket_encryption_key,
-        size_t ticket_encryption_key_length);
+/* QUIC context create and dispose */
+picoquic_quic_t* picoquic_create(uint32_t nb_connections,
+    char const* cert_file_name, char const* key_file_name,
+    char const* default_alpn,
+    picoquic_stream_data_cb_fn default_callback_fn,
+    void* default_callback_ctx,
+    cnx_id_cb_fn cnx_id_callback,
+    void* cnx_id_callback_data,
+    uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
+    uint64_t current_time,
+    uint64_t* p_simulated_time,
+    char const* ticket_file_name,
+    const uint8_t* ticket_encryption_key,
+    size_t ticket_encryption_key_length);
 
-	void picoquic_free(picoquic_quic_t * quic);
+void picoquic_free(picoquic_quic_t* quic);
 
-    /* Set cookie mode on QUIC context when under stress */
-    void picoquic_set_cookie_mode(picoquic_quic_t * quic, int cookie_mode);
+/* Set cookie mode on QUIC context when under stress */
+void picoquic_set_cookie_mode(picoquic_quic_t* quic, int cookie_mode);
 
-	/* Connection context creation and registration */
-	picoquic_cnx_t * picoquic_create_cnx(picoquic_quic_t * quic,
-		uint64_t cnx_id, struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-		char const * sni, char const * alpn, char client_mode);
+/* Connection context creation and registration */
+picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
+    uint64_t cnx_id, struct sockaddr* addr, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn, char client_mode);
 
-	picoquic_cnx_t * picoquic_create_client_cnx(picoquic_quic_t * quic,
-		struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-		char const * sni, char const * alpn,
-		picoquic_stream_data_cb_fn callback_fn, void * callback_ctx);
+picoquic_cnx_t* picoquic_create_client_cnx(picoquic_quic_t* quic,
+    struct sockaddr* addr, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn,
+    picoquic_stream_data_cb_fn callback_fn, void* callback_ctx);
 
-	void picoquic_delete_cnx(picoquic_cnx_t * cnx);
+void picoquic_delete_cnx(picoquic_cnx_t* cnx);
 
-	int picoquic_close(picoquic_cnx_t * cnx, uint16_t reason_code);
+int picoquic_close(picoquic_cnx_t* cnx, uint16_t reason_code);
 
-	picoquic_cnx_t * picoquic_get_first_cnx(picoquic_quic_t * quic);
-    picoquic_cnx_t * picoquic_get_next_cnx(picoquic_cnx_t * cnx);
-    int64_t picoquic_get_next_wake_delay(picoquic_quic_t * quic, 
-        uint64_t current_time,
-        int64_t delay_max);
+picoquic_cnx_t* picoquic_get_first_cnx(picoquic_quic_t* quic);
+picoquic_cnx_t* picoquic_get_next_cnx(picoquic_cnx_t* cnx);
+int64_t picoquic_get_next_wake_delay(picoquic_quic_t* quic,
+    uint64_t current_time,
+    int64_t delay_max);
 
-	picoquic_state_enum picoquic_get_cnx_state(picoquic_cnx_t * cnx);
+picoquic_state_enum picoquic_get_cnx_state(picoquic_cnx_t* cnx);
 
-    int picoquic_tls_is_psk_handshake(picoquic_cnx_t * cnx);
+int picoquic_tls_is_psk_handshake(picoquic_cnx_t* cnx);
 
-    void picoquic_get_peer_addr(picoquic_cnx_t * cnx, struct sockaddr ** addr, int * addr_len);
-    void picoquic_get_local_addr(picoquic_cnx_t * cnx, struct sockaddr ** addr, int * addr_len);
-    unsigned long picoquic_get_local_if_index(picoquic_cnx_t * cnx);
+void picoquic_get_peer_addr(picoquic_cnx_t* cnx, struct sockaddr** addr, int* addr_len);
+void picoquic_get_local_addr(picoquic_cnx_t* cnx, struct sockaddr** addr, int* addr_len);
+unsigned long picoquic_get_local_if_index(picoquic_cnx_t* cnx);
 
-    uint64_t picoquic_get_cnxid(picoquic_cnx_t * cnx);
-    uint64_t picoquic_get_initial_cnxid(picoquic_cnx_t * cnx);
-    uint64_t picoquic_get_cnx_start_time(picoquic_cnx_t * cnx);
-    uint64_t picoquic_is_0rtt_available(picoquic_cnx_t * cnx);
+uint64_t picoquic_get_cnxid(picoquic_cnx_t* cnx);
+uint64_t picoquic_get_initial_cnxid(picoquic_cnx_t* cnx);
+uint64_t picoquic_get_cnx_start_time(picoquic_cnx_t* cnx);
+uint64_t picoquic_is_0rtt_available(picoquic_cnx_t* cnx);
 
-    int picoquic_is_cnx_backlog_empty(picoquic_cnx_t * cnx);
+int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx);
 
-    void picoquic_set_callback(picoquic_cnx_t * cnx,
-        picoquic_stream_data_cb_fn callback_fn, void * callback_ctx);
+void picoquic_set_callback(picoquic_cnx_t* cnx,
+    picoquic_stream_data_cb_fn callback_fn, void* callback_ctx);
 
-    /* Send extra frames */
-    int picoquic_queue_misc_frame(picoquic_cnx_t * cnx, const uint8_t * bytes, size_t length);
+/* Send extra frames */
+int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length);
 
-	/* Send and receive network packets */
+/* Send and receive network packets */
 
-	picoquic_stateless_packet_t * picoquic_dequeue_stateless_packet(picoquic_quic_t * quic);
-	void picoquic_delete_stateless_packet(picoquic_stateless_packet_t * sp);
+picoquic_stateless_packet_t* picoquic_dequeue_stateless_packet(picoquic_quic_t* quic);
+void picoquic_delete_stateless_packet(picoquic_stateless_packet_t* sp);
 
-	int picoquic_incoming_packet(
-		picoquic_quic_t * quic,
-		uint8_t * bytes,
-		uint32_t length,
-		struct sockaddr * addr_from,
-        struct sockaddr * addr_to,
-        int if_index_to,
-		uint64_t current_time);
+int picoquic_incoming_packet(
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
+    uint32_t length,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
+    int if_index_to,
+    uint64_t current_time);
 
-	picoquic_packet * picoquic_create_packet();
+picoquic_packet* picoquic_create_packet();
 
-	int picoquic_prepare_packet(picoquic_cnx_t * cnx, picoquic_packet * packet,
-		uint64_t current_time, uint8_t * send_buffer, size_t send_buffer_max, size_t * send_length);
+int picoquic_prepare_packet(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length);
 
-	/* send and receive data on streams */
-	int picoquic_add_to_stream(picoquic_cnx_t * cnx,
-		uint64_t stream_id, const uint8_t * data, size_t length, int set_fin);
+/* send and receive data on streams */
+int picoquic_add_to_stream(picoquic_cnx_t* cnx,
+    uint64_t stream_id, const uint8_t* data, size_t length, int set_fin);
 
-	int picoquic_reset_stream(picoquic_cnx_t * cnx,
-		uint64_t stream_id, uint16_t local_stream_error);
+int picoquic_reset_stream(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint16_t local_stream_error);
 
-    int picoquic_stop_sending(picoquic_cnx_t * cnx,
-        uint64_t stream_id, uint16_t local_stream_error);
+int picoquic_stop_sending(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint16_t local_stream_error);
 
+/* Congestion algorithm definition */
+typedef enum {
+    picoquic_congestion_notification_acknowledgement,
+    picoquic_congestion_notification_repeat,
+    picoquic_congestion_notification_timeout,
+    picoquic_congestion_notification_spurious_repeat,
+    picoquic_congestion_notification_rtt_measurement
+} picoquic_congestion_notification_t;
 
-	/* Congestion algorithm definition */
-	typedef enum {
-		picoquic_congestion_notification_acknowledgement,
-		picoquic_congestion_notification_repeat,
-		picoquic_congestion_notification_timeout,
-		picoquic_congestion_notification_spurious_repeat,
-		picoquic_congestion_notification_rtt_measurement
-	} picoquic_congestion_notification_t;
+typedef void (*picoquic_congestion_algorithm_init)(picoquic_cnx_t* cnx);
+typedef void (*picoquic_congestion_algorithm_notify)(picoquic_cnx_t* cnx,
+    picoquic_congestion_notification_t notification,
+    uint64_t rtt_measurement,
+    uint64_t nb_bytes_acknowledged,
+    uint64_t lost_packet_number,
+    uint64_t current_time);
+typedef void (*picoquic_congestion_algorithm_delete)(picoquic_cnx_t* cnx);
 
-	typedef void(*picoquic_congestion_algorithm_init) (picoquic_cnx_t * cnx);
-	typedef void(*picoquic_congestion_algorithm_notify)(picoquic_cnx_t * cnx,
-		picoquic_congestion_notification_t notification,
-		uint64_t rtt_measurement,
-		uint64_t nb_bytes_acknowledged,
-		uint64_t lost_packet_number,
-		uint64_t current_time);
-	typedef void(*picoquic_congestion_algorithm_delete) (picoquic_cnx_t * cnx);
+typedef struct st_picoquic_congestion_algorithm_t {
+    uint32_t congestion_algorithm_id;
+    picoquic_congestion_algorithm_init alg_init;
+    picoquic_congestion_algorithm_notify alg_notify;
+    picoquic_congestion_algorithm_delete alg_delete;
+} picoquic_congestion_algorithm_t;
 
-	typedef struct st_picoquic_congestion_algorithm_t {
-		uint32_t congestion_algorithm_id;
-		picoquic_congestion_algorithm_init alg_init;
-		picoquic_congestion_algorithm_notify alg_notify;
-		picoquic_congestion_algorithm_delete alg_delete;
-	} picoquic_congestion_algorithm_t;
+void picoquic_set_default_congestion_algorithm(picoquic_quic_t* quic, picoquic_congestion_algorithm_t const* algo);
 
-	void picoquic_set_default_congestion_algorithm(picoquic_quic_t * quic, picoquic_congestion_algorithm_t const * algo);
+void picoquic_set_congestion_algorithm(picoquic_cnx_t* cnx, picoquic_congestion_algorithm_t const* algo);
 
-	void picoquic_set_congestion_algorithm(picoquic_cnx_t * cnx, picoquic_congestion_algorithm_t const * algo);
+/* For building a basic HTTP 0.9 test server */
+int http0dot9_get(uint8_t* command, size_t command_length,
+    uint8_t* response, size_t response_max, size_t* response_length);
 
-    /* For building a basic HTTP 0.9 test server */
-    int http0dot9_get(uint8_t * command, size_t command_length,
-        uint8_t * response, size_t response_max, size_t *response_length);
-
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -22,12 +22,12 @@
 #ifndef PICOQUIC_INTERNAL_H
 #define PICOQUIC_INTERNAL_H
 
-#include "picoquic.h"
 #include "picohash.h"
+#include "picoquic.h"
 #include "picotlsapi.h"
 #include "util.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -48,242 +48,237 @@ extern "C" {
 #define PICOQUIC_MICROSEC_SILENCE_MAX 120000000 /* 120 seconds for now */
 #define PICOQUIC_MICROSEC_WAIT_MAX 10000000 /* 10 seconds for now */
 
-#define PICOQUIC_CWIN_INITIAL  (10*PICOQUIC_MAX_PACKET_SIZE)
-#define PICOQUIC_CWIN_MINIMUM  (2*PICOQUIC_MAX_PACKET_SIZE)
+#define PICOQUIC_CWIN_INITIAL (10 * PICOQUIC_MAX_PACKET_SIZE)
+#define PICOQUIC_CWIN_MINIMUM (2 * PICOQUIC_MAX_PACKET_SIZE)
 
 #define PICOQUIC_ERRONEOUS_SNI "erroneous-sni"
 
-
-    /*
+/*
      * Nominal packet types. These are the packet types used internally by the
      * implementation. The wire encoding depends on the version.
      */
-    typedef enum
-    {
-        picoquic_packet_error = 0,
-        picoquic_packet_version_negotiation = 1,
-        picoquic_packet_client_initial = 2,
-        picoquic_packet_server_stateless = 3,
-        picoquic_packet_server_cleartext = 4,
-        picoquic_packet_client_cleartext = 5,
-        picoquic_packet_0rtt_protected = 6,
-        picoquic_packet_1rtt_protected_phi0 = 7,
-        picoquic_packet_1rtt_protected_phi1 = 8,
-        picoquic_packet_type_max = 9
-    } picoquic_packet_type_enum;
+typedef enum {
+    picoquic_packet_error = 0,
+    picoquic_packet_version_negotiation = 1,
+    picoquic_packet_client_initial = 2,
+    picoquic_packet_server_stateless = 3,
+    picoquic_packet_server_cleartext = 4,
+    picoquic_packet_client_cleartext = 5,
+    picoquic_packet_0rtt_protected = 6,
+    picoquic_packet_1rtt_protected_phi0 = 7,
+    picoquic_packet_1rtt_protected_phi1 = 8,
+    picoquic_packet_type_max = 9
+} picoquic_packet_type_enum;
 
-    /*
+/*
      * Types of frames
      */
-    typedef enum {
-        picoquic_frame_type_padding = 0,
-        picoquic_frame_type_reset_stream = 1,
-        picoquic_frame_type_connection_close = 2,
-        picoquic_frame_type_application_close = 3,
-        picoquic_frame_type_max_data = 4,
-        picoquic_frame_type_max_stream_data = 5,
-        picoquic_frame_type_max_stream_id = 6,
-        picoquic_frame_type_ping = 7,
-        picoquic_frame_type_blocked = 8,
-        picoquic_frame_type_stream_blocked = 9,
-        picoquic_frame_type_stream_id_needed = 0x0a,
-        picoquic_frame_type_new_connection_id = 0x0b,
-        picoquic_frame_type_stop_sending = 0x0c,
-        picoquic_frame_type_pong = 0x0d,
-        picoquic_frame_type_ack = 0x0e,
-        picoquic_frame_type_stream_range_min = 0x10,
-        picoquic_frame_type_stream_range_max = 0x1F,
-        picoquic_frame_type_ack_range_min_old = 0xa0,
-        picoquic_frame_type_ack_range_max_old = 0xbf,
-        picoquic_frame_type_stream_range_min_old = 0xc0,
-        picoquic_frame_type_stream_range_max_old = 0xcf
-    } picoquic_frame_type_enum_t;
+typedef enum {
+    picoquic_frame_type_padding = 0,
+    picoquic_frame_type_reset_stream = 1,
+    picoquic_frame_type_connection_close = 2,
+    picoquic_frame_type_application_close = 3,
+    picoquic_frame_type_max_data = 4,
+    picoquic_frame_type_max_stream_data = 5,
+    picoquic_frame_type_max_stream_id = 6,
+    picoquic_frame_type_ping = 7,
+    picoquic_frame_type_blocked = 8,
+    picoquic_frame_type_stream_blocked = 9,
+    picoquic_frame_type_stream_id_needed = 0x0a,
+    picoquic_frame_type_new_connection_id = 0x0b,
+    picoquic_frame_type_stop_sending = 0x0c,
+    picoquic_frame_type_pong = 0x0d,
+    picoquic_frame_type_ack = 0x0e,
+    picoquic_frame_type_stream_range_min = 0x10,
+    picoquic_frame_type_stream_range_max = 0x1F,
+    picoquic_frame_type_ack_range_min_old = 0xa0,
+    picoquic_frame_type_ack_range_max_old = 0xbf,
+    picoquic_frame_type_stream_range_min_old = 0xc0,
+    picoquic_frame_type_stream_range_max_old = 0xcf
+} picoquic_frame_type_enum_t;
 
-	/*
+/*
 	* Supported versions
 	*/
-#define PICOQUIC_FIRST_INTEROP_VERSION   0xFF000005
-#define PICOQUIC_SECOND_INTEROP_VERSION  0xFF000007
-#define PICOQUIC_THIRD_INTEROP_VERSION  0xFF000008
-#define PICOQUIC_INTERNAL_TEST_VERSION_1 0x50435130 
+#define PICOQUIC_FIRST_INTEROP_VERSION 0xFF000005
+#define PICOQUIC_SECOND_INTEROP_VERSION 0xFF000007
+#define PICOQUIC_THIRD_INTEROP_VERSION 0xFF000008
+#define PICOQUIC_INTERNAL_TEST_VERSION_1 0x50435130
 
-    /* 
+/* 
      * Flags used to describe the capbilities of different
      * versions.
      */
 
-    typedef enum {
-        picoquic_version_no_flag = 0
-    } picoquic_version_feature_flags;
+typedef enum {
+    picoquic_version_no_flag = 0
+} picoquic_version_feature_flags;
 
-    /*
+/*
      * Codes used for representing the various types of packet encodings
      */
-    typedef enum {
-        picoquic_version_header_08 
-    } picoquic_version_header_encoding;
+typedef enum {
+    picoquic_version_header_08
+} picoquic_version_header_encoding;
 
-    typedef struct st_picoquic_version_parameters_t {
-        uint32_t version;
-        uint32_t version_flags;
-        picoquic_version_header_encoding version_header_encoding;
-        size_t version_aead_key_length;
-        uint8_t * version_aead_key;
-    } picoquic_version_parameters_t;
+typedef struct st_picoquic_version_parameters_t {
+    uint32_t version;
+    uint32_t version_flags;
+    picoquic_version_header_encoding version_header_encoding;
+    size_t version_aead_key_length;
+    uint8_t* version_aead_key;
+} picoquic_version_parameters_t;
 
-    extern const picoquic_version_parameters_t picoquic_supported_versions[];
-	extern const size_t picoquic_nb_supported_versions;
-    int picoquic_get_version_index(uint32_t proposed_version);
+extern const picoquic_version_parameters_t picoquic_supported_versions[];
+extern const size_t picoquic_nb_supported_versions;
+int picoquic_get_version_index(uint32_t proposed_version);
 
-
-    /*
+/*
      * Definition of the session ticket store that can be associated with a 
      * client context.
      */
-    typedef struct st_picoquic_stored_ticket_t {
-        struct st_picoquic_stored_ticket_t * next_ticket;
-        char * sni;
-        char * alpn;
-        uint8_t * ticket;
-        uint64_t time_valid_until;
-        uint16_t sni_length;
-        uint16_t alpn_length;
-        uint16_t ticket_length;
-    } picoquic_stored_ticket_t;
+typedef struct st_picoquic_stored_ticket_t {
+    struct st_picoquic_stored_ticket_t* next_ticket;
+    char* sni;
+    char* alpn;
+    uint8_t* ticket;
+    uint64_t time_valid_until;
+    uint16_t sni_length;
+    uint16_t alpn_length;
+    uint16_t ticket_length;
+} picoquic_stored_ticket_t;
 
-    int picoquic_store_ticket(picoquic_stored_ticket_t ** p_first_ticket,
-        uint64_t current_time,
-        char const * sni, uint16_t sni_length, char const * alpn, uint16_t alpn_length,
-        uint8_t * ticket, uint16_t ticket_length);
-    int picoquic_get_ticket(picoquic_stored_ticket_t * p_first_ticket,
-        uint64_t current_time,
-        char const * sni, uint16_t sni_length, char const * alpn, uint16_t alpn_length,
-        uint8_t ** ticket, uint16_t * ticket_length);
+int picoquic_store_ticket(picoquic_stored_ticket_t** p_first_ticket,
+    uint64_t current_time,
+    char const* sni, uint16_t sni_length, char const* alpn, uint16_t alpn_length,
+    uint8_t* ticket, uint16_t ticket_length);
+int picoquic_get_ticket(picoquic_stored_ticket_t* p_first_ticket,
+    uint64_t current_time,
+    char const* sni, uint16_t sni_length, char const* alpn, uint16_t alpn_length,
+    uint8_t** ticket, uint16_t* ticket_length);
 
-    int picoquic_save_tickets(picoquic_stored_ticket_t * first_ticket,
-        uint64_t current_time, char const * ticket_file_name);
-    int picoquic_load_tickets(picoquic_stored_ticket_t ** pp_first_ticket,
-        uint64_t current_time, char const * ticket_file_name);
-    void picoquic_free_tickets(picoquic_stored_ticket_t ** pp_first_ticket);
+int picoquic_save_tickets(picoquic_stored_ticket_t* first_ticket,
+    uint64_t current_time, char const* ticket_file_name);
+int picoquic_load_tickets(picoquic_stored_ticket_t** pp_first_ticket,
+    uint64_t current_time, char const* ticket_file_name);
+void picoquic_free_tickets(picoquic_stored_ticket_t** pp_first_ticket);
 
-	/*
+/*
 	 * Quic context flags
 	 */
-	typedef enum {
-		picoquic_context_check_cookie = 1,
-		picoquic_context_unconditional_cnx_id = 2
-	} picoquic_context_flags;
+typedef enum {
+    picoquic_context_check_cookie = 1,
+    picoquic_context_unconditional_cnx_id = 2
+} picoquic_context_flags;
 
-	/*
+/*
 	 * QUIC context, defining the tables of connections,
 	 * open sockets, etc.
 	 */
-	typedef struct st_picoquic_quic_t
-	{
-		void* tls_master_ctx;
-		picoquic_stream_data_cb_fn default_callback_fn;
-		void * default_callback_ctx;
-		char const * default_alpn;
-		uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE];
-        uint8_t retry_seed[PICOQUIC_RETRY_SECRET_SIZE];
-        uint64_t * p_simulated_time;
-        char const * ticket_file_name;
-        picoquic_stored_ticket_t * p_first_ticket;
+typedef struct st_picoquic_quic_t {
+    void* tls_master_ctx;
+    picoquic_stream_data_cb_fn default_callback_fn;
+    void* default_callback_ctx;
+    char const* default_alpn;
+    uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE];
+    uint8_t retry_seed[PICOQUIC_RETRY_SECRET_SIZE];
+    uint64_t* p_simulated_time;
+    char const* ticket_file_name;
+    picoquic_stored_ticket_t* p_first_ticket;
 
-		uint32_t flags;
+    uint32_t flags;
 
-		picoquic_stateless_packet_t * pending_stateless_packet;
+    picoquic_stateless_packet_t* pending_stateless_packet;
 
-		picoquic_congestion_algorithm_t const * default_congestion_alg;
+    picoquic_congestion_algorithm_t const* default_congestion_alg;
 
-		struct st_picoquic_cnx_t * cnx_list;
-		struct st_picoquic_cnx_t * cnx_last;
+    struct st_picoquic_cnx_t* cnx_list;
+    struct st_picoquic_cnx_t* cnx_last;
 
-		picohash_table * table_cnx_by_id;
-		picohash_table * table_cnx_by_net;
+    picohash_table* table_cnx_by_id;
+    picohash_table* table_cnx_by_net;
 
-		cnx_id_cb_fn cnx_id_callback_fn;
-		void * cnx_id_callback_ctx;
+    cnx_id_cb_fn cnx_id_callback_fn;
+    void* cnx_id_callback_ctx;
 
-        void * aead_encrypt_ticket_ctx;
-        void * aead_decrypt_ticket_ctx;
-	} picoquic_quic_t;
+    void* aead_encrypt_ticket_ctx;
+    void* aead_decrypt_ticket_ctx;
+} picoquic_quic_t;
 
-	/*
+/*
 	* Transport parameters, as defined by the QUIC transport specification
 	*/
 
-	typedef struct _picoquic_transport_parameters {
-		uint32_t initial_max_stream_data;
-		uint32_t initial_max_data;
-		uint32_t initial_max_stream_id_bidir;
-        uint32_t initial_max_stream_id_unidir;
-		uint32_t idle_timeout;
-		uint32_t omit_connection_id;
-		uint32_t max_packet_size;
-        uint8_t ack_delay_exponent;
-	} picoquic_transport_parameters;
+typedef struct _picoquic_transport_parameters {
+    uint32_t initial_max_stream_data;
+    uint32_t initial_max_data;
+    uint32_t initial_max_stream_id_bidir;
+    uint32_t initial_max_stream_id_unidir;
+    uint32_t idle_timeout;
+    uint32_t omit_connection_id;
+    uint32_t max_packet_size;
+    uint8_t ack_delay_exponent;
+} picoquic_transport_parameters;
 
-	/*
+/*
 	 * SACK dashboard item, part of connection context.
 	 */
 
-	typedef struct st_picoquic_sack_item_t {
-		struct st_picoquic_sack_item_t * next_sack;
-		uint64_t start_of_sack_range;
-		uint64_t end_of_sack_range;
-		// uint64_t time_stamp_last_in_range;
-	} picoquic_sack_item_t;
+typedef struct st_picoquic_sack_item_t {
+    struct st_picoquic_sack_item_t* next_sack;
+    uint64_t start_of_sack_range;
+    uint64_t end_of_sack_range;
+    // uint64_t time_stamp_last_in_range;
+} picoquic_sack_item_t;
 
-
-	/*
+/*
 	 * Stream head.
 	 * Stream contains bytes of data, which are not always delivered in order.
 	 * When in order data is available, the application can read it,
 	 * or a callback can be set.
 	 */
 
-	typedef struct _picoquic_stream_data {
-		struct _picoquic_stream_data * next_stream_data;
-		uint64_t offset;
-		size_t length;
-		uint8_t * bytes;
-	} picoquic_stream_data;
+typedef struct _picoquic_stream_data {
+    struct _picoquic_stream_data* next_stream_data;
+    uint64_t offset;
+    size_t length;
+    uint8_t* bytes;
+} picoquic_stream_data;
 
-	typedef enum picoquic_stream_flags {
-		picoquic_stream_flag_fin_received = 1,
-		picoquic_stream_flag_fin_signalled = 2,
-		picoquic_stream_flag_fin_notified = 4,
-		picoquic_stream_flag_fin_sent = 8,
-		picoquic_stream_flag_reset_requested = 16,
-		picoquic_stream_flag_reset_sent = 32,
-		picoquic_stream_flag_reset_received = 64,
-		picoquic_stream_flag_reset_signalled = 128,
-        picoquic_stream_flag_stop_sending_requested = 256,
-        picoquic_stream_flag_stop_sending_sent = 512,
-        picoquic_stream_flag_stop_sending_received = 1024,
-        picoquic_stream_flag_stop_sending_signalled = 2048
-	} picoquic_stream_flags;
+typedef enum picoquic_stream_flags {
+    picoquic_stream_flag_fin_received = 1,
+    picoquic_stream_flag_fin_signalled = 2,
+    picoquic_stream_flag_fin_notified = 4,
+    picoquic_stream_flag_fin_sent = 8,
+    picoquic_stream_flag_reset_requested = 16,
+    picoquic_stream_flag_reset_sent = 32,
+    picoquic_stream_flag_reset_received = 64,
+    picoquic_stream_flag_reset_signalled = 128,
+    picoquic_stream_flag_stop_sending_requested = 256,
+    picoquic_stream_flag_stop_sending_sent = 512,
+    picoquic_stream_flag_stop_sending_received = 1024,
+    picoquic_stream_flag_stop_sending_signalled = 2048
+} picoquic_stream_flags;
 
-	typedef struct _picoquic_stream_head {
-		struct _picoquic_stream_head * next_stream;
-		uint64_t stream_id;
-		uint64_t consumed_offset;
-		uint64_t fin_offset;
-		uint64_t maxdata_local;
-		uint64_t maxdata_remote;
-        uint32_t stream_flags;
-		uint32_t local_error;
-		uint32_t remote_error;
-        uint32_t local_stop_error;
-        uint32_t remote_stop_error;
-		picoquic_stream_data * stream_data;
-		uint64_t sent_offset;
-		picoquic_stream_data * send_queue;
-        picoquic_sack_item_t first_sack_item;
-	} picoquic_stream_head;
+typedef struct _picoquic_stream_head {
+    struct _picoquic_stream_head* next_stream;
+    uint64_t stream_id;
+    uint64_t consumed_offset;
+    uint64_t fin_offset;
+    uint64_t maxdata_local;
+    uint64_t maxdata_remote;
+    uint32_t stream_flags;
+    uint32_t local_error;
+    uint32_t remote_error;
+    uint32_t local_stop_error;
+    uint32_t remote_stop_error;
+    picoquic_stream_data* stream_data;
+    uint64_t sent_offset;
+    picoquic_stream_data* send_queue;
+    picoquic_sack_item_t first_sack_item;
+} picoquic_stream_head;
 
-    /*
+/*
      * Frame queue. This is used for miscellaneous packets, such as the PONG
      * response to a PING.
      *
@@ -291,327 +286,325 @@ extern "C" {
      * misc_frame_header, followed by the misc frame content.
      */
 
-    typedef struct st_picoquic_misc_frame_header_t {
-        struct st_picoquic_misc_frame_header_t * next_misc_frame;
-        size_t length;
-    } picoquic_misc_frame_header_t;
+typedef struct st_picoquic_misc_frame_header_t {
+    struct st_picoquic_misc_frame_header_t* next_misc_frame;
+    size_t length;
+} picoquic_misc_frame_header_t;
 
-
-	/*
+/*
 	 * Per connection context.
 	 */
-	typedef struct st_picoquic_cnx_t
-	{
-		picoquic_quic_t * quic;
+typedef struct st_picoquic_cnx_t {
+    picoquic_quic_t* quic;
 
-		/* Management of context retrieval tables */
-		struct st_picoquic_cnx_t * next_in_table;
-		struct st_picoquic_cnx_t * previous_in_table;
-		struct st_picoquic_cnx_id_t * first_cnx_id;
-		struct st_picoquic_net_id_t * first_net_id;
+    /* Management of context retrieval tables */
+    struct st_picoquic_cnx_t* next_in_table;
+    struct st_picoquic_cnx_t* previous_in_table;
+    struct st_picoquic_cnx_id_t* first_cnx_id;
+    struct st_picoquic_net_id_t* first_net_id;
 
-		/* Proposed and negotiated version. Feature flags denote version dependent features */
-		uint32_t proposed_version;
-        int version_index;
+    /* Proposed and negotiated version. Feature flags denote version dependent features */
+    uint32_t proposed_version;
+    int version_index;
 
-		/* Local and remote parameters */
-		picoquic_transport_parameters local_parameters;
-		picoquic_transport_parameters remote_parameters;
-        int remote_parameters_received;
-		/* On clients, document the SNI and ALPN expected from the server */
-		/* TODO: there may be a need to propose multiple ALPN */
-		char const * sni;
-		char const * alpn;
-        /* On clients, receives the maximum 0RTT size accepted by server, and whether 0-RTT is accepted */
-        size_t max_early_data_size;
-        int is_0RTT_accepted;
-		/* Call back function and context */
-		picoquic_stream_data_cb_fn callback_fn;
-		void * callback_ctx;
+    /* Local and remote parameters */
+    picoquic_transport_parameters local_parameters;
+    picoquic_transport_parameters remote_parameters;
+    int remote_parameters_received;
+    /* On clients, document the SNI and ALPN expected from the server */
+    /* TODO: there may be a need to propose multiple ALPN */
+    char const* sni;
+    char const* alpn;
+    /* On clients, receives the maximum 0RTT size accepted by server, and whether 0-RTT is accepted */
+    size_t max_early_data_size;
+    int is_0RTT_accepted;
+    /* Call back function and context */
+    picoquic_stream_data_cb_fn callback_fn;
+    void* callback_ctx;
 
-        /* Peer address. To do: allow for multiple addresses */
-        struct sockaddr_storage peer_addr;
-        int peer_addr_len;
-        struct sockaddr_storage dest_addr;
-        int dest_addr_len;
-        unsigned long if_index_dest;
+    /* Peer address. To do: allow for multiple addresses */
+    struct sockaddr_storage peer_addr;
+    int peer_addr_len;
+    struct sockaddr_storage dest_addr;
+    int dest_addr_len;
+    unsigned long if_index_dest;
 
-		/* connection state, ID, etc. Todo: allow for multiple cnxid */
-		picoquic_state_enum cnx_state;
-		uint64_t initial_cnxid;
-		uint64_t server_cnxid;
-        uint64_t start_time;
-		uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE];
-        uint32_t application_error;
-		uint32_t local_error;
-        uint32_t remote_application_error;
-		uint32_t remote_error;
+    /* connection state, ID, etc. Todo: allow for multiple cnxid */
+    picoquic_state_enum cnx_state;
+    uint64_t initial_cnxid;
+    uint64_t server_cnxid;
+    uint64_t start_time;
+    uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE];
+    uint32_t application_error;
+    uint32_t local_error;
+    uint32_t remote_application_error;
+    uint32_t remote_error;
 
-        /* Next time sending data is expected */
-        uint64_t next_wake_time;
+    /* Next time sending data is expected */
+    uint64_t next_wake_time;
 
-		/* TLS context, TLS Send Buffer, chain of receive buffers (todo) */
-		void * tls_ctx;
-		struct st_ptls_buffer_t * tls_sendbuf;
-		uint64_t send_sequence;
-		uint32_t send_mtu;
-        uint32_t send_mtu_max_tried;
-        uint16_t psk_cipher_suite_id;
-        int mtu_probe_sent;
+    /* TLS context, TLS Send Buffer, chain of receive buffers (todo) */
+    void* tls_ctx;
+    struct st_ptls_buffer_t* tls_sendbuf;
+    uint64_t send_sequence;
+    uint32_t send_mtu;
+    uint32_t send_mtu_max_tried;
+    uint16_t psk_cipher_suite_id;
+    int mtu_probe_sent;
 
-        /* Liveness detection */
-        uint64_t latest_progress_time; /* last local time at which the connection progressed */
+    /* Liveness detection */
+    uint64_t latest_progress_time; /* last local time at which the connection progressed */
 
-		/* Encryption and decryption objects */
-        void * aead_encrypt_cleartext_ctx;
-        void * aead_decrypt_cleartext_ctx;
-        void * aead_de_encrypt_cleartext_ctx; /* used by logging functions to see what is sent. */
-		void * aead_encrypt_ctx; 
-		void * aead_decrypt_ctx;
-        void * aead_de_encrypt_ctx; /* used by logging functions to see what is sent. */
-        void * aead_0rtt_encrypt_ctx; /* setup on client if 0-RTT is possible */
-        void * aead_0rtt_decrypt_ctx; /* setup on server if 0-RTT is possible, also used on client for logging */
+    /* Encryption and decryption objects */
+    void* aead_encrypt_cleartext_ctx;
+    void* aead_decrypt_cleartext_ctx;
+    void* aead_de_encrypt_cleartext_ctx; /* used by logging functions to see what is sent. */
+    void* aead_encrypt_ctx;
+    void* aead_decrypt_ctx;
+    void* aead_de_encrypt_ctx; /* used by logging functions to see what is sent. */
+    void* aead_0rtt_encrypt_ctx; /* setup on client if 0-RTT is possible */
+    void* aead_0rtt_decrypt_ctx; /* setup on server if 0-RTT is possible, also used on client for logging */
 
-		/* Receive state */
-		picoquic_sack_item_t first_sack_item;
-        uint64_t time_stamp_largest_received;
-		uint64_t sack_block_size_max;
-		uint64_t highest_ack_sent;
-		uint64_t highest_ack_time;
-		int ack_needed;
+    /* Receive state */
+    picoquic_sack_item_t first_sack_item;
+    uint64_t time_stamp_largest_received;
+    uint64_t sack_block_size_max;
+    uint64_t highest_ack_sent;
+    uint64_t highest_ack_time;
+    int ack_needed;
 
-		/* Time measurement */
-        uint64_t max_ack_delay;
-		uint64_t smoothed_rtt;
-		uint64_t rtt_variant;
-		uint64_t retransmit_timer;
-		uint64_t rtt_min;
-        uint64_t ack_delay_local;
+    /* Time measurement */
+    uint64_t max_ack_delay;
+    uint64_t smoothed_rtt;
+    uint64_t rtt_variant;
+    uint64_t retransmit_timer;
+    uint64_t rtt_min;
+    uint64_t ack_delay_local;
 
-		/* Retransmission state */
-        uint32_t nb_zero_rtt_sent;
-        uint32_t nb_zero_rtt_acked;
-        uint64_t nb_retransmission_total;
-		uint64_t nb_retransmit;
-        uint64_t nb_spurious;
-        uint64_t max_spurious_rtt;
-        uint64_t max_reorder_delay;
-        uint64_t max_reorder_gap;
-		uint64_t latest_retransmit_time;
-		uint64_t highest_acknowledged; 
-		uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
-		picoquic_packet * retransmit_newest;
-		picoquic_packet * retransmit_oldest;
-        picoquic_packet * retransmitted_newest;
-        picoquic_packet * retransmitted_oldest;
+    /* Retransmission state */
+    uint32_t nb_zero_rtt_sent;
+    uint32_t nb_zero_rtt_acked;
+    uint64_t nb_retransmission_total;
+    uint64_t nb_retransmit;
+    uint64_t nb_spurious;
+    uint64_t max_spurious_rtt;
+    uint64_t max_reorder_delay;
+    uint64_t max_reorder_gap;
+    uint64_t latest_retransmit_time;
+    uint64_t highest_acknowledged;
+    uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
+    picoquic_packet* retransmit_newest;
+    picoquic_packet* retransmit_oldest;
+    picoquic_packet* retransmitted_newest;
+    picoquic_packet* retransmitted_oldest;
 
-		/* Congestion control state */
-		uint64_t cwin;
-		uint64_t bytes_in_transit;
-		void * congestion_alg_state;
-		picoquic_congestion_algorithm_t const * congestion_alg;
+    /* Congestion control state */
+    uint64_t cwin;
+    uint64_t bytes_in_transit;
+    void* congestion_alg_state;
+    picoquic_congestion_algorithm_t const* congestion_alg;
 
-        /* Pacing */
-        uint64_t packet_time_nano_sec;
-        uint64_t pacing_reminder_nano_sec;
-        uint64_t pacing_margin_micros;
-        uint64_t next_pacing_time;
+    /* Pacing */
+    uint64_t packet_time_nano_sec;
+    uint64_t pacing_reminder_nano_sec;
+    uint64_t pacing_margin_micros;
+    uint64_t next_pacing_time;
 
-		/* Flow control information */
-		uint64_t data_sent;
-		uint64_t data_received;
-		uint64_t maxdata_local;
-		uint64_t maxdata_remote;
-		//uint64_t highest_stream_id_local;
-		//uint64_t highest_stream_id_remote;
-		uint64_t max_stream_id_bidir_local;
-        uint64_t max_stream_id_unidir_local;
-		uint64_t max_stream_id_bidir_remote;
-        uint64_t max_stream_id_unidir_remote;
+    /* Flow control information */
+    uint64_t data_sent;
+    uint64_t data_received;
+    uint64_t maxdata_local;
+    uint64_t maxdata_remote;
+    //uint64_t highest_stream_id_local;
+    //uint64_t highest_stream_id_remote;
+    uint64_t max_stream_id_bidir_local;
+    uint64_t max_stream_id_unidir_local;
+    uint64_t max_stream_id_bidir_remote;
+    uint64_t max_stream_id_unidir_remote;
 
-        /* Queue for frames waiting to be sent */
-        picoquic_misc_frame_header_t * first_misc_frame;
+    /* Queue for frames waiting to be sent */
+    picoquic_misc_frame_header_t* first_misc_frame;
 
-		/* Management of streams */
-		picoquic_stream_head first_stream;
+    /* Management of streams */
+    picoquic_stream_head first_stream;
 
     /* Is this connection the client side? */
     char client_mode;
-	} picoquic_cnx_t;
+} picoquic_cnx_t;
 
-    /* Init of transport parameters */
-    void picoquic_init_transport_parameters(picoquic_transport_parameters * tp, int is_server);
+/* Init of transport parameters */
+void picoquic_init_transport_parameters(picoquic_transport_parameters* tp, int is_server);
 
-	/* Handling of stateless packets */
-	picoquic_stateless_packet_t * picoquic_create_stateless_packet(picoquic_quic_t * quic);
-	void picoquic_queue_stateless_packet(picoquic_quic_t * quic, picoquic_stateless_packet_t * sp);
+/* Handling of stateless packets */
+picoquic_stateless_packet_t* picoquic_create_stateless_packet(picoquic_quic_t* quic);
+void picoquic_queue_stateless_packet(picoquic_quic_t* quic, picoquic_stateless_packet_t* sp);
 
-    /* Registration of connection ID in server context */
-    int picoquic_register_cnx_id(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uint64_t cnx_id);
+/* Registration of connection ID in server context */
+int picoquic_register_cnx_id(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t cnx_id);
 
-	/* handling of retransmission queue */
-	void picoquic_enqueue_retransmit_packet(picoquic_cnx_t * cnx, picoquic_packet * p);
-	void picoquic_dequeue_retransmit_packet(picoquic_cnx_t * cnx, picoquic_packet * p, int should_free);
+/* handling of retransmission queue */
+void picoquic_enqueue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p);
+void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free);
 
-	/* Reset connection after receiving version negotiation */
-	int picoquic_reset_cnx_version(picoquic_cnx_t * cnx, uint8_t * bytes, size_t length, uint64_t current_time);
+/* Reset connection after receiving version negotiation */
+int picoquic_reset_cnx_version(picoquic_cnx_t* cnx, uint8_t* bytes, size_t length, uint64_t current_time);
 
-    /* Notify error on connection */
-    int picoquic_connection_error(picoquic_cnx_t * cnx, uint32_t local_error);
+/* Notify error on connection */
+int picoquic_connection_error(picoquic_cnx_t* cnx, uint32_t local_error);
 
-	/* Connection context retrieval functions */
-	picoquic_cnx_t * picoquic_cnx_by_id(picoquic_quic_t * quic, uint64_t cnx_id);
-	picoquic_cnx_t * picoquic_cnx_by_net(picoquic_quic_t * quic, struct sockaddr* addr);
+/* Connection context retrieval functions */
+picoquic_cnx_t* picoquic_cnx_by_id(picoquic_quic_t* quic, uint64_t cnx_id);
+picoquic_cnx_t* picoquic_cnx_by_net(picoquic_quic_t* quic, struct sockaddr* addr);
 
-    /*
+/*
      * Reset the pacing data after CWIN is updated
      */
 
-    void picoquic_update_pacing_data(picoquic_cnx_t * cnx);
+void picoquic_update_pacing_data(picoquic_cnx_t* cnx);
 
-    /* Next time is used to order the list of available connections,
+/* Next time is used to order the list of available connections,
      * so ready connections are polled first */
-    void picoquic_reinsert_by_wake_time(picoquic_quic_t * quic, picoquic_cnx_t * cnx);
+void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx);
 
-    void picoquic_cnx_set_next_wake_time(picoquic_cnx_t * cnx, uint64_t current_time);
+void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time);
 
-	/* Integer parsing macros */
-#define PICOPARSE_16(b) ((((uint16_t)(b)[0])<<8)|(b)[1])
-#define PICOPARSE_24(b) ((((uint32_t)PICOPARSE_16(b))<<16)|((b)[2]))
-#define PICOPARSE_32(b) ((((uint32_t)PICOPARSE_16(b))<<16)|PICOPARSE_16((b)+2))
-#define PICOPARSE_64(b) ((((uint64_t)PICOPARSE_32(b))<<32)|PICOPARSE_32((b)+4))
+/* Integer parsing macros */
+#define PICOPARSE_16(b) ((((uint16_t)(b)[0]) << 8) | (b)[1])
+#define PICOPARSE_24(b) ((((uint32_t)PICOPARSE_16(b)) << 16) | ((b)[2]))
+#define PICOPARSE_32(b) ((((uint32_t)PICOPARSE_16(b)) << 16) | PICOPARSE_16((b) + 2))
+#define PICOPARSE_64(b) ((((uint64_t)PICOPARSE_32(b)) << 32) | PICOPARSE_32((b) + 4))
 
-	/* Integer formatting functions */
-	void picoformat_16(uint8_t *bytes, uint16_t n16);
-	void picoformat_32(uint8_t *bytes, uint32_t n32);
-	void picoformat_64(uint8_t *bytes, uint64_t n64);
+/* Integer formatting functions */
+void picoformat_16(uint8_t* bytes, uint16_t n16);
+void picoformat_32(uint8_t* bytes, uint32_t n32);
+void picoformat_64(uint8_t* bytes, uint64_t n64);
 
-    size_t picoquic_varint_encode(uint8_t *bytes, size_t max_bytes, uint64_t n64);
-    size_t picoquic_varint_decode(const uint8_t *bytes, size_t max_bytes, uint64_t * n64);
-    size_t picoquic_varint_skip(uint8_t *bytes);
+size_t picoquic_varint_encode(uint8_t* bytes, size_t max_bytes, uint64_t n64);
+size_t picoquic_varint_decode(const uint8_t* bytes, size_t max_bytes, uint64_t* n64);
+size_t picoquic_varint_skip(uint8_t* bytes);
 
-	/* utilities */
-	char * picoquic_string_create(const char * original, size_t len);
-	char * picoquic_string_duplicate(const char * original);
+/* utilities */
+char* picoquic_string_create(const char* original, size_t len);
+char* picoquic_string_duplicate(const char* original);
 
-	/* Packet parsing */
+/* Packet parsing */
 
-	typedef struct _picoquic_packet_header {
-		uint64_t cnx_id;
-		uint32_t pn;
-		uint32_t vn;
-		uint32_t offset;
-		picoquic_packet_type_enum ptype;
-		uint64_t pnmask;
-		uint64_t pn64;
-        int version_index;
-	} picoquic_packet_header;
+typedef struct _picoquic_packet_header {
+    uint64_t cnx_id;
+    uint32_t pn;
+    uint32_t vn;
+    uint32_t offset;
+    picoquic_packet_type_enum ptype;
+    uint64_t pnmask;
+    uint64_t pn64;
+    int version_index;
+} picoquic_packet_header;
 
-	int picoquic_parse_packet_header(
-        picoquic_quic_t * quic,
-        uint8_t * bytes,
-        uint32_t length,
-        struct sockaddr * addr_from,
-        picoquic_packet_header * ph,
-        picoquic_cnx_t ** pcnx);
+int picoquic_parse_packet_header(
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
+    uint32_t length,
+    struct sockaddr* addr_from,
+    picoquic_packet_header* ph,
+    picoquic_cnx_t** pcnx);
 
-    int picoquic_test_stream_frame_unlimited(uint8_t * bytes);
-    int picoquic_check_stream_frame_already_acked(picoquic_cnx_t * cnx, uint8_t * bytes,
-        size_t bytes_max, int * no_need_to_repeat);
+int picoquic_test_stream_frame_unlimited(uint8_t* bytes);
+int picoquic_check_stream_frame_already_acked(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, int* no_need_to_repeat);
 
-    int picoquic_parse_stream_header(
-		const uint8_t * bytes, size_t bytes_max,
-		uint64_t * stream_id, uint64_t * offset, size_t * data_length, int * fin,
-		size_t * consumed);
+int picoquic_parse_stream_header(
+    const uint8_t* bytes, size_t bytes_max,
+    uint64_t* stream_id, uint64_t* offset, size_t* data_length, int* fin,
+    size_t* consumed);
 
-	int picoquic_parse_ack_header(
-		uint8_t const * bytes, size_t bytes_max,
-		uint64_t * num_block, uint64_t * largest,
-		uint64_t * ack_delay, size_t * consumed,
-        uint8_t ack_delay_exponent);
-  
-	uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t pn);
+int picoquic_parse_ack_header(
+    uint8_t const* bytes, size_t bytes_max,
+    uint64_t* num_block, uint64_t* largest,
+    uint64_t* ack_delay, size_t* consumed,
+    uint8_t ack_delay_exponent);
 
-    size_t picoquic_decrypt_cleartext(picoquic_cnx_t * cnx,
-        uint8_t * bytes, size_t length, picoquic_packet_header * ph);
+uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t pn);
 
-	/* handling of ACK logic */
-	int picoquic_is_ack_needed(picoquic_cnx_t * cnx, uint64_t current_time);
+size_t picoquic_decrypt_cleartext(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t length, picoquic_packet_header* ph);
 
-	int picoquic_is_pn_already_received(picoquic_cnx_t * cnx, uint64_t pn64);
-	int picoquic_record_pn_received(picoquic_cnx_t * cnx, uint64_t pn64, uint64_t current_microsec);
-	uint16_t picoquic_deltat_to_float16(uint64_t delta_t);
-	uint64_t picoquic_float16_to_deltat(uint16_t float16);
+/* handling of ACK logic */
+int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time);
 
-    int picoquic_update_sack_list(picoquic_sack_item_t * sack,
-        uint64_t pn64_min, uint64_t pn64_max,
-        uint64_t * sack_block_size_max);
-    /*
+int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, uint64_t pn64);
+int picoquic_record_pn_received(picoquic_cnx_t* cnx, uint64_t pn64, uint64_t current_microsec);
+uint16_t picoquic_deltat_to_float16(uint64_t delta_t);
+uint64_t picoquic_float16_to_deltat(uint16_t float16);
+
+int picoquic_update_sack_list(picoquic_sack_item_t* sack,
+    uint64_t pn64_min, uint64_t pn64_max,
+    uint64_t* sack_block_size_max);
+/*
      * Check whether the data fills a hole. returns 0 if it does, -1 otherwise.
      */
-    int picoquic_check_sack_list(picoquic_sack_item_t * sack,
-        uint64_t pn64_min, uint64_t pn64_max);
+int picoquic_check_sack_list(picoquic_sack_item_t* sack,
+    uint64_t pn64_min, uint64_t pn64_max);
 
-    /*
+/*
      * Process ack of ack
      */
-    int picoquic_process_ack_of_ack_frame(
-        picoquic_sack_item_t * first_sack,
-        uint8_t * bytes, size_t bytes_max, size_t * consumed);
+int picoquic_process_ack_of_ack_frame(
+    picoquic_sack_item_t* first_sack,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-	/* stream management */
-    picoquic_stream_head * picoquic_create_stream(picoquic_cnx_t * cnx, uint64_t stream_id);
-    void picoquic_update_stream_initial_remote(picoquic_cnx_t * cnx);
-	picoquic_stream_head * picoquic_find_stream(picoquic_cnx_t * cnx, uint64_t stream_id, int create);
-	picoquic_stream_head * picoquic_find_ready_stream(picoquic_cnx_t * cnx, int restricted);
-	int picoquic_stream_network_input(picoquic_cnx_t * cnx, uint64_t stream_id,
-		uint64_t offset, int fin, uint8_t * bytes, size_t length, uint64_t current_time);
-	int picoquic_decode_stream_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-		size_t bytes_max, int restricted, size_t * consumed, uint64_t current_time);
-	int picoquic_prepare_stream_frame(picoquic_cnx_t * cnx, picoquic_stream_head * stream,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
-	int picoquic_prepare_ack_frame(picoquic_cnx_t * cnx, uint64_t current_time,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
-	int picoquic_prepare_connection_close_frame(picoquic_cnx_t * cnx,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
-    int picoquic_prepare_application_close_frame(picoquic_cnx_t * cnx,
-        uint8_t * bytes, size_t bytes_max, size_t * consumed);
-	int picoquic_prepare_required_max_stream_data_frames(picoquic_cnx_t * cnx,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
-	int picoquic_prepare_max_data_frame(picoquic_cnx_t * cnx, uint64_t maxdata_increase,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
-    void picoquic_clear_stream(picoquic_stream_head * stream);
+/* stream management */
+picoquic_stream_head* picoquic_create_stream(picoquic_cnx_t* cnx, uint64_t stream_id);
+void picoquic_update_stream_initial_remote(picoquic_cnx_t* cnx);
+picoquic_stream_head* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t stream_id, int create);
+picoquic_stream_head* picoquic_find_ready_stream(picoquic_cnx_t* cnx, int restricted);
+int picoquic_stream_network_input(picoquic_cnx_t* cnx, uint64_t stream_id,
+    uint64_t offset, int fin, uint8_t* bytes, size_t length, uint64_t current_time);
+int picoquic_decode_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, int restricted, size_t* consumed, uint64_t current_time);
+int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* stream,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_connection_close_frame(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_application_close_frame(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_required_max_stream_data_frames(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_max_data_frame(picoquic_cnx_t* cnx, uint64_t maxdata_increase,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
+void picoquic_clear_stream(picoquic_stream_head* stream);
 
-    int picoquic_prepare_misc_frame(picoquic_cnx_t * cnx, uint8_t * bytes,
-        size_t bytes_max, size_t * consumed);
+int picoquic_prepare_misc_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, size_t* consumed);
 
-	/* send/receive */
+/* send/receive */
 
-	int picoquic_decode_frames(picoquic_cnx_t * cnx, uint8_t * bytes,
-		size_t bytes_max, int restricted, uint64_t current_time);
+int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
+    size_t bytes_max, int restricted, uint64_t current_time);
 
-	int picoquic_skip_frame(uint8_t * bytes, size_t bytes_max, size_t * consumed, 
-        int * pure_ack);
+int picoquic_skip_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed,
+    int* pure_ack);
 
-    int picoquic_decode_closing_frames(uint8_t * bytes,
-        size_t bytes_max, int *closing_received);
+int picoquic_decode_closing_frames(uint8_t* bytes,
+    size_t bytes_max, int* closing_received);
 
-	int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
+int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-	int picoquic_receive_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-		uint8_t * bytes, size_t bytes_max, size_t * consumed);
+int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-    /* Check whether a packet was sent in clear text */
-    int picoquic_is_packet_encrypted(picoquic_cnx_t * cnx, uint8_t byte_zero);
+/* Check whether a packet was sent in clear text */
+int picoquic_is_packet_encrypted(picoquic_cnx_t* cnx, uint8_t byte_zero);
 
-    /* Queue stateless reset */
-    void picoquic_queue_stateless_reset(picoquic_cnx_t * cnx,
-        picoquic_packet_header * ph, struct sockaddr* addr_from,
-        struct sockaddr * addr_to,
-        unsigned long if_index_to);
+/* Queue stateless reset */
+void picoquic_queue_stateless_reset(picoquic_cnx_t* cnx,
+    picoquic_packet_header* ph, struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
+    unsigned long if_index_to);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 #endif /* PICOQUIC_INTERNAL_H */

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "util.h"
 #include "picosocks.h"
+#include "util.h"
 
 static int bind_to_port(SOCKET_TYPE fd, int af, int port)
 {
@@ -29,55 +29,43 @@ static int bind_to_port(SOCKET_TYPE fd, int af, int port)
 
     memset(&sa, 0, sizeof(sa));
 
-    if (af == AF_INET)
-    {
-        struct sockaddr_in * s4 = (struct sockaddr_in *)&sa;
+    if (af == AF_INET) {
+        struct sockaddr_in* s4 = (struct sockaddr_in*)&sa;
 
         s4->sin_family = af;
         s4->sin_port = htons((u_short)port);
         addr_length = sizeof(struct sockaddr_in);
-    }
-    else
-    {
-        struct sockaddr_in6 * s6 = (struct sockaddr_in6 *)&sa;
+    } else {
+        struct sockaddr_in6* s6 = (struct sockaddr_in6*)&sa;
 
         s6->sin6_family = AF_INET6;
         s6->sin6_port = htons((u_short)port);
         addr_length = sizeof(struct sockaddr_in6);
     }
 
-    return bind(fd, (struct sockaddr *) &sa, addr_length);
+    return bind(fd, (struct sockaddr*)&sa, addr_length);
 }
 
-int picoquic_open_server_sockets(picoquic_server_sockets_t * sockets, int port)
+int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port)
 {
     int ret = 0;
     const int sock_af[] = { AF_INET6, AF_INET };
 
-    for (int i = 0; i < PICOQUIC_NB_SERVER_SOCKETS; i++)
-    {
-        if (ret == 0)
-        {
+    for (int i = 0; i < PICOQUIC_NB_SERVER_SOCKETS; i++) {
+        if (ret == 0) {
             sockets->s_socket[i] = socket(sock_af[i], SOCK_DGRAM, IPPROTO_UDP);
-        }
-        else
-        {
+        } else {
             sockets->s_socket[i] = INVALID_SOCKET;
         }
 
-        if (sockets->s_socket[i] == INVALID_SOCKET)
-        {
+        if (sockets->s_socket[i] == INVALID_SOCKET) {
             ret = -1;
-        }
-        else
-        {
+        } else {
 #ifdef _WINDOWS
             int option_value = 1;
             if (sock_af[i] == AF_INET6) {
                 ret = setsockopt(sockets->s_socket[i], IPPROTO_IPV6, IPV6_PKTINFO, (char*)&option_value, sizeof(int));
-            }
-            else
-            {
+            } else {
                 ret = setsockopt(sockets->s_socket[i], IPPROTO_IP, IP_PKTINFO, (char*)&option_value, sizeof(int));
             }
 #else
@@ -85,20 +73,16 @@ int picoquic_open_server_sockets(picoquic_server_sockets_t * sockets, int port)
                 int val = 1;
                 ret = setsockopt(sockets->s_socket[i], IPPROTO_IPV6, IPV6_V6ONLY,
                     &val, sizeof(val));
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     val = 1;
                     ret = setsockopt(sockets->s_socket[i], IPPROTO_IPV6, IPV6_RECVPKTINFO, (char*)&val, sizeof(int));
                 }
-            }
-            else
-            {
+            } else {
                 int val = 1;
                 ret = setsockopt(sockets->s_socket[i], IPPROTO_IP, IP_PKTINFO, (char*)&val, sizeof(int));
             }
 #endif
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 ret = bind_to_port(sockets->s_socket[i], sock_af[i], port);
             }
         }
@@ -107,12 +91,10 @@ int picoquic_open_server_sockets(picoquic_server_sockets_t * sockets, int port)
     return ret;
 }
 
-void picoquic_close_server_sockets(picoquic_server_sockets_t * sockets)
+void picoquic_close_server_sockets(picoquic_server_sockets_t* sockets)
 {
-    for (int i = 0; i < PICOQUIC_NB_SERVER_SOCKETS; i++)
-    {
-        if (sockets->s_socket[i] != INVALID_SOCKET)
-        {
+    for (int i = 0; i < PICOQUIC_NB_SERVER_SOCKETS; i++) {
+        if (sockets->s_socket[i] != INVALID_SOCKET) {
             SOCKET_CLOSE(sockets->s_socket[i]);
             sockets->s_socket[i] = INVALID_SOCKET;
         }
@@ -155,12 +137,12 @@ uint64_t picoquic_current_time()
 }
 
 int picoquic_recvmsg(SOCKET_TYPE fd,
-    struct sockaddr_storage * addr_from,
-    socklen_t * from_length,
-    struct sockaddr_storage * addr_dest,
-    socklen_t * dest_length,
-    unsigned long * dest_if,
-    uint8_t * buffer, int buffer_max)
+    struct sockaddr_storage* addr_from,
+    socklen_t* from_length,
+    struct sockaddr_storage* addr_dest,
+    socklen_t* dest_length,
+    unsigned long* dest_if,
+    uint8_t* buffer, int buffer_max)
 #ifdef _WINDOWS
 {
     GUID WSARecvMsg_GUID = WSAID_WSARECVMSG;
@@ -174,13 +156,11 @@ int picoquic_recvmsg(SOCKET_TYPE fd,
     int bytes_recv;
     int last_error;
 
-    if (dest_length != NULL)
-    {
+    if (dest_length != NULL) {
         *dest_length = 0;
     }
 
-    if (dest_if != NULL)
-    {
+    if (dest_if != NULL) {
         *dest_if = 0;
     }
 
@@ -195,13 +175,11 @@ int picoquic_recvmsg(SOCKET_TYPE fd,
             (int)fd, last_error);
         bytes_recv = -1;
         *from_length = 0;
-    }
-    else
-    {
+    } else {
         dataBuf.buf = (char*)buffer;
         dataBuf.len = buffer_max;
 
-        msg.name = (struct sockaddr *)addr_from;
+        msg.name = (struct sockaddr*)addr_from;
         msg.namelen = *from_length;
         msg.lpBuffers = &dataBuf;
         msg.dwBufferCount = 1;
@@ -211,52 +189,41 @@ int picoquic_recvmsg(SOCKET_TYPE fd,
 
         recv_ret = WSARecvMsg(fd, &msg, &NumberOfBytes, NULL, NULL);
 
-        if (recv_ret != 0)
-        {
+        if (recv_ret != 0) {
             last_error = WSAGetLastError();
             DBG_PRINTF("Could not receive message (WSARecvMsg) on UDP socket %d = %d!\n",
-                (int) fd, last_error);
+                (int)fd, last_error);
             bytes_recv = -1;
             *from_length = 0;
-        }
-        else
-        {
-            struct cmsghdr *cmsg;
+        } else {
+            struct cmsghdr* cmsg;
 
             bytes_recv = NumberOfBytes;
             *from_length = msg.namelen;
 
             /* Get the control information */
-            for (cmsg = WSA_CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = WSA_CMSG_NXTHDR(&msg, cmsg))
-            {
-                if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO))
-                {
-                    if (addr_dest != NULL && dest_length != NULL)
-                    {
-                        IN_PKTINFO *pPktInfo = (IN_PKTINFO *)WSA_CMSG_DATA(cmsg);
-                        ((struct sockaddr_in *)addr_dest)->sin_family = AF_INET;
-                        ((struct sockaddr_in *)addr_dest)->sin_port = 0;
-                        ((struct sockaddr_in *)addr_dest)->sin_addr.s_addr = pPktInfo->ipi_addr.s_addr;
+            for (cmsg = WSA_CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = WSA_CMSG_NXTHDR(&msg, cmsg)) {
+                if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO)) {
+                    if (addr_dest != NULL && dest_length != NULL) {
+                        IN_PKTINFO* pPktInfo = (IN_PKTINFO*)WSA_CMSG_DATA(cmsg);
+                        ((struct sockaddr_in*)addr_dest)->sin_family = AF_INET;
+                        ((struct sockaddr_in*)addr_dest)->sin_port = 0;
+                        ((struct sockaddr_in*)addr_dest)->sin_addr.s_addr = pPktInfo->ipi_addr.s_addr;
                         *dest_length = sizeof(struct sockaddr_in);
 
-                        if (dest_if != NULL)
-                        {
+                        if (dest_if != NULL) {
                             *dest_if = pPktInfo->ipi_ifindex;
                         }
                     }
-                }
-                else if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO))
-                {
-                    if (addr_dest != NULL && dest_length != NULL)
-                    {
-                        IN6_PKTINFO *pPktInfo6 = (IN6_PKTINFO *)WSA_CMSG_DATA(cmsg);
-                        ((struct sockaddr_in6 *)addr_dest)->sin6_family = AF_INET6;
-                        ((struct sockaddr_in6 *)addr_dest)->sin6_port = 0;
-                        memcpy(&((struct sockaddr_in6 *)addr_dest)->sin6_addr, &pPktInfo6->ipi6_addr, sizeof(IN6_ADDR));
+                } else if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO)) {
+                    if (addr_dest != NULL && dest_length != NULL) {
+                        IN6_PKTINFO* pPktInfo6 = (IN6_PKTINFO*)WSA_CMSG_DATA(cmsg);
+                        ((struct sockaddr_in6*)addr_dest)->sin6_family = AF_INET6;
+                        ((struct sockaddr_in6*)addr_dest)->sin6_port = 0;
+                        memcpy(&((struct sockaddr_in6*)addr_dest)->sin6_addr, &pPktInfo6->ipi6_addr, sizeof(IN6_ADDR));
                         *dest_length = sizeof(struct sockaddr_in6);
 
-                        if (dest_if != NULL)
-                        {
+                        if (dest_if != NULL) {
                             *dest_if = pPktInfo6->ipi6_ifindex;
                         }
                     }
@@ -274,70 +241,57 @@ int picoquic_recvmsg(SOCKET_TYPE fd,
     struct iovec dataBuf;
     char cmsg_buffer[1024];
 
-    if (dest_length != NULL)
-    {
+    if (dest_length != NULL) {
         *dest_length = 0;
     }
 
-    if (dest_if != NULL)
-    {
+    if (dest_if != NULL) {
         *dest_if = 0;
     }
 
     dataBuf.iov_base = (char*)buffer;
     dataBuf.iov_len = buffer_max;
 
-    msg.msg_name = (struct sockaddr *)addr_from;
+    msg.msg_name = (struct sockaddr*)addr_from;
     msg.msg_namelen = *from_length;
     msg.msg_iov = &dataBuf;
     msg.msg_iovlen = 1;
     msg.msg_flags = 0;
-    msg.msg_control = (void *) cmsg_buffer;
+    msg.msg_control = (void*)cmsg_buffer;
     msg.msg_controllen = sizeof(cmsg_buffer);
 
     bytes_recv = recvmsg(fd, &msg, 0);
 
-    if (bytes_recv <= 0) 
-    {
+    if (bytes_recv <= 0) {
         *from_length = 0;
-    }
-    else
-    {
+    } else {
         /* Get the control information */
-        struct cmsghdr *cmsg;
+        struct cmsghdr* cmsg;
         *from_length = msg.msg_namelen;
 
-        for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg))
-        {
-            if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO))
-            {
-                if (addr_dest != NULL && dest_length != NULL)
-                {
-                    struct in_pktinfo *pPktInfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
-                    ((struct sockaddr_in *)addr_dest)->sin_family = AF_INET;
-                    ((struct sockaddr_in *)addr_dest)->sin_port = 0;
-                    ((struct sockaddr_in *)addr_dest)->sin_addr.s_addr = pPktInfo->ipi_addr.s_addr;
+        for (cmsg = CMSG_FIRSTHDR(&msg); cmsg != NULL; cmsg = CMSG_NXTHDR(&msg, cmsg)) {
+            if ((cmsg->cmsg_level == IPPROTO_IP) && (cmsg->cmsg_type == IP_PKTINFO)) {
+                if (addr_dest != NULL && dest_length != NULL) {
+                    struct in_pktinfo* pPktInfo = (struct in_pktinfo*)CMSG_DATA(cmsg);
+                    ((struct sockaddr_in*)addr_dest)->sin_family = AF_INET;
+                    ((struct sockaddr_in*)addr_dest)->sin_port = 0;
+                    ((struct sockaddr_in*)addr_dest)->sin_addr.s_addr = pPktInfo->ipi_addr.s_addr;
                     *dest_length = sizeof(struct sockaddr_in);
 
-                    if (dest_if != NULL)
-                    {
+                    if (dest_if != NULL) {
                         *dest_if = pPktInfo->ipi_ifindex;
                     }
                 }
-            }
-            else if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO))
-            {
-                if (addr_dest != NULL && dest_length != NULL)
-                {
-                    struct in6_pktinfo *pPktInfo6 = (struct in6_pktinfo *)CMSG_DATA(cmsg);
+            } else if ((cmsg->cmsg_level == IPPROTO_IPV6) && (cmsg->cmsg_type == IPV6_PKTINFO)) {
+                if (addr_dest != NULL && dest_length != NULL) {
+                    struct in6_pktinfo* pPktInfo6 = (struct in6_pktinfo*)CMSG_DATA(cmsg);
 
-                    ((struct sockaddr_in6 *)addr_dest)->sin6_family = AF_INET6;
-                    ((struct sockaddr_in6 *)addr_dest)->sin6_port = 0;
-                    memcpy(&((struct sockaddr_in6 *)addr_dest)->sin6_addr, &pPktInfo6->ipi6_addr, sizeof(struct in6_addr));
+                    ((struct sockaddr_in6*)addr_dest)->sin6_family = AF_INET6;
+                    ((struct sockaddr_in6*)addr_dest)->sin6_port = 0;
+                    memcpy(&((struct sockaddr_in6*)addr_dest)->sin6_addr, &pPktInfo6->ipi6_addr, sizeof(struct in6_addr));
                     *dest_length = sizeof(struct sockaddr_in6);
 
-                    if (dest_if != NULL)
-                    {
+                    if (dest_if != NULL) {
                         *dest_if = pPktInfo6->ipi6_ifindex;
                     }
                 }
@@ -345,18 +299,17 @@ int picoquic_recvmsg(SOCKET_TYPE fd,
         }
     }
 
-	return bytes_recv;
+    return bytes_recv;
 }
 #endif
 
-
 int picoquic_sendmsg(SOCKET_TYPE fd,
-    struct sockaddr * addr_dest,
+    struct sockaddr* addr_dest,
     socklen_t dest_length,
-    struct sockaddr * addr_from,
+    struct sockaddr* addr_from,
     socklen_t from_length,
     unsigned long dest_if,
-    const char * bytes, int length)
+    const char* bytes, int length)
 #ifdef _WINDOWS
 {
     GUID WSASendMsg_GUID = WSAID_WSASENDMSG;
@@ -370,8 +323,7 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
     WSABUF dataBuf;
     int bytes_sent;
     int last_error;
-    WSACMSGHDR *cmsg;
-
+    WSACMSGHDR* cmsg;
 
     ret = WSAIoctl(fd, SIO_GET_EXTENSION_FUNCTION_POINTER,
         &WSASendMsg_GUID, sizeof WSASendMsg_GUID,
@@ -383,9 +335,7 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
         DBG_PRINTF("Could not initialize WSARecvMsg) on UDP socket %d= %d!\n",
             (int)fd, last_error);
         bytes_sent = -1;
-    }
-    else
-    {
+    } else {
         /* Format the message header */
 
         memset(&msg, 0, sizeof(msg));
@@ -395,56 +345,48 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
         dataBuf.len = length;
         msg.lpBuffers = &dataBuf;
         msg.dwBufferCount = 1;
-        msg.Control.buf = (char *)cmsg_buffer;
+        msg.Control.buf = (char*)cmsg_buffer;
         msg.Control.len = sizeof(cmsg_buffer);
 
         /* Format the control message */
         cmsg = WSA_CMSG_FIRSTHDR(&msg);
 
-        if (addr_from != NULL && from_length != 0)
-        {
-            if (addr_from->sa_family == AF_INET)
-            {
+        if (addr_from != NULL && from_length != 0) {
+            if (addr_from->sa_family == AF_INET) {
                 memset(cmsg, 0, WSA_CMSG_SPACE(sizeof(struct in_pktinfo)));
                 cmsg->cmsg_level = IPPROTO_IP;
                 cmsg->cmsg_type = IP_PKTINFO;
                 cmsg->cmsg_len = WSA_CMSG_LEN(sizeof(struct in_pktinfo));
-                struct in_pktinfo *pktinfo = (struct in_pktinfo *)WSA_CMSG_DATA(cmsg);
-                pktinfo->ipi_addr.s_addr = ((struct sockaddr_in *)addr_from)->sin_addr.s_addr;
+                struct in_pktinfo* pktinfo = (struct in_pktinfo*)WSA_CMSG_DATA(cmsg);
+                pktinfo->ipi_addr.s_addr = ((struct sockaddr_in*)addr_from)->sin_addr.s_addr;
                 pktinfo->ipi_ifindex = dest_if;
 
                 control_length += WSA_CMSG_SPACE(sizeof(struct in_pktinfo));
-            }
-            else
-            {
+            } else {
                 memset(cmsg, 0, WSA_CMSG_SPACE(sizeof(struct in6_pktinfo)));
                 cmsg->cmsg_level = IPPROTO_IPV6;
                 cmsg->cmsg_type = IPV6_PKTINFO;
                 cmsg->cmsg_len = WSA_CMSG_LEN(sizeof(struct in6_pktinfo));
-                struct in6_pktinfo *pktinfo6 = (struct in6_pktinfo *)WSA_CMSG_DATA(cmsg);
-                memcpy(&pktinfo6->ipi6_addr.u, &((struct sockaddr_in6 *)addr_from)->sin6_addr.u, sizeof(IN6_ADDR));
+                struct in6_pktinfo* pktinfo6 = (struct in6_pktinfo*)WSA_CMSG_DATA(cmsg);
+                memcpy(&pktinfo6->ipi6_addr.u, &((struct sockaddr_in6*)addr_from)->sin6_addr.u, sizeof(IN6_ADDR));
                 pktinfo6->ipi6_ifindex = dest_if;
 
                 control_length += WSA_CMSG_SPACE(sizeof(struct in6_pktinfo));
             }
         }
         msg.Control.len = control_length;
-        if (control_length == 0)
-        {
+        if (control_length == 0) {
             msg.Control.buf = NULL;
         }
 
-		/* Send the message */
+        /* Send the message */
 
         ret = WSASendMsg(fd, &msg, 0, &dwBytesSent, NULL, NULL);
 
-        if (ret != 0)
-        {
+        if (ret != 0) {
             bytes_sent = -1;
-        }
-        else
-        {
-            bytes_sent = (int) dwBytesSent;
+        } else {
+            bytes_sent = (int)dwBytesSent;
         }
     }
 
@@ -457,7 +399,7 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
     char cmsg_buffer[1024];
     int control_length = 0;
     int bytes_sent;
-    struct cmsghdr *cmsg;
+    struct cmsghdr* cmsg;
 
     /* Format the message header */
 
@@ -469,46 +411,39 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
     msg.msg_namelen = dest_length;
     msg.msg_iov = &dataBuf;
     msg.msg_iovlen = 1;
-    msg.msg_control = (void *)cmsg_buffer;
+    msg.msg_control = (void*)cmsg_buffer;
     msg.msg_controllen = sizeof(cmsg_buffer);
 
     /* Format the control message */
     cmsg = CMSG_FIRSTHDR(&msg);
 
-    if (addr_from != NULL && from_length != 0)
-    {
-        if (addr_from->sa_family == AF_INET)
-        {
+    if (addr_from != NULL && from_length != 0) {
+        if (addr_from->sa_family == AF_INET) {
             memset(cmsg, 0, CMSG_SPACE(sizeof(struct in_pktinfo)));
             cmsg->cmsg_level = IPPROTO_IP;
             cmsg->cmsg_type = IP_PKTINFO;
             cmsg->cmsg_len = CMSG_LEN(sizeof(struct in_pktinfo));
-            struct in_pktinfo *pktinfo = (struct in_pktinfo *)CMSG_DATA(cmsg);
-            pktinfo->ipi_addr.s_addr = ((struct sockaddr_in *)addr_from)->sin_addr.s_addr;
+            struct in_pktinfo* pktinfo = (struct in_pktinfo*)CMSG_DATA(cmsg);
+            pktinfo->ipi_addr.s_addr = ((struct sockaddr_in*)addr_from)->sin_addr.s_addr;
             pktinfo->ipi_ifindex = dest_if;
 
             control_length += CMSG_SPACE(sizeof(struct in_pktinfo));
-        }
-        else if (addr_from->sa_family == AF_INET6)
-        {
+        } else if (addr_from->sa_family == AF_INET6) {
             memset(cmsg, 0, CMSG_SPACE(sizeof(struct in6_pktinfo)));
             cmsg->cmsg_level = IPPROTO_IPV6;
             cmsg->cmsg_type = IPV6_PKTINFO;
             cmsg->cmsg_len = CMSG_LEN(sizeof(struct in6_pktinfo));
-            struct in6_pktinfo *pktinfo6 = (struct in6_pktinfo *)CMSG_DATA(cmsg);
-            memcpy(&pktinfo6->ipi6_addr, &((struct sockaddr_in6 *)addr_from)->sin6_addr, sizeof(struct in6_addr));
+            struct in6_pktinfo* pktinfo6 = (struct in6_pktinfo*)CMSG_DATA(cmsg);
+            memcpy(&pktinfo6->ipi6_addr, &((struct sockaddr_in6*)addr_from)->sin6_addr, sizeof(struct in6_addr));
             pktinfo6->ipi6_ifindex = dest_if;
 
             control_length += CMSG_SPACE(sizeof(struct in6_pktinfo));
-        }
-        else
-        {
+        } else {
             DBG_PRINTF("Unexpected address family: %d\n", addr_from->sa_family);
         }
     }
     msg.msg_controllen = control_length;
-    if (control_length == 0)
-    {
+    if (control_length == 0) {
         msg.msg_control = NULL;
     }
 
@@ -518,18 +453,18 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
 }
 #endif
 
-int picoquic_select(SOCKET_TYPE * sockets, 
-	int nb_sockets,
-    struct sockaddr_storage * addr_from,
-    socklen_t * from_length,
-    struct sockaddr_storage * addr_dest,
-    socklen_t * dest_length,
-	unsigned long * dest_if,
-    uint8_t * buffer, int buffer_max,
+int picoquic_select(SOCKET_TYPE* sockets,
+    int nb_sockets,
+    struct sockaddr_storage* addr_from,
+    socklen_t* from_length,
+    struct sockaddr_storage* addr_dest,
+    socklen_t* dest_length,
+    unsigned long* dest_if,
+    uint8_t* buffer, int buffer_max,
     int64_t delta_t,
-    uint64_t * current_time)
+    uint64_t* current_time)
 {
-    fd_set   readfds;
+    fd_set readfds;
     struct timeval tv;
     int ret_select = 0;
     int bytes_recv = 0;
@@ -537,29 +472,21 @@ int picoquic_select(SOCKET_TYPE * sockets,
 
     FD_ZERO(&readfds);
 
-    for (int i = 0; i < nb_sockets; i++)
-    {
-        if (sockmax < (int)sockets[i])
-        {
+    for (int i = 0; i < nb_sockets; i++) {
+        if (sockmax < (int)sockets[i]) {
             sockmax = (int)sockets[i];
         }
         FD_SET(sockets[i], &readfds);
     }
 
-    if (delta_t <= 0)
-    {
+    if (delta_t <= 0) {
         tv.tv_sec = 0;
         tv.tv_usec = 0;
-    }
-    else
-    {
-        if (delta_t > 10000000)
-        {
+    } else {
+        if (delta_t > 10000000) {
             tv.tv_sec = (long)10;
             tv.tv_usec = 0;
-        }
-        else
-        {
+        } else {
             tv.tv_sec = (long)(delta_t / 1000000);
             tv.tv_usec = (long)(delta_t % 1000000);
         }
@@ -567,32 +494,24 @@ int picoquic_select(SOCKET_TYPE * sockets,
 
     ret_select = select(sockmax + 1, &readfds, NULL, NULL, &tv);
 
-    if (ret_select < 0)
-    {
+    if (ret_select < 0) {
         bytes_recv = -1;
-        if (bytes_recv <= 0)
-        {
+        if (bytes_recv <= 0) {
             DBG_PRINTF("Error: select returns %d\n", ret_select);
         }
-    }
-    else if (ret_select > 0)
-    {
-        for (int i = 0; i < nb_sockets; i++)
-        {
-            if (FD_ISSET(sockets[i], &readfds))
-            {
-                bytes_recv = picoquic_recvmsg(sockets[i], addr_from, from_length, 
-				addr_dest, dest_length, dest_if, 
-				buffer, buffer_max);
-				// bytes_recv = recvfrom(socket[i], buffer, buffer_max, 0, addr_from, from_length);
+    } else if (ret_select > 0) {
+        for (int i = 0; i < nb_sockets; i++) {
+            if (FD_ISSET(sockets[i], &readfds)) {
+                bytes_recv = picoquic_recvmsg(sockets[i], addr_from, from_length,
+                    addr_dest, dest_length, dest_if,
+                    buffer, buffer_max);
+                // bytes_recv = recvfrom(socket[i], buffer, buffer_max, 0, addr_from, from_length);
 
-                if (bytes_recv <= 0)
-                {
+                if (bytes_recv <= 0) {
 #ifdef _WINDOWS
                     int last_error = WSAGetLastError();
 
-                    if (last_error == WSAECONNRESET)
-                    {
+                    if (last_error == WSAECONNRESET) {
                         bytes_recv = 0;
                         continue;
                     }
@@ -601,9 +520,7 @@ int picoquic_select(SOCKET_TYPE * sockets,
                         i, (int)sockets[i]);
 
                     break;
-                }
-                else
-                {
+                } else {
                     break;
                 }
             }
@@ -616,10 +533,10 @@ int picoquic_select(SOCKET_TYPE * sockets,
 }
 
 int picoquic_send_through_server_sockets(
-    picoquic_server_sockets_t * sockets,
-    struct sockaddr * addr_dest, socklen_t dest_length,
-    struct sockaddr * addr_from, socklen_t from_length, unsigned long from_if,
-    const char * bytes, int length)
+    picoquic_server_sockets_t* sockets,
+    struct sockaddr* addr_dest, socklen_t dest_length,
+    struct sockaddr* addr_from, socklen_t from_length, unsigned long from_if,
+    const char* bytes, int length)
 {
     /* Both Linux and Windows use separate sockets for V4 and V6 */
     int socket_index = (addr_dest->sa_family == AF_INET) ? 1 : 0;
@@ -627,8 +544,7 @@ int picoquic_send_through_server_sockets(
     int sent = picoquic_sendmsg(sockets->s_socket[socket_index], addr_dest, dest_length,
         addr_from, from_length, from_if, bytes, length);
 
-    if (sent <= 0)
-    {
+    if (sent <= 0) {
 #ifdef _WINDOWS
         int last_error = WSAGetLastError();
 #else
@@ -643,39 +559,34 @@ int picoquic_send_through_server_sockets(
     return sent;
 }
 
-int picoquic_get_server_address(const char * ip_address_text, int server_port, 
-    struct sockaddr_storage *server_address,
-    int * server_addr_length,
-    int * is_name)
+int picoquic_get_server_address(const char* ip_address_text, int server_port,
+    struct sockaddr_storage* server_address,
+    int* server_addr_length,
+    int* is_name)
 {
     int ret = 0;
-    struct sockaddr_in * ipv4_dest = (struct sockaddr_in *)server_address;
-    struct sockaddr_in6 * ipv6_dest = (struct sockaddr_in6 *)server_address;
+    struct sockaddr_in* ipv4_dest = (struct sockaddr_in*)server_address;
+    struct sockaddr_in6* ipv6_dest = (struct sockaddr_in6*)server_address;
 
     /* get the IP address of the server */
     memset(server_address, 0, sizeof(struct sockaddr_storage));
     *is_name = 0;
     *server_addr_length = 0;
 
-    if (inet_pton(AF_INET, ip_address_text, &ipv4_dest->sin_addr) == 1)
-    {
+    if (inet_pton(AF_INET, ip_address_text, &ipv4_dest->sin_addr) == 1) {
         /* Valid IPv4 address */
         ipv4_dest->sin_family = AF_INET;
         ipv4_dest->sin_port = htons((u_short)server_port);
         *server_addr_length = sizeof(struct sockaddr_in);
-    }
-    else if (inet_pton(AF_INET6, ip_address_text, &ipv6_dest->sin6_addr) == 1)
-    {
+    } else if (inet_pton(AF_INET6, ip_address_text, &ipv6_dest->sin6_addr) == 1) {
         /* Valid IPv6 address */
         ipv6_dest->sin6_family = AF_INET6;
         ipv6_dest->sin6_port = htons((u_short)server_port);
         *server_addr_length = sizeof(struct sockaddr_in6);
-    }
-    else
-    {
+    } else {
         /* Server is described by name. Do a lookup for the IP address,
         * and then use the name as SNI parameter */
-        struct addrinfo *result = NULL;
+        struct addrinfo* result = NULL;
         struct addrinfo hints;
 
         memset(&hints, 0, sizeof(hints));
@@ -683,26 +594,20 @@ int picoquic_get_server_address(const char * ip_address_text, int server_port,
         hints.ai_socktype = SOCK_DGRAM;
         hints.ai_protocol = IPPROTO_UDP;
 
-        if (getaddrinfo(ip_address_text, NULL, &hints, &result) != 0)
-        {
+        if (getaddrinfo(ip_address_text, NULL, &hints, &result) != 0) {
             fprintf(stderr, "Cannot get IP address for %s\n", ip_address_text);
             ret = -1;
-        }
-        else
-        {
+        } else {
             *is_name = 1;
 
-            switch (result->ai_family)
-            {
+            switch (result->ai_family) {
             case AF_INET:
                 ipv4_dest->sin_family = AF_INET;
                 ipv4_dest->sin_port = htons((u_short)server_port);
 #ifdef _WINDOWS
-                ipv4_dest->sin_addr.S_un.S_addr =
-                    ((struct sockaddr_in *) result->ai_addr)->sin_addr.S_un.S_addr;
+                ipv4_dest->sin_addr.S_un.S_addr = ((struct sockaddr_in*)result->ai_addr)->sin_addr.S_un.S_addr;
 #else
-                ipv4_dest->sin_addr.s_addr =
-                    ((struct sockaddr_in *) result->ai_addr)->sin_addr.s_addr;
+                ipv4_dest->sin_addr.s_addr = ((struct sockaddr_in*)result->ai_addr)->sin_addr.s_addr;
 #endif
                 *server_addr_length = sizeof(struct sockaddr_in);
                 break;
@@ -710,7 +615,7 @@ int picoquic_get_server_address(const char * ip_address_text, int server_port,
                 ipv6_dest->sin6_family = AF_INET6;
                 ipv6_dest->sin6_port = htons((u_short)server_port);
                 memcpy(&ipv6_dest->sin6_addr,
-                    &((struct sockaddr_in6 *) result->ai_addr)->sin6_addr,
+                    &((struct sockaddr_in6*)result->ai_addr)->sin6_addr,
                     sizeof(ipv6_dest->sin6_addr));
                 *server_addr_length = sizeof(struct sockaddr_in6);
                 break;

--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -24,18 +24,18 @@
 
 #ifdef _WINDOWS
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
-#include <assert.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <WinSock2.h>
-#include <iphlpapi.h>
-#include <ws2tcpip.h>
 #include <Mswsock.h>
+#include <WinSock2.h>
+#include <Windows.h>
 #include <Ws2def.h>
+#include <assert.h>
+#include <iphlpapi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <ws2tcpip.h>
 
-#ifndef SOCKET_TYPE 
+#ifndef SOCKET_TYPE
 #define SOCKET_TYPE SOCKET
 #endif
 #ifndef SOCKET_CLOSE
@@ -48,23 +48,23 @@
 #define WSA_START(x, y) WSAStartup((x), (y))
 #endif
 #ifndef WSA_LAST_ERROR
-#define WSA_LAST_ERROR(x)  WSAGetLastError()
+#define WSA_LAST_ERROR(x) WSAGetLastError()
 #endif
 #ifndef socklen_t
 #define socklen_t int
-#endif 
+#endif
 
-#else  /* Linux */
+#else /* Linux */
 
-#include <stdint.h>
 #include "getopt.h"
-#include <stdlib.h>
 #include <alloca.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
 
 #ifndef __USE_XOPEN2K
@@ -80,16 +80,16 @@
 #define __APPLE_USE_RFC_3542 /* IPV6_PKTINFO */
 #endif
 
+#include <arpa/inet.h>
+#include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 #include <sys/select.h>
-#include <errno.h>
 
-#ifndef SOCKET_TYPE 
+#ifndef SOCKET_TYPE
 #define SOCKET_TYPE int
 #endif
-#ifndef INVALID_SOCKET 
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET -1
 #endif
 #ifndef SOCKET_CLOSE
@@ -100,38 +100,37 @@
 #endif
 #endif
 
-
 #define PICOQUIC_NB_SERVER_SOCKETS 2
 
 typedef struct st_picoquic_server_sockets_t {
     SOCKET_TYPE s_socket[PICOQUIC_NB_SERVER_SOCKETS];
 } picoquic_server_sockets_t;
 
-int picoquic_open_server_sockets(picoquic_server_sockets_t * sockets, int port);
+int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port);
 
-void picoquic_close_server_sockets(picoquic_server_sockets_t * sockets);
+void picoquic_close_server_sockets(picoquic_server_sockets_t* sockets);
 
 uint64_t picoquic_current_time();
 
-int picoquic_select(SOCKET_TYPE * sockets, int nb_sockets,
-    struct sockaddr_storage * addr_from,
-    socklen_t * from_length,
-    struct sockaddr_storage * addr_dest,
-    socklen_t * dest_length,
-    unsigned long * dest_if,
-    uint8_t * buffer, int buffer_max,
+int picoquic_select(SOCKET_TYPE* sockets, int nb_sockets,
+    struct sockaddr_storage* addr_from,
+    socklen_t* from_length,
+    struct sockaddr_storage* addr_dest,
+    socklen_t* dest_length,
+    unsigned long* dest_if,
+    uint8_t* buffer, int buffer_max,
     int64_t delta_t,
-    uint64_t * current_time);
+    uint64_t* current_time);
 
 int picoquic_send_through_server_sockets(
-    picoquic_server_sockets_t * sockets,
-    struct sockaddr * addr_dest, socklen_t addr_length,
-    struct sockaddr * addr_from, socklen_t from_length, unsigned long from_if,
-    const char * bytes, int length);
+    picoquic_server_sockets_t* sockets,
+    struct sockaddr* addr_dest, socklen_t addr_length,
+    struct sockaddr* addr_from, socklen_t from_length, unsigned long from_if,
+    const char* bytes, int length);
 
-int picoquic_get_server_address(const char * ip_address_text, int server_port,
-    struct sockaddr_storage *server_address,
-    int * server_addr_length,
-    int * is_name);
+int picoquic_get_server_address(const char* ip_address_text, int server_port,
+    struct sockaddr_storage* server_address,
+    int* server_addr_length,
+    int* is_name);
 
 #endif

--- a/picoquic/picotlsapi.h
+++ b/picoquic/picotlsapi.h
@@ -22,27 +22,15 @@
 #ifndef PICOTLSAPI_H
 #define PICOTLSAPI_H
 
+typedef struct st_ptls_buffer_t ptls_buffer_t;
 
-#ifndef picotls_h
-/*
- * define here the picotls struct used for storing output
- */
-typedef struct st_ptls_buffer_t {
-    uint8_t *base;
-    size_t capacity;
-    size_t off;
-    int is_allocated;
-} ptls_buffer_t;
-#endif
-
-typedef struct _picotlsapi
-{
-    void* (*get_session_context)(void *);
-    int(*process_handshake)(void*, ptls_buffer_t *, const void *, size_t *, void *);
-    int(*get_1rtt_key)(void*, const void *, size_t *);
-    int(*get_0rtt_key)(void*,const void *, size_t *);
-    int(*get_resume_ticket)(void*, const void *, size_t *);
-    int(*set_resume_ticket)(void*, const void *, size_t *);
+typedef struct _picotlsapi {
+    void* (*get_session_context)(void*);
+    int (*process_handshake)(void*, ptls_buffer_t*, const void*, size_t*, void*);
+    int (*get_1rtt_key)(void*, const void*, size_t*);
+    int (*get_0rtt_key)(void*, const void*, size_t*);
+    int (*get_resume_ticket)(void*, const void*, size_t*);
+    int (*set_resume_ticket)(void*, const void*, size_t*);
 } picotlsapi;
 
 #endif /* PICOTLSAPI_H */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -19,64 +19,62 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdlib.h>
-#include <string.h>
 #include "picoquic_internal.h"
 #include "tls_api.h"
+#include <stdlib.h>
+#include <string.h>
 
 /*
  * Default congestion algorithm
  */
-extern picoquic_congestion_algorithm_t * picoquic_newreno_algorithm;
+extern picoquic_congestion_algorithm_t* picoquic_newreno_algorithm;
 
 #define PICOQUIC_DEFAULT_CONGESTION_ALGORITHM picoquic_newreno_algorithm;
 
 /*
 * Structures used in the hash table of connections
 */
-typedef struct st_picoquic_cnx_id_t
-{
+typedef struct st_picoquic_cnx_id_t {
     uint64_t cnx_id;
-    picoquic_cnx_t * cnx;
-    struct st_picoquic_cnx_id_t * next_cnx_id;
+    picoquic_cnx_t* cnx;
+    struct st_picoquic_cnx_id_t* next_cnx_id;
 } picoquic_cnx_id;
 
-typedef struct st_picoquic_net_id_t
-{
+typedef struct st_picoquic_net_id_t {
     struct sockaddr_storage saddr;
-    picoquic_cnx_t * cnx;
-    struct st_picoquic_net_id_t * next_net_id;
+    picoquic_cnx_t* cnx;
+    struct st_picoquic_net_id_t* next_net_id;
 } picoquic_net_id;
 
 /* Hash and compare for CNX hash tables */
-static uint64_t picoquic_cnx_id_hash(void * key)
+static uint64_t picoquic_cnx_id_hash(void* key)
 {
-    picoquic_cnx_id * cid = (picoquic_cnx_id *)key;
+    picoquic_cnx_id* cid = (picoquic_cnx_id*)key;
 
     /* TODO: should scramble the value for security and DOS protection */
 
     return cid->cnx_id;
 }
 
-static int picoquic_cnx_id_compare(void * key1, void * key2)
+static int picoquic_cnx_id_compare(void* key1, void* key2)
 {
-    picoquic_cnx_id * cid1 = (picoquic_cnx_id *)key1;
-    picoquic_cnx_id * cid2 = (picoquic_cnx_id *)key2;
+    picoquic_cnx_id* cid1 = (picoquic_cnx_id*)key1;
+    picoquic_cnx_id* cid2 = (picoquic_cnx_id*)key2;
 
     return (cid1->cnx_id == cid2->cnx_id) ? 0 : -1;
 }
 
-static uint64_t picoquic_net_id_hash(void * key)
+static uint64_t picoquic_net_id_hash(void* key)
 {
-    picoquic_net_id * net = (picoquic_net_id *)key;
+    picoquic_net_id* net = (picoquic_net_id*)key;
 
-    return picohash_bytes((uint8_t *)&net->saddr, sizeof(net->saddr));
+    return picohash_bytes((uint8_t*)&net->saddr, sizeof(net->saddr));
 }
 
-static int picoquic_net_id_compare(void * key1, void * key2)
+static int picoquic_net_id_compare(void* key1, void* key2)
 {
-    picoquic_net_id * net1 = (picoquic_net_id *)key1;
-    picoquic_net_id * net2 = (picoquic_net_id *)key2;
+    picoquic_net_id* net1 = (picoquic_net_id*)key1;
+    picoquic_net_id* net2 = (picoquic_net_id*)key2;
 
     return memcmp(&net1->saddr, &net2->saddr, sizeof(net1->saddr));
 }
@@ -91,67 +89,65 @@ static int picoquic_net_id_compare(void * key1, void * key2)
 static uint8_t picoquic_cleartext_internal_test_1_salt[] = {
     0x30, 0x67, 0x16, 0xd7, 0x63, 0x75, 0xd5, 0x55,
     0x4b, 0x2f, 0x60, 0x5e, 0xef, 0x78, 0xd8, 0x33,
-    0x3d, 0xc1, 0xca, 0x36 };
+    0x3d, 0xc1, 0xca, 0x36
+};
 
 static uint8_t picoquic_cleartext_version_1_salt[] = {
     0xaf, 0xc8, 0x24, 0xec, 0x5f, 0xc7, 0x7e, 0xca,
     0x1e, 0x9d, 0x36, 0xf3, 0x7f, 0xb2, 0xd4, 0x65,
-    0x18, 0xc3, 0x66, 0x39 };
+    0x18, 0xc3, 0x66, 0x39
+};
 
 const picoquic_version_parameters_t picoquic_supported_versions[] = {
     { PICOQUIC_INTERNAL_TEST_VERSION_1, 0,
-    picoquic_version_header_08,
-    sizeof(picoquic_cleartext_internal_test_1_salt), 
-    picoquic_cleartext_internal_test_1_salt },
+        picoquic_version_header_08,
+        sizeof(picoquic_cleartext_internal_test_1_salt),
+        picoquic_cleartext_internal_test_1_salt },
     { PICOQUIC_THIRD_INTEROP_VERSION, 0,
-    picoquic_version_header_08,
-    sizeof(picoquic_cleartext_version_1_salt),
-    picoquic_cleartext_version_1_salt }
+        picoquic_version_header_08,
+        sizeof(picoquic_cleartext_version_1_salt),
+        picoquic_cleartext_version_1_salt }
 };
 
-const size_t picoquic_nb_supported_versions = sizeof(picoquic_supported_versions) / 
-    sizeof(picoquic_version_parameters_t);
+const size_t picoquic_nb_supported_versions = sizeof(picoquic_supported_versions) / sizeof(picoquic_version_parameters_t);
 
 /* QUIC context create and dispose */
-picoquic_quic_t * picoquic_create(uint32_t nb_connections, 
-	char const * cert_file_name,
-	char const * key_file_name,
-	char const * default_alpn,
-	picoquic_stream_data_cb_fn default_callback_fn,
-	void * default_callback_ctx,
-	cnx_id_cb_fn cnx_id_callback,
-	void * cnx_id_callback_ctx,
-	uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
+picoquic_quic_t* picoquic_create(uint32_t nb_connections,
+    char const* cert_file_name,
+    char const* key_file_name,
+    char const* default_alpn,
+    picoquic_stream_data_cb_fn default_callback_fn,
+    void* default_callback_ctx,
+    cnx_id_cb_fn cnx_id_callback,
+    void* cnx_id_callback_ctx,
+    uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
     uint64_t current_time,
-    uint64_t * p_simulated_time,
-    char const * ticket_file_name,
-    const uint8_t * ticket_encryption_key,
+    uint64_t* p_simulated_time,
+    char const* ticket_file_name,
+    const uint8_t* ticket_encryption_key,
     size_t ticket_encryption_key_length)
 {
-    picoquic_quic_t * quic = (picoquic_quic_t *)malloc(sizeof(picoquic_quic_t));
+    picoquic_quic_t* quic = (picoquic_quic_t*)malloc(sizeof(picoquic_quic_t));
     int ret = 0;
 
-    if (quic != NULL)
-    {
+    if (quic != NULL) {
         /* TODO: winsock init */
         /* TODO: open UDP sockets - maybe */
         memset(quic, 0, sizeof(picoquic_quic_t));
 
-		quic->default_callback_fn = default_callback_fn;
-		quic->default_callback_ctx = default_callback_ctx;
-		quic->default_congestion_alg = PICOQUIC_DEFAULT_CONGESTION_ALGORITHM;
-		quic->default_alpn = picoquic_string_duplicate(default_alpn);
-		quic->cnx_id_callback_fn = cnx_id_callback;
-		quic->cnx_id_callback_ctx = cnx_id_callback_ctx;
+        quic->default_callback_fn = default_callback_fn;
+        quic->default_callback_ctx = default_callback_ctx;
+        quic->default_congestion_alg = PICOQUIC_DEFAULT_CONGESTION_ALGORITHM;
+        quic->default_alpn = picoquic_string_duplicate(default_alpn);
+        quic->cnx_id_callback_fn = cnx_id_callback;
+        quic->cnx_id_callback_ctx = cnx_id_callback_ctx;
         quic->p_simulated_time = p_simulated_time;
 
-		if (cnx_id_callback != NULL)
-		{
-			quic->flags |= picoquic_context_unconditional_cnx_id;
-		}
+        if (cnx_id_callback != NULL) {
+            quic->flags |= picoquic_context_unconditional_cnx_id;
+        }
 
-        if (ticket_file_name != NULL)
-        {
+        if (ticket_file_name != NULL) {
             quic->ticket_file_name = ticket_file_name;
             ret = picoquic_load_tickets(&quic->p_first_ticket, current_time, ticket_file_name);
         }
@@ -162,83 +158,68 @@ picoquic_quic_t * picoquic_create(uint32_t nb_connections,
         quic->table_cnx_by_net = picohash_create(nb_connections * 4,
             picoquic_net_id_hash, picoquic_net_id_compare);
 
-        if (quic->table_cnx_by_id == NULL ||
-            quic->table_cnx_by_net == NULL ||
-            picoquic_master_tlscontext(quic, cert_file_name, key_file_name,
-                ticket_encryption_key, ticket_encryption_key_length) != 0)
-        {
+        if (quic->table_cnx_by_id == NULL || quic->table_cnx_by_net == NULL || picoquic_master_tlscontext(quic, cert_file_name, key_file_name, ticket_encryption_key, ticket_encryption_key_length) != 0) {
             picoquic_free(quic);
             quic = NULL;
-        }
-		else
-		{
-			/* the random generator was initialized as part of the TLS context. 
+        } else {
+            /* the random generator was initialized as part of the TLS context. 
 			 * Use it to create the seed for generating the per context stateless
 			 * resets. */
 
-			if (!reset_seed)
-				picoquic_crypto_random(quic, quic->reset_seed, sizeof(quic->reset_seed));
-			else
-				memcpy(quic->reset_seed, reset_seed, sizeof(quic->reset_seed));
-		}
+            if (!reset_seed)
+                picoquic_crypto_random(quic, quic->reset_seed, sizeof(quic->reset_seed));
+            else
+                memcpy(quic->reset_seed, reset_seed, sizeof(quic->reset_seed));
+        }
     }
 
     return quic;
 }
 
-void picoquic_free(picoquic_quic_t * quic)
+void picoquic_free(picoquic_quic_t* quic)
 {
-    if (quic != NULL)
-    {
-        if (quic->aead_encrypt_ticket_ctx != NULL)
-        {
+    if (quic != NULL) {
+        if (quic->aead_encrypt_ticket_ctx != NULL) {
             picoquic_aead_free(quic->aead_encrypt_ticket_ctx);
             quic->aead_encrypt_ticket_ctx = NULL;
         }
 
-        if (quic->aead_decrypt_ticket_ctx != NULL)
-        {
+        if (quic->aead_decrypt_ticket_ctx != NULL) {
             picoquic_aead_free(quic->aead_decrypt_ticket_ctx);
             quic->aead_decrypt_ticket_ctx = NULL;
         }
 
-		if (quic->default_alpn != NULL)
-		{
-			free((void*)quic->default_alpn);
-			quic->default_alpn = NULL;
-		}
+        if (quic->default_alpn != NULL) {
+            free((void*)quic->default_alpn);
+            quic->default_alpn = NULL;
+        }
 
         /* delete the stored tickets */
         picoquic_free_tickets(&quic->p_first_ticket);
 
-		/* delete all pending packets */
-		while (quic->pending_stateless_packet != NULL)
-		{
-			picoquic_stateless_packet_t * to_delete = quic->pending_stateless_packet;
-			quic->pending_stateless_packet = to_delete->next_packet;
-			free(to_delete);
-		}
+        /* delete all pending packets */
+        while (quic->pending_stateless_packet != NULL) {
+            picoquic_stateless_packet_t* to_delete = quic->pending_stateless_packet;
+            quic->pending_stateless_packet = to_delete->next_packet;
+            free(to_delete);
+        }
 
         /* delete all the connection contexts */
-        while (quic->cnx_list != NULL)
-        {
+        while (quic->cnx_list != NULL) {
             picoquic_delete_cnx(quic->cnx_list);
         }
 
-        if (quic->table_cnx_by_id != NULL)
-        {
+        if (quic->table_cnx_by_id != NULL) {
             picohash_delete(quic->table_cnx_by_id, 1);
         }
 
-        if (quic->table_cnx_by_net != NULL)
-        {
+        if (quic->table_cnx_by_net != NULL) {
             picohash_delete(quic->table_cnx_by_net, 1);
         }
 
         /* Delete the picotls context */
-        if (quic->tls_master_ctx != NULL)
-        {
-			picoquic_master_tlscontext_free(quic);
+        if (quic->tls_master_ctx != NULL) {
+            picoquic_master_tlscontext_free(quic);
 
             free(quic->tls_master_ctx);
             quic->tls_master_ctx = NULL;
@@ -246,84 +227,72 @@ void picoquic_free(picoquic_quic_t * quic)
     }
 }
 
-void picoquic_set_cookie_mode(picoquic_quic_t * quic, int cookie_mode)
+void picoquic_set_cookie_mode(picoquic_quic_t* quic, int cookie_mode)
 {
-    if (cookie_mode)
-    {
+    if (cookie_mode) {
         quic->flags |= picoquic_context_check_cookie;
         picoquic_crypto_random(quic, quic->retry_seed, PICOQUIC_RETRY_SECRET_SIZE);
-    }
-    else
-    {
+    } else {
         quic->flags &= ~picoquic_context_check_cookie;
     }
 }
 
-picoquic_stateless_packet_t * picoquic_create_stateless_packet(picoquic_quic_t * quic)
+picoquic_stateless_packet_t* picoquic_create_stateless_packet(picoquic_quic_t* quic)
 {
-	return (picoquic_stateless_packet_t *)malloc(sizeof(picoquic_stateless_packet_t));
+    return (picoquic_stateless_packet_t*)malloc(sizeof(picoquic_stateless_packet_t));
 }
 
-void picoquic_delete_stateless_packet(picoquic_stateless_packet_t * sp)
+void picoquic_delete_stateless_packet(picoquic_stateless_packet_t* sp)
 {
-	free(sp);
+    free(sp);
 }
 
-void picoquic_queue_stateless_packet(picoquic_quic_t * quic, picoquic_stateless_packet_t * sp)
+void picoquic_queue_stateless_packet(picoquic_quic_t* quic, picoquic_stateless_packet_t* sp)
 {
-	picoquic_stateless_packet_t ** pnext = &quic->pending_stateless_packet;
+    picoquic_stateless_packet_t** pnext = &quic->pending_stateless_packet;
 
-	while ((*pnext) != NULL)
-	{
-		pnext = &(*pnext)->next_packet;
-	}
+    while ((*pnext) != NULL) {
+        pnext = &(*pnext)->next_packet;
+    }
 
-	*pnext = sp;
-	sp->next_packet = NULL;
+    *pnext = sp;
+    sp->next_packet = NULL;
 }
 
-picoquic_stateless_packet_t * picoquic_dequeue_stateless_packet(picoquic_quic_t * quic)
+picoquic_stateless_packet_t* picoquic_dequeue_stateless_packet(picoquic_quic_t* quic)
 {
-	picoquic_stateless_packet_t * sp = quic->pending_stateless_packet;
+    picoquic_stateless_packet_t* sp = quic->pending_stateless_packet;
 
-	if (sp != NULL)
-	{
-		quic->pending_stateless_packet = sp->next_packet;
-		sp->next_packet = NULL;
-	}
+    if (sp != NULL) {
+        quic->pending_stateless_packet = sp->next_packet;
+        sp->next_packet = NULL;
+    }
 
-	return sp;
+    return sp;
 }
 
 /* Connection context creation and registration */
-int picoquic_register_cnx_id(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uint64_t cnx_id)
+int picoquic_register_cnx_id(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t cnx_id)
 {
     int ret = 0;
-    picohash_item * item;
-    picoquic_cnx_id * key = (picoquic_cnx_id *)malloc(sizeof(picoquic_cnx_id));
+    picohash_item* item;
+    picoquic_cnx_id* key = (picoquic_cnx_id*)malloc(sizeof(picoquic_cnx_id));
 
-    if (key == NULL)
-    {
+    if (key == NULL) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         key->cnx_id = cnx_id;
         key->cnx = cnx;
         key->next_cnx_id = NULL;
 
         item = picohash_retrieve(quic->table_cnx_by_id, key);
 
-        if (item != NULL)
-        {
+        if (item != NULL) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             ret = picohash_insert(quic->table_cnx_by_id, key);
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 key->next_cnx_id = cnx->first_cnx_id;
                 cnx->first_cnx_id = key;
             }
@@ -333,141 +302,109 @@ int picoquic_register_cnx_id(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uint6
     return ret;
 }
 
-int picoquic_register_net_id(picoquic_quic_t * quic, picoquic_cnx_t * cnx, struct sockaddr * addr)
+int picoquic_register_net_id(picoquic_quic_t* quic, picoquic_cnx_t* cnx, struct sockaddr* addr)
 {
     int ret = 0;
-    picohash_item * item;
-    picoquic_net_id * key = (picoquic_net_id *)malloc(sizeof(picoquic_net_id));
+    picohash_item* item;
+    picoquic_net_id* key = (picoquic_net_id*)malloc(sizeof(picoquic_net_id));
 
-    if (key == NULL)
-    {
+    if (key == NULL) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         memset(&key->saddr, 0, sizeof(key->saddr));
-        if (addr->sa_family == AF_INET)
-        {
+        if (addr->sa_family == AF_INET) {
             memcpy(&key->saddr, addr, sizeof(struct sockaddr_in));
-        }
-        else
-        {
+        } else {
             memcpy(&key->saddr, addr, sizeof(struct sockaddr_in6));
         }
         key->cnx = cnx;
 
         item = picohash_retrieve(quic->table_cnx_by_net, key);
 
-        if (item != NULL)
-        {
+        if (item != NULL) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             ret = picohash_insert(quic->table_cnx_by_net, key);
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 key->next_net_id = cnx->first_net_id;
                 cnx->first_net_id = key;
             }
         }
     }
 
-    if (key != NULL && ret != 0)
-    {
+    if (key != NULL && ret != 0) {
         free(key);
     }
 
     return ret;
 }
 
-void picoquic_init_transport_parameters(picoquic_transport_parameters * tp, int is_server)
+void picoquic_init_transport_parameters(picoquic_transport_parameters* tp, int is_server)
 {
-	tp->initial_max_stream_data = 65535;
-	tp->initial_max_data = 0x100000;
-    if (is_server == 0)
-    {
+    tp->initial_max_stream_data = 65535;
+    tp->initial_max_data = 0x100000;
+    if (is_server == 0) {
         tp->initial_max_stream_id_bidir = 65533;
         tp->initial_max_stream_id_unidir = 65535;
-    }
-    else
-    {
+    } else {
         tp->initial_max_stream_id_bidir = 65532;
         tp->initial_max_stream_id_unidir = 65534;
-
     }
-	tp->idle_timeout = 30;
-	tp->omit_connection_id = 0;
-	tp->max_packet_size = PICOQUIC_MAX_PACKET_SIZE - 16 - 40;
+    tp->idle_timeout = 30;
+    tp->omit_connection_id = 0;
+    tp->max_packet_size = PICOQUIC_MAX_PACKET_SIZE - 16 - 40;
     tp->ack_delay_exponent = 3;
 }
 
-static void picoquic_insert_cnx_by_wake_time(picoquic_quic_t * quic, picoquic_cnx_t * cnx)
+static void picoquic_insert_cnx_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
 {
-    picoquic_cnx_t * cnx_next = quic->cnx_list;
-    picoquic_cnx_t * previous = NULL;
-    while (cnx_next != NULL &&
-        cnx_next->next_wake_time <= cnx->next_wake_time)
-    {
+    picoquic_cnx_t* cnx_next = quic->cnx_list;
+    picoquic_cnx_t* previous = NULL;
+    while (cnx_next != NULL && cnx_next->next_wake_time <= cnx->next_wake_time) {
         previous = cnx_next;
         cnx_next = cnx_next->next_in_table;
     }
 
     cnx->previous_in_table = previous;
-    if (previous == NULL)
-    {
+    if (previous == NULL) {
         quic->cnx_list = cnx;
-    }
-    else
-    {
+    } else {
         previous->next_in_table = cnx;
     }
 
     cnx->next_in_table = cnx_next;
 
-    if (cnx_next == NULL)
-    {
+    if (cnx_next == NULL) {
         quic->cnx_last = cnx;
-    }
-    else
-    {
+    } else {
         cnx_next->previous_in_table = cnx;
     }
 }
 
-void picoquic_reinsert_by_wake_time(picoquic_quic_t * quic, picoquic_cnx_t * cnx)
+void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
 {
-    if (cnx->next_in_table == NULL)
-    {
+    if (cnx->next_in_table == NULL) {
         quic->cnx_last = cnx->previous_in_table;
-    }
-    else
-    {
+    } else {
         cnx->next_in_table->previous_in_table = cnx->previous_in_table;
     }
 
-    if (cnx->previous_in_table == NULL)
-    {
+    if (cnx->previous_in_table == NULL) {
         quic->cnx_list = cnx->next_in_table;
-    }
-    else
-    {
+    } else {
         cnx->previous_in_table->next_in_table = cnx->next_in_table;
     }
 
     picoquic_insert_cnx_by_wake_time(quic, cnx);
 }
 
-
 int picoquic_get_version_index(uint32_t proposed_version)
 {
     int ret = -1;
 
-    for (size_t i = 0; i < picoquic_nb_supported_versions; i++)
-    {
-        if (picoquic_supported_versions[i].version == proposed_version)
-        {
+    for (size_t i = 0; i < picoquic_nb_supported_versions; i++) {
+        if (picoquic_supported_versions[i].version == proposed_version) {
             ret = (int)i;
             break;
         }
@@ -476,15 +413,14 @@ int picoquic_get_version_index(uint32_t proposed_version)
     return ret;
 }
 
-picoquic_cnx_t * picoquic_create_cnx(picoquic_quic_t * quic,
-    uint64_t cnx_id, struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-	char const * sni, char const * alpn, char client_mode)
+picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
+    uint64_t cnx_id, struct sockaddr* addr, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn, char client_mode)
 {
-    picoquic_cnx_t * cnx = (picoquic_cnx_t *)malloc(sizeof(picoquic_cnx_t));
+    picoquic_cnx_t* cnx = (picoquic_cnx_t*)malloc(sizeof(picoquic_cnx_t));
     uint32_t random_sequence;
 
-    if (cnx != NULL)
-    {
+    if (cnx != NULL) {
         memset(cnx, 0, sizeof(picoquic_cnx_t));
 
         cnx->next_wake_time = start_time;
@@ -495,242 +431,207 @@ picoquic_cnx_t * picoquic_create_cnx(picoquic_quic_t * quic,
         picoquic_insert_cnx_by_wake_time(quic, cnx);
     }
 
-    if (cnx != NULL)
-    {
-        cnx->peer_addr_len = (int)((addr->sa_family == AF_INET) ?
-            sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+    if (cnx != NULL) {
+        cnx->peer_addr_len = (int)((addr->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
         memcpy(&cnx->peer_addr, addr, cnx->peer_addr_len);
 
         picoquic_init_transport_parameters(&cnx->local_parameters, !cnx->client_mode);
         /* Special provision for test -- create a deliberate transport parameters error */
-        if (sni != NULL && cnx->client_mode && strcmp(sni, PICOQUIC_ERRONEOUS_SNI) == 0)
-        {
+        if (sni != NULL && cnx->client_mode && strcmp(sni, PICOQUIC_ERRONEOUS_SNI) == 0) {
             /* Illegal value: server limits should be odd */
             cnx->local_parameters.initial_max_stream_id_bidir = 0x202;
         }
-		// picoquic_init_transport_parameters(&cnx->remote_parameters);
-		/* Initialize local flow control variables to advertised values */
+        // picoquic_init_transport_parameters(&cnx->remote_parameters);
+        /* Initialize local flow control variables to advertised values */
 
         cnx->maxdata_local = ((uint64_t)cnx->local_parameters.initial_max_data);
-		cnx->max_stream_id_bidir_local = cnx->local_parameters.initial_max_stream_id_bidir;
+        cnx->max_stream_id_bidir_local = cnx->local_parameters.initial_max_stream_id_bidir;
         cnx->max_stream_id_unidir_local = cnx->local_parameters.initial_max_stream_id_unidir;
 
-		/* Initialize remote variables to some plausible value. 
+        /* Initialize remote variables to some plausible value. 
 		 * Hopefully, this will be overwritten by the parameters received in
 		 * the TLS transport parameter extension */
-		cnx->maxdata_remote = PICOQUIC_DEFAULT_0RTT_WINDOW;
+        cnx->maxdata_remote = PICOQUIC_DEFAULT_0RTT_WINDOW;
         cnx->remote_parameters.initial_max_stream_data = PICOQUIC_DEFAULT_0RTT_WINDOW;
-		cnx->max_stream_id_bidir_remote = 0;
+        cnx->max_stream_id_bidir_remote = 0;
         cnx->max_stream_id_unidir_remote = 0;
 
-		if (sni != NULL)
-		{
-			cnx->sni = picoquic_string_duplicate(sni);
-		}
+        if (sni != NULL) {
+            cnx->sni = picoquic_string_duplicate(sni);
+        }
 
-		if (alpn != NULL)
-		{
-			cnx->alpn = picoquic_string_duplicate(alpn);
-		}
+        if (alpn != NULL) {
+            cnx->alpn = picoquic_string_duplicate(alpn);
+        }
 
-		cnx->callback_fn = quic->default_callback_fn;
-		cnx->callback_ctx = quic->default_callback_ctx;
-		cnx->congestion_alg = quic->default_congestion_alg;
+        cnx->callback_fn = quic->default_callback_fn;
+        cnx->callback_ctx = quic->default_callback_ctx;
+        cnx->congestion_alg = quic->default_congestion_alg;
 
-		if (cnx->client_mode)
-		{
-			if (preferred_version == 0)
-			{
-				cnx->proposed_version = picoquic_supported_versions[0].version;
+        if (cnx->client_mode) {
+            if (preferred_version == 0) {
+                cnx->proposed_version = picoquic_supported_versions[0].version;
                 cnx->version_index = 0;
-			}
-			else
-			{
+            } else {
                 cnx->version_index = picoquic_get_version_index(preferred_version);
-                if (cnx->version_index < 0)
-                {
+                if (cnx->version_index < 0) {
                     cnx->version_index = 0;
-                    if ((preferred_version & 0x0A0A0A0A) == 0x0A0A0A0A)
-                    {
+                    if ((preferred_version & 0x0A0A0A0A) == 0x0A0A0A0A) {
                         /* This is a hack, to allow greasing the cnx ID */
                         cnx->proposed_version = preferred_version;
-                    }
-                    else
-                    {
+                    } else {
                         cnx->proposed_version = picoquic_supported_versions[0].version;
                     }
-                }
-                else
-                {
+                } else {
                     cnx->proposed_version = preferred_version;
                 }
-			}
-			cnx->local_parameters.omit_connection_id = 1;
+            }
+            cnx->local_parameters.omit_connection_id = 1;
 
-			cnx->cnx_state = picoquic_state_client_init;
-			if (cnx_id == 0)
-			{
-				picoquic_crypto_random(quic, &cnx_id, sizeof(uint64_t));
-			}
+            cnx->cnx_state = picoquic_state_client_init;
+            if (cnx_id == 0) {
+                picoquic_crypto_random(quic, &cnx_id, sizeof(uint64_t));
+            }
 
-			if (quic->cnx_id_callback_fn)
-				cnx_id = quic->cnx_id_callback_fn(cnx_id, 0, quic->cnx_id_callback_ctx);
+            if (quic->cnx_id_callback_fn)
+                cnx_id = quic->cnx_id_callback_fn(cnx_id, 0, quic->cnx_id_callback_ctx);
 
-			cnx->initial_cnxid = cnx_id;
-			cnx->server_cnxid = 0;
-			/* Initialize the reset secret to a random value. This
+            cnx->initial_cnxid = cnx_id;
+            cnx->server_cnxid = 0;
+            /* Initialize the reset secret to a random value. This
 			 * will prevent spurious matches to an all zero value, for example.
 			 * The real value will be set when receiving the transport parameters. 
 			 */
             picoquic_public_random(cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
-		}
-        else
-        {
+        } else {
             cnx->first_stream.send_queue = NULL;
             cnx->cnx_state = picoquic_state_server_init;
             cnx->initial_cnxid = cnx_id;
-			picoquic_crypto_random(quic, &cnx->server_cnxid, sizeof(uint64_t));
+            picoquic_crypto_random(quic, &cnx->server_cnxid, sizeof(uint64_t));
 
-			if (quic->cnx_id_callback_fn)
-				cnx->server_cnxid = quic->cnx_id_callback_fn(cnx->server_cnxid, cnx->initial_cnxid,
-						quic->cnx_id_callback_ctx);
+            if (quic->cnx_id_callback_fn)
+                cnx->server_cnxid = quic->cnx_id_callback_fn(cnx->server_cnxid, cnx->initial_cnxid,
+                    quic->cnx_id_callback_ctx);
 
-			(void)picoquic_create_cnxid_reset_secret(quic, cnx->server_cnxid,
-				cnx->reset_secret);
+            (void)picoquic_create_cnxid_reset_secret(quic, cnx->server_cnxid,
+                cnx->reset_secret);
 
             cnx->version_index = picoquic_get_version_index(preferred_version);
-            if (cnx->version_index < 0)
-            {
+            if (cnx->version_index < 0) {
                 /* TODO: this is an internal error condition, should not happen */
                 cnx->version_index = 0;
                 cnx->proposed_version = picoquic_supported_versions[0].version;
-            }
-            else
-            {
+            } else {
                 cnx->proposed_version = preferred_version;
             }
         }
 
-		if (cnx != NULL)
-		{
-			cnx->first_sack_item.start_of_sack_range = 0;
-			cnx->first_sack_item.end_of_sack_range = 0;
-			cnx->first_sack_item.next_sack = NULL;
-			cnx->sack_block_size_max = 0;
-			cnx->highest_ack_sent = 0;
-			cnx->highest_ack_time = start_time;
+        if (cnx != NULL) {
+            cnx->first_sack_item.start_of_sack_range = 0;
+            cnx->first_sack_item.end_of_sack_range = 0;
+            cnx->first_sack_item.next_sack = NULL;
+            cnx->sack_block_size_max = 0;
+            cnx->highest_ack_sent = 0;
+            cnx->highest_ack_time = start_time;
             cnx->time_stamp_largest_received = start_time;
 
-			cnx->first_stream.stream_id = 0;
-			cnx->first_stream.consumed_offset = 0;
-			cnx->first_stream.stream_flags = 0;
-			cnx->first_stream.fin_offset = 0;
-			cnx->first_stream.next_stream = NULL;
-			cnx->first_stream.stream_data = NULL;
-			cnx->first_stream.sent_offset = 0;
-			cnx->first_stream.local_error = 0;
-			cnx->first_stream.remote_error = 0;
-			cnx->first_stream.maxdata_local = (uint64_t)((int64_t)-1);
-			cnx->first_stream.maxdata_remote = (uint64_t)((int64_t)-1);
+            cnx->first_stream.stream_id = 0;
+            cnx->first_stream.consumed_offset = 0;
+            cnx->first_stream.stream_flags = 0;
+            cnx->first_stream.fin_offset = 0;
+            cnx->first_stream.next_stream = NULL;
+            cnx->first_stream.stream_data = NULL;
+            cnx->first_stream.sent_offset = 0;
+            cnx->first_stream.local_error = 0;
+            cnx->first_stream.remote_error = 0;
+            cnx->first_stream.maxdata_local = (uint64_t)((int64_t)-1);
+            cnx->first_stream.maxdata_remote = (uint64_t)((int64_t)-1);
 
-			cnx->aead_decrypt_ctx = NULL;
-			cnx->aead_encrypt_ctx = NULL;
+            cnx->aead_decrypt_ctx = NULL;
+            cnx->aead_encrypt_ctx = NULL;
             cnx->aead_de_encrypt_ctx = NULL;
 
             /* Set the initial sequence randomly between 1 and 2^31 - 1 
              * The spec does not require avoiding the value 0, but doing
              * so minimizes risks of triggering bugs in other implementations.
              */
-            do
-            {
+            do {
                 random_sequence = (uint32_t)(0x7FFFFFFF & picoquic_public_random_64());
             } while (random_sequence == 0);
             cnx->send_sequence = random_sequence;
 
-			cnx->send_mtu = (addr == NULL || addr->sa_family == AF_INET)?
-				PICOQUIC_INITIAL_MTU_IPV4 : PICOQUIC_INITIAL_MTU_IPV6;
+            cnx->send_mtu = (addr == NULL || addr->sa_family == AF_INET) ? PICOQUIC_INITIAL_MTU_IPV4 : PICOQUIC_INITIAL_MTU_IPV6;
 
-			cnx->nb_retransmit = 0;
-			cnx->latest_retransmit_time = 0;
+            cnx->nb_retransmit = 0;
+            cnx->latest_retransmit_time = 0;
 
-			cnx->retransmit_newest = NULL;
-			cnx->retransmit_oldest = NULL;
-			cnx->highest_acknowledged = cnx->send_sequence - 1;
+            cnx->retransmit_newest = NULL;
+            cnx->retransmit_oldest = NULL;
+            cnx->highest_acknowledged = cnx->send_sequence - 1;
 
-			cnx->latest_time_acknowledged = start_time;
-			cnx->latest_progress_time = start_time;
-			cnx->ack_needed = 0;
+            cnx->latest_time_acknowledged = start_time;
+            cnx->latest_progress_time = start_time;
+            cnx->ack_needed = 0;
 
-
-			/* Time measurement */
-			cnx->smoothed_rtt = PICOQUIC_INITIAL_RTT;
-			cnx->rtt_variant = 0;
-			cnx->retransmit_timer = PICOQUIC_INITIAL_RETRANSMIT_TIMER;
-			cnx->rtt_min = 0;
+            /* Time measurement */
+            cnx->smoothed_rtt = PICOQUIC_INITIAL_RTT;
+            cnx->rtt_variant = 0;
+            cnx->retransmit_timer = PICOQUIC_INITIAL_RETRANSMIT_TIMER;
+            cnx->rtt_min = 0;
 
             cnx->ack_delay_local = 10000;
 
-			/* Congestion control state */
-			cnx->cwin = PICOQUIC_CWIN_INITIAL;
-			cnx->bytes_in_transit = 0;
-			cnx->congestion_alg_state = NULL;
-			cnx->congestion_alg = cnx->quic->default_congestion_alg;
-			if (cnx->congestion_alg != NULL)
-			{
-				cnx->congestion_alg->alg_init(cnx);
-			}
+            /* Congestion control state */
+            cnx->cwin = PICOQUIC_CWIN_INITIAL;
+            cnx->bytes_in_transit = 0;
+            cnx->congestion_alg_state = NULL;
+            cnx->congestion_alg = cnx->quic->default_congestion_alg;
+            if (cnx->congestion_alg != NULL) {
+                cnx->congestion_alg->alg_init(cnx);
+            }
             /* Pacing state */
             cnx->packet_time_nano_sec = 0;
             cnx->pacing_reminder_nano_sec = 0;
             cnx->pacing_margin_micros = 1000;
             cnx->next_pacing_time = start_time;
-		}
+        }
     }
 
-	/* Only initialize TLS after all parameters have been set */
+    /* Only initialize TLS after all parameters have been set */
 
-	if (picoquic_tlscontext_create(quic, cnx, start_time) != 0)
-	{
-		/* Cannot just do partial creation! */
-		picoquic_delete_cnx(cnx);
-		cnx = NULL;
-	}
-	else if (cnx->client_mode)
-	{
-		/* Initialize the tls connection */
-		int ret = picoquic_initialize_stream_zero(cnx);
+    if (picoquic_tlscontext_create(quic, cnx, start_time) != 0) {
+        /* Cannot just do partial creation! */
+        picoquic_delete_cnx(cnx);
+        cnx = NULL;
+    } else if (cnx->client_mode) {
+        /* Initialize the tls connection */
+        int ret = picoquic_initialize_stream_zero(cnx);
 
-		if (ret != 0)
-		{
-			/* Cannot just do partial initialization! */
-			picoquic_delete_cnx(cnx);
-			cnx = NULL;
-		}
-	}
+        if (ret != 0) {
+            /* Cannot just do partial initialization! */
+            picoquic_delete_cnx(cnx);
+            cnx = NULL;
+        }
+    }
 
-    if (cnx != NULL)
-    {
+    if (cnx != NULL) {
         cnx->aead_encrypt_cleartext_ctx = NULL;
         cnx->aead_decrypt_cleartext_ctx = NULL;
         cnx->aead_de_encrypt_cleartext_ctx = NULL;
 
-        if (picoquic_setup_cleartext_aead_contexts(cnx))
-        {
+        if (picoquic_setup_cleartext_aead_contexts(cnx)) {
             /* Cannot initialize clear text aead */
             picoquic_delete_cnx(cnx);
             cnx = NULL;
         }
     }
 
-    if (cnx != NULL)
-    {
-        if (cnx->server_cnxid != 0)
-        {
+    if (cnx != NULL) {
+        if (cnx->server_cnxid != 0) {
             (void)picoquic_register_cnx_id(quic, cnx, cnx->server_cnxid);
         }
 
-        if (addr != NULL)
-        {
+        if (addr != NULL) {
             (void)picoquic_register_net_id(quic, cnx, addr);
         }
     }
@@ -738,127 +639,112 @@ picoquic_cnx_t * picoquic_create_cnx(picoquic_quic_t * quic,
     return cnx;
 }
 
-picoquic_cnx_t * picoquic_create_client_cnx(picoquic_quic_t * quic, 
-	struct sockaddr * addr, uint64_t start_time, uint32_t preferred_version,
-	char const * sni, char const * alpn, picoquic_stream_data_cb_fn callback_fn, void * callback_ctx)
+picoquic_cnx_t* picoquic_create_client_cnx(picoquic_quic_t* quic,
+    struct sockaddr* addr, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn, picoquic_stream_data_cb_fn callback_fn, void* callback_ctx)
 {
-	picoquic_cnx_t * cnx = picoquic_create_cnx(quic, 0, addr, start_time, preferred_version, sni, alpn, 1);
+    picoquic_cnx_t* cnx = picoquic_create_cnx(quic, 0, addr, start_time, preferred_version, sni, alpn, 1);
 
-	if (cnx != NULL)
-	{
-		if (callback_fn != NULL)
-			cnx->callback_fn = callback_fn;
-		if (callback_ctx != NULL)
-			cnx->callback_ctx = callback_ctx;
-	}
+    if (cnx != NULL) {
+        if (callback_fn != NULL)
+            cnx->callback_fn = callback_fn;
+        if (callback_ctx != NULL)
+            cnx->callback_ctx = callback_ctx;
+    }
 
-	return cnx;
+    return cnx;
 }
 
-void picoquic_get_peer_addr(picoquic_cnx_t * cnx, struct sockaddr ** addr, int * addr_len)
+void picoquic_get_peer_addr(picoquic_cnx_t* cnx, struct sockaddr** addr, int* addr_len)
 {
-    *addr = (struct sockaddr *) &cnx->peer_addr;
+    *addr = (struct sockaddr*)&cnx->peer_addr;
     *addr_len = cnx->peer_addr_len;
 }
 
-void picoquic_get_local_addr(picoquic_cnx_t * cnx, struct sockaddr ** addr, int * addr_len)
+void picoquic_get_local_addr(picoquic_cnx_t* cnx, struct sockaddr** addr, int* addr_len)
 {
-    *addr = (struct sockaddr *) &cnx->dest_addr;
+    *addr = (struct sockaddr*)&cnx->dest_addr;
     *addr_len = cnx->dest_addr_len;
 }
 
-unsigned long picoquic_get_local_if_index(picoquic_cnx_t * cnx)
+unsigned long picoquic_get_local_if_index(picoquic_cnx_t* cnx)
 {
     return cnx->if_index_dest;
 }
 
-uint64_t picoquic_get_cnxid(picoquic_cnx_t * cnx)
+uint64_t picoquic_get_cnxid(picoquic_cnx_t* cnx)
 {
     return cnx->server_cnxid;
 }
 
-uint64_t picoquic_get_initial_cnxid(picoquic_cnx_t * cnx)
+uint64_t picoquic_get_initial_cnxid(picoquic_cnx_t* cnx)
 {
     return cnx->initial_cnxid;
 }
 
-
-uint64_t picoquic_get_cnx_start_time(picoquic_cnx_t * cnx)
+uint64_t picoquic_get_cnx_start_time(picoquic_cnx_t* cnx)
 {
     return cnx->start_time;
 }
 
-picoquic_state_enum picoquic_get_cnx_state(picoquic_cnx_t * cnx)
+picoquic_state_enum picoquic_get_cnx_state(picoquic_cnx_t* cnx)
 {
-	return cnx->cnx_state;
+    return cnx->cnx_state;
 }
 
-picoquic_cnx_t * picoquic_get_first_cnx(picoquic_quic_t * quic)
+picoquic_cnx_t* picoquic_get_first_cnx(picoquic_quic_t* quic)
 {
-	return quic->cnx_list;
+    return quic->cnx_list;
 }
 
-
-picoquic_cnx_t * picoquic_get_next_cnx(picoquic_cnx_t * cnx)
+picoquic_cnx_t* picoquic_get_next_cnx(picoquic_cnx_t* cnx)
 {
     return cnx->next_in_table;
 }
 
-uint64_t picoquic_is_0rtt_available(picoquic_cnx_t * cnx)
+uint64_t picoquic_is_0rtt_available(picoquic_cnx_t* cnx)
 {
     return (cnx->aead_0rtt_encrypt_ctx == NULL) ? 0 : 1;
 }
 
-
-int64_t picoquic_get_next_wake_delay(picoquic_quic_t * quic, 
+int64_t picoquic_get_next_wake_delay(picoquic_quic_t* quic,
     uint64_t current_time, int64_t delay_max)
 {
     int64_t wake_delay;
 
-    if (quic->cnx_list != NULL)
-    {
-        if (quic->cnx_list->next_wake_time > current_time)
-        {
+    if (quic->cnx_list != NULL) {
+        if (quic->cnx_list->next_wake_time > current_time) {
             wake_delay = quic->cnx_list->next_wake_time - current_time;
 
-            if (wake_delay > delay_max)
-            {
+            if (wake_delay > delay_max) {
                 wake_delay = delay_max;
             }
-        }
-        else
-        {
+        } else {
             wake_delay = 0;
         }
-    }
-    else
-    {
+    } else {
         wake_delay = delay_max;
     }
 
     return wake_delay;
 }
 
-
-void picoquic_set_callback(picoquic_cnx_t * cnx,
-    picoquic_stream_data_cb_fn callback_fn, void * callback_ctx)
+void picoquic_set_callback(picoquic_cnx_t* cnx,
+    picoquic_stream_data_cb_fn callback_fn, void* callback_ctx)
 {
     cnx->callback_fn = callback_fn;
     cnx->callback_ctx = callback_ctx;
 }
 
-int picoquic_queue_misc_frame(picoquic_cnx_t * cnx, const uint8_t * bytes, size_t length)
+int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length)
 {
     int ret = 0;
-    uint8_t * misc_frame = (uint8_t *) malloc(sizeof(picoquic_misc_frame_header_t) + length);
+    uint8_t* misc_frame = (uint8_t*)malloc(sizeof(picoquic_misc_frame_header_t) + length);
 
-    if (misc_frame == NULL)
-    {
+    if (misc_frame == NULL) {
         ret = PICOQUIC_ERROR_MEMORY;
-    }
-    else
-    {
-        picoquic_misc_frame_header_t * head = (picoquic_misc_frame_header_t*)misc_frame;
+    } else {
+        picoquic_misc_frame_header_t* head = (picoquic_misc_frame_header_t*)misc_frame;
         head->length = length;
         memcpy(misc_frame + sizeof(picoquic_misc_frame_header_t), bytes, length);
         head->next_misc_frame = cnx->first_misc_frame;
@@ -868,22 +754,19 @@ int picoquic_queue_misc_frame(picoquic_cnx_t * cnx, const uint8_t * bytes, size_
     return ret;
 }
 
-void picoquic_clear_stream(picoquic_stream_head * stream)
+void picoquic_clear_stream(picoquic_stream_head* stream)
 {
-    picoquic_stream_data ** pdata[2];
+    picoquic_stream_data** pdata[2];
     pdata[0] = &stream->stream_data;
     pdata[1] = &stream->send_queue;
 
-    for (int i = 0; i < 2; i++)
-    {
-        picoquic_stream_data * next; 
+    for (int i = 0; i < 2; i++) {
+        picoquic_stream_data* next;
 
-        while ((next = *pdata[i]) != NULL)
-        {
+        while ((next = *pdata[i]) != NULL) {
             *pdata[i] = next->next_stream_data;
 
-            if (next->bytes != NULL)
-            {
+            if (next->bytes != NULL) {
                 free(next->bytes);
             }
             free(next);
@@ -891,80 +774,59 @@ void picoquic_clear_stream(picoquic_stream_head * stream)
     }
 }
 
-void picoquic_enqueue_retransmit_packet(picoquic_cnx_t * cnx, picoquic_packet * p)
+void picoquic_enqueue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p)
 {
-	if (cnx->retransmit_oldest == NULL)
-	{
-		p->previous_packet = NULL;
-		cnx->retransmit_newest = p;
-	}
-	else
-	{
-		cnx->retransmit_oldest->next_packet = p;
-		p->previous_packet = cnx->retransmit_oldest;
-	}
-	p->next_packet = NULL;
-	cnx->retransmit_oldest = p;
+    if (cnx->retransmit_oldest == NULL) {
+        p->previous_packet = NULL;
+        cnx->retransmit_newest = p;
+    } else {
+        cnx->retransmit_oldest->next_packet = p;
+        p->previous_packet = cnx->retransmit_oldest;
+    }
+    p->next_packet = NULL;
+    cnx->retransmit_oldest = p;
 
-	/* Account for bytes in transit, for congestion control */
-	cnx->bytes_in_transit += p->length;
+    /* Account for bytes in transit, for congestion control */
+    cnx->bytes_in_transit += p->length;
 }
 
-void picoquic_dequeue_retransmit_packet(picoquic_cnx_t * cnx, picoquic_packet * p, int should_free)
+void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free)
 {
-	if (p->previous_packet == NULL)
-	{
-		cnx->retransmit_newest = p->next_packet;
-	}
-	else
-	{
-		p->previous_packet->next_packet = p->next_packet;
-	}
-
-	if (p->next_packet == NULL)
-	{
-		cnx->retransmit_oldest = p->previous_packet;
-	}
-	else
-	{
-		p->next_packet->previous_packet = p->previous_packet;
-	}
-
-	/* Account for bytes in transit, for congestion control */
-	if (cnx->retransmit_newest == NULL)
-	{
-		cnx->bytes_in_transit = 0;
-	}
-	else
-	{
-		size_t dequeued_length = p->length + p->checksum_overhead;
-
-		if (cnx->bytes_in_transit > dequeued_length)
-		{
-			cnx->bytes_in_transit -= dequeued_length;
-		}
-		else
-		{
-			cnx->bytes_in_transit = 0;
-		}
-	}
-
-    if (should_free)
-    {
-        free(p);
+    if (p->previous_packet == NULL) {
+        cnx->retransmit_newest = p->next_packet;
+    } else {
+        p->previous_packet->next_packet = p->next_packet;
     }
-    else
-    {
+
+    if (p->next_packet == NULL) {
+        cnx->retransmit_oldest = p->previous_packet;
+    } else {
+        p->next_packet->previous_packet = p->previous_packet;
+    }
+
+    /* Account for bytes in transit, for congestion control */
+    if (cnx->retransmit_newest == NULL) {
+        cnx->bytes_in_transit = 0;
+    } else {
+        size_t dequeued_length = p->length + p->checksum_overhead;
+
+        if (cnx->bytes_in_transit > dequeued_length) {
+            cnx->bytes_in_transit -= dequeued_length;
+        } else {
+            cnx->bytes_in_transit = 0;
+        }
+    }
+
+    if (should_free) {
+        free(p);
+    } else {
         p->next_packet = NULL;
 
         /* add this packet to the retransmitted list */
-        if (cnx->retransmitted_oldest == NULL)
-        {
+        if (cnx->retransmitted_oldest == NULL) {
             cnx->retransmitted_newest = p;
             p->previous_packet = NULL;
-        }
-        else
-        {
+        } else {
             cnx->retransmitted_oldest->next_packet = p;
             p->previous_packet = cnx->retransmitted_oldest;
             cnx->retransmitted_oldest = p;
@@ -987,301 +849,252 @@ void picoquic_dequeue_retransmit_packet(picoquic_cnx_t * cnx, picoquic_packet * 
 * - State changes.
 */
 
-int picoquic_reset_cnx_version(picoquic_cnx_t * cnx, uint8_t * bytes, size_t length, uint64_t current_time)
+int picoquic_reset_cnx_version(picoquic_cnx_t* cnx, uint8_t* bytes, size_t length, uint64_t current_time)
 {
-	/* First parse the incoming connection negotiation to choose the
+    /* First parse the incoming connection negotiation to choose the
 	* new version. If none is available, return an error */
-	size_t byte_index = 0;
-	uint32_t proposed_version = 0;
-	int ret = -1;
+    size_t byte_index = 0;
+    uint32_t proposed_version = 0;
+    int ret = -1;
 
-	if (cnx->cnx_state == picoquic_state_client_init ||
-		cnx->cnx_state == picoquic_state_client_init_sent)
-	{
-		while (cnx->cnx_state != picoquic_state_client_renegotiate && 
-			byte_index + 4 <= length)
-		{
-			/* parsing the list of proposed versions encoded in renegotiation packet */
-			proposed_version = PICOPARSE_32(bytes + byte_index);
-			byte_index += 4;
+    if (cnx->cnx_state == picoquic_state_client_init || cnx->cnx_state == picoquic_state_client_init_sent) {
+        while (cnx->cnx_state != picoquic_state_client_renegotiate && byte_index + 4 <= length) {
+            /* parsing the list of proposed versions encoded in renegotiation packet */
+            proposed_version = PICOPARSE_32(bytes + byte_index);
+            byte_index += 4;
 
-			for (size_t i = 0; i < picoquic_nb_supported_versions; i++)
-			{
-				if (proposed_version == picoquic_supported_versions[i].version)
-				{
-                    cnx->version_index = (int) i;
-					cnx->cnx_state = picoquic_state_client_renegotiate;
+            for (size_t i = 0; i < picoquic_nb_supported_versions; i++) {
+                if (proposed_version == picoquic_supported_versions[i].version) {
+                    cnx->version_index = (int)i;
+                    cnx->cnx_state = picoquic_state_client_renegotiate;
 
                     /* TODO: Reset the clear text context */
 
-					/* Delete the packets queued for retransmission */
-					while (cnx->retransmit_newest != NULL)
-					{
-						picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
-					}
+                    /* Delete the packets queued for retransmission */
+                    while (cnx->retransmit_newest != NULL) {
+                        picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
+                    }
 
-					/* Reset the streams */
-					picoquic_clear_stream(&cnx->first_stream);
-					cnx->first_stream.consumed_offset = 0;
-					cnx->first_stream.stream_flags = 0;
-					cnx->first_stream.fin_offset = 0;
-					cnx->first_stream.sent_offset = 0;
+                    /* Reset the streams */
+                    picoquic_clear_stream(&cnx->first_stream);
+                    cnx->first_stream.consumed_offset = 0;
+                    cnx->first_stream.stream_flags = 0;
+                    cnx->first_stream.fin_offset = 0;
+                    cnx->first_stream.sent_offset = 0;
                     /* TODO: reset clear text AEAD */
 
-					/* Reset the TLS context, Re-initialize the tls connection */
-					picoquic_tlscontext_free(cnx->tls_ctx);
-					cnx->tls_ctx = NULL;
-					ret = picoquic_tlscontext_create(cnx->quic, cnx, current_time);
-					if (ret == 0)
-					{
-						ret = picoquic_initialize_stream_zero(cnx);
-					}
+                    /* Reset the TLS context, Re-initialize the tls connection */
+                    picoquic_tlscontext_free(cnx->tls_ctx);
+                    cnx->tls_ctx = NULL;
+                    ret = picoquic_tlscontext_create(cnx->quic, cnx, current_time);
+                    if (ret == 0) {
+                        ret = picoquic_initialize_stream_zero(cnx);
+                    }
 
-                    if (cnx->aead_encrypt_cleartext_ctx != NULL)
-                    {
+                    if (cnx->aead_encrypt_cleartext_ctx != NULL) {
                         picoquic_aead_free(cnx->aead_encrypt_cleartext_ctx);
                         cnx->aead_encrypt_cleartext_ctx = NULL;
                     }
 
-                    if (cnx->aead_decrypt_cleartext_ctx != NULL)
-                    {
+                    if (cnx->aead_decrypt_cleartext_ctx != NULL) {
                         picoquic_aead_free(cnx->aead_decrypt_cleartext_ctx);
                         cnx->aead_decrypt_cleartext_ctx = NULL;
                     }
 
-                    if (cnx->aead_de_encrypt_cleartext_ctx != NULL)
-                    {
+                    if (cnx->aead_de_encrypt_cleartext_ctx != NULL) {
                         picoquic_aead_free(cnx->aead_de_encrypt_cleartext_ctx);
                         cnx->aead_de_encrypt_cleartext_ctx = NULL;
                     }
 
-                    if (cnx->aead_0rtt_decrypt_ctx != NULL)
-                    {
+                    if (cnx->aead_0rtt_decrypt_ctx != NULL) {
                         picoquic_aead_free(cnx->aead_0rtt_decrypt_ctx);
                         cnx->aead_0rtt_decrypt_ctx = NULL;
                     }
 
-                    if (cnx->aead_0rtt_encrypt_ctx != NULL)
-                    {
+                    if (cnx->aead_0rtt_encrypt_ctx != NULL) {
                         picoquic_aead_free(cnx->aead_0rtt_encrypt_ctx);
                         cnx->aead_0rtt_encrypt_ctx = NULL;
                     }
 
-                    if (ret == 0)
-                    {
+                    if (ret == 0) {
                         ret = picoquic_setup_cleartext_aead_contexts(cnx);
                     }
-					break;
-				}
-			}
-		}
-	}
+                    break;
+                }
+            }
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
-int picoquic_connection_error(picoquic_cnx_t * cnx, uint32_t local_error)
+int picoquic_connection_error(picoquic_cnx_t* cnx, uint32_t local_error)
 {
-    if (cnx->cnx_state == picoquic_state_client_ready ||
-        cnx->cnx_state == picoquic_state_server_ready)
-    {
+    if (cnx->cnx_state == picoquic_state_client_ready || cnx->cnx_state == picoquic_state_server_ready) {
         cnx->local_error = local_error;
         cnx->cnx_state = picoquic_state_disconnecting;
 
         DBG_PRINTF("Protocol error (%x)", local_error);
-    }
-    else if (cnx->cnx_state < picoquic_state_client_ready)
-    {
+    } else if (cnx->cnx_state < picoquic_state_client_ready) {
         cnx->local_error = local_error;
         cnx->cnx_state = picoquic_state_handshake_failure;
 
         DBG_PRINTF("Protocol error %x", local_error);
-
     }
 
     return PICOQUIC_ERROR_DETECTED;
 }
 
-void picoquic_delete_cnx(picoquic_cnx_t * cnx)
+void picoquic_delete_cnx(picoquic_cnx_t* cnx)
 {
-    picoquic_stream_head * stream;
-    picoquic_misc_frame_header_t * misc_frame;
+    picoquic_stream_head* stream;
+    picoquic_misc_frame_header_t* misc_frame;
 
-    if (cnx != NULL)
-    {
-		if (cnx->alpn != NULL)
-		{
-			free((void*)cnx->alpn);
-			cnx->alpn = NULL;
-		}
+    if (cnx != NULL) {
+        if (cnx->alpn != NULL) {
+            free((void*)cnx->alpn);
+            cnx->alpn = NULL;
+        }
 
-		if (cnx->sni != NULL)
-		{
-			free((void*)cnx->sni);
-			cnx->sni = NULL;
-		}
+        if (cnx->sni != NULL) {
+            free((void*)cnx->sni);
+            cnx->sni = NULL;
+        }
 
-        while (cnx->first_cnx_id != NULL)
-        {
-            picohash_item * item;
-            picoquic_cnx_id * cnx_id_key = cnx->first_cnx_id;
+        while (cnx->first_cnx_id != NULL) {
+            picohash_item* item;
+            picoquic_cnx_id* cnx_id_key = cnx->first_cnx_id;
             cnx->first_cnx_id = cnx_id_key->next_cnx_id;
             cnx_id_key->next_cnx_id = NULL;
 
             item = picohash_retrieve(cnx->quic->table_cnx_by_id, cnx_id_key);
-            if (item != NULL)
-            {
+            if (item != NULL) {
                 picohash_item_delete(cnx->quic->table_cnx_by_id, item, 1);
             }
         }
 
-        while (cnx->first_net_id != NULL)
-        {
-            picohash_item * item;
-            picoquic_net_id * net_id_key = cnx->first_net_id;
+        while (cnx->first_net_id != NULL) {
+            picohash_item* item;
+            picoquic_net_id* net_id_key = cnx->first_net_id;
             cnx->first_net_id = net_id_key->next_net_id;
             net_id_key->next_net_id = NULL;
 
             item = picohash_retrieve(cnx->quic->table_cnx_by_net, net_id_key);
-            if (item != NULL)
-            {
+            if (item != NULL) {
                 picohash_item_delete(cnx->quic->table_cnx_by_net, item, 1);
             }
         }
 
-        if (cnx->next_in_table == NULL)
-        {
+        if (cnx->next_in_table == NULL) {
             cnx->quic->cnx_last = cnx->previous_in_table;
-        }
-        else
-        {
+        } else {
             cnx->next_in_table->previous_in_table = cnx->previous_in_table;
         }
 
-        if (cnx->previous_in_table == NULL)
-        {
+        if (cnx->previous_in_table == NULL) {
             cnx->quic->cnx_list = cnx->next_in_table;
-        }
-        else
-        {
+        } else {
             cnx->previous_in_table->next_in_table = cnx->next_in_table;
         }
 
-        if (cnx->aead_encrypt_cleartext_ctx != NULL)
-        {
+        if (cnx->aead_encrypt_cleartext_ctx != NULL) {
             picoquic_aead_free(cnx->aead_encrypt_cleartext_ctx);
             cnx->aead_encrypt_cleartext_ctx = NULL;
         }
 
-        if (cnx->aead_decrypt_cleartext_ctx != NULL)
-        {
+        if (cnx->aead_decrypt_cleartext_ctx != NULL) {
             picoquic_aead_free(cnx->aead_decrypt_cleartext_ctx);
             cnx->aead_decrypt_cleartext_ctx = NULL;
         }
 
-        if (cnx->aead_de_encrypt_cleartext_ctx != NULL)
-        {
+        if (cnx->aead_de_encrypt_cleartext_ctx != NULL) {
             picoquic_aead_free(cnx->aead_de_encrypt_cleartext_ctx);
             cnx->aead_de_encrypt_cleartext_ctx = NULL;
         }
 
-        if (cnx->aead_decrypt_ctx != NULL)
-        {
+        if (cnx->aead_decrypt_ctx != NULL) {
             picoquic_aead_free(cnx->aead_decrypt_ctx);
             cnx->aead_decrypt_ctx = NULL;
         }
 
-        if (cnx->aead_encrypt_ctx != NULL)
-        {
+        if (cnx->aead_encrypt_ctx != NULL) {
             picoquic_aead_free(cnx->aead_encrypt_ctx);
             cnx->aead_encrypt_ctx = NULL;
         }
 
-        if (cnx->aead_de_encrypt_ctx != NULL)
-        {
+        if (cnx->aead_de_encrypt_ctx != NULL) {
             picoquic_aead_free(cnx->aead_de_encrypt_ctx);
             cnx->aead_encrypt_ctx = NULL;
         }
 
-		while (cnx->retransmit_newest != NULL)
-		{
-			picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
-		}
+        while (cnx->retransmit_newest != NULL) {
+            picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
+        }
 
-        while (cnx->retransmitted_newest != NULL)
-        {
-            picoquic_packet * p = cnx->retransmitted_newest;
+        while (cnx->retransmitted_newest != NULL) {
+            picoquic_packet* p = cnx->retransmitted_newest;
             cnx->retransmitted_newest = p->next_packet;
             free(p);
         }
         cnx->retransmitted_oldest = NULL;
 
-        while ((misc_frame = cnx->first_misc_frame) != NULL)
-        {
+        while ((misc_frame = cnx->first_misc_frame) != NULL) {
             cnx->first_misc_frame = misc_frame->next_misc_frame;
             free(misc_frame);
         }
 
-        while ((stream = cnx->first_stream.next_stream) != NULL)
-        {
+        while ((stream = cnx->first_stream.next_stream) != NULL) {
             cnx->first_stream.next_stream = stream->next_stream;
             picoquic_clear_stream(stream);
             free(stream);
         }
         picoquic_clear_stream(&cnx->first_stream);
 
-        if (cnx->tls_ctx != NULL)
-        {
+        if (cnx->tls_ctx != NULL) {
             picoquic_tlscontext_free(cnx->tls_ctx);
             cnx->tls_ctx = NULL;
         }
 
-		if (cnx->congestion_alg != NULL)
-		{
-			cnx->congestion_alg->alg_delete(cnx);
-		}
+        if (cnx->congestion_alg != NULL) {
+            cnx->congestion_alg->alg_delete(cnx);
+        }
 
         free(cnx);
     }
 }
 
 /* Context retrieval functions */
-picoquic_cnx_t * picoquic_cnx_by_id(picoquic_quic_t * quic, uint64_t cnx_id)
+picoquic_cnx_t* picoquic_cnx_by_id(picoquic_quic_t* quic, uint64_t cnx_id)
 {
-    picoquic_cnx_t * ret = NULL;
-    picohash_item * item;
+    picoquic_cnx_t* ret = NULL;
+    picohash_item* item;
     picoquic_cnx_id key = { 0 };
     key.cnx_id = cnx_id;
 
     item = picohash_retrieve(quic->table_cnx_by_id, &key);
 
-    if (item != NULL)
-    {
-        ret = ((picoquic_cnx_id *)item->key)->cnx;
+    if (item != NULL) {
+        ret = ((picoquic_cnx_id*)item->key)->cnx;
     }
     return ret;
 }
 
-picoquic_cnx_t * picoquic_cnx_by_net(picoquic_quic_t * quic, struct sockaddr* addr)
+picoquic_cnx_t* picoquic_cnx_by_net(picoquic_quic_t* quic, struct sockaddr* addr)
 {
-    picoquic_cnx_t * ret = NULL;
-    picohash_item * item;
-    picoquic_net_id key = { {0} };
+    picoquic_cnx_t* ret = NULL;
+    picohash_item* item;
+    picoquic_net_id key = { { 0 } };
 
-    if (addr->sa_family == AF_INET)
-    {
+    if (addr->sa_family == AF_INET) {
         memcpy(&key.saddr, addr, sizeof(struct sockaddr_in));
-    }
-    else
-    {
+    } else {
         memcpy(&key.saddr, addr, sizeof(struct sockaddr_in6));
     }
 
     item = picohash_retrieve(quic->table_cnx_by_net, &key);
 
-    if (item != NULL)
-    {
-        ret = ((picoquic_net_id *)item->key)->cnx;
+    if (item != NULL) {
+        ret = ((picoquic_net_id*)item->key)->cnx;
     }
     return ret;
 }
@@ -1290,22 +1103,20 @@ picoquic_cnx_t * picoquic_cnx_by_net(picoquic_quic_t * quic, struct sockaddr* ad
  * Set or reset the congestion control algorithm
  */
 
-void picoquic_set_default_congestion_algorithm(picoquic_quic_t * quic, picoquic_congestion_algorithm_t const * alg)
+void picoquic_set_default_congestion_algorithm(picoquic_quic_t* quic, picoquic_congestion_algorithm_t const* alg)
 {
-	quic->default_congestion_alg = alg;
+    quic->default_congestion_alg = alg;
 }
 
-void picoquic_set_congestion_algorithm(picoquic_cnx_t * cnx, picoquic_congestion_algorithm_t const * alg)
+void picoquic_set_congestion_algorithm(picoquic_cnx_t* cnx, picoquic_congestion_algorithm_t const* alg)
 {
-	if (cnx->congestion_alg != NULL)
-	{
-		cnx->congestion_alg->alg_delete(cnx);
-	}
+    if (cnx->congestion_alg != NULL) {
+        cnx->congestion_alg->alg_delete(cnx);
+    }
 
-	cnx->congestion_alg = alg;
+    cnx->congestion_alg = alg;
 
-	if (cnx->congestion_alg != NULL)
-	{
-		cnx->congestion_alg->alg_init(cnx);
-	}
+    if (cnx->congestion_alg != NULL) {
+        cnx->congestion_alg->alg_init(cnx);
+    }
 }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -19,11 +19,11 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <string.h>
-#include <stdlib.h>
-#include "picoquic_internal.h"
 #include "fnv1a.h"
+#include "picoquic_internal.h"
 #include "tls_api.h"
+#include <stdlib.h>
+#include <string.h>
 
 /*
  * Sending logic.
@@ -44,115 +44,85 @@
  * Stream 0 is special, in the sense that it cannot be closed or reset, and is not
  * subject to flow control.
  */
-int picoquic_add_to_stream(picoquic_cnx_t * cnx, uint64_t stream_id, 
-	const uint8_t * data, size_t length, int set_fin)
+int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
+    const uint8_t* data, size_t length, int set_fin)
 {
     int ret = 0;
     int is_unidir = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
 
-    if (stream_id == 0)
-    {
+    if (stream_id == 0) {
         stream = &cnx->first_stream;
-    }
-    else
-    {
+    } else {
         stream = picoquic_find_stream(cnx, stream_id, 0);
 
-        if (stream == NULL)
-        {
+        if (stream == NULL) {
             /* Need to check that the ID is authorized */
 
             /* Check parity */
             int parity = cnx->client_mode ? 0 : 1;
-            if ((stream_id & 1) != parity)
-            {
+            if ((stream_id & 1) != parity) {
                 ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-            }
-            else
-            {
-                if ((stream_id & 2) == 0)
-                {
-                    if (stream_id > cnx->max_stream_id_bidir_remote)
-                    {
+            } else {
+                if ((stream_id & 2) == 0) {
+                    if (stream_id > cnx->max_stream_id_bidir_remote) {
                         ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
                     }
-                }
-                else
-                {
+                } else {
                     is_unidir = 1;
 
-                    if (stream_id > cnx->max_stream_id_unidir_remote)
-                    {
+                    if (stream_id > cnx->max_stream_id_unidir_remote) {
                         ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
                     }
                 }
             }
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 stream = picoquic_create_stream(cnx, stream_id);
 
-                if (stream == NULL)
-                {
+                if (stream == NULL) {
                     ret = PICOQUIC_ERROR_MEMORY;
-                }
-                else if (is_unidir)
-                {
+                } else if (is_unidir) {
                     /* Mark the stream as already finished in remote direction */
-                    stream->stream_flags |= picoquic_stream_flag_fin_signalled |
-                        picoquic_stream_flag_fin_received;
+                    stream->stream_flags |= picoquic_stream_flag_fin_signalled | picoquic_stream_flag_fin_received;
                 }
             }
         }
     }
 
-    if (ret == 0 && set_fin)
-    {
-        if ((stream->stream_flags&picoquic_stream_flag_fin_notified) != 0)
-        {
+    if (ret == 0 && set_fin) {
+        if ((stream->stream_flags & picoquic_stream_flag_fin_notified) != 0) {
             /* app error, notified the fin twice*/
-            if (length > 0)
-            {
+            if (length > 0) {
                 ret = -1;
             }
-        }
-        else
-        {
+        } else {
             stream->stream_flags |= picoquic_stream_flag_fin_notified;
         }
     }
 
-	if (ret == 0 && length > 0)
-    {
-        picoquic_stream_data * stream_data = (picoquic_stream_data *)malloc(sizeof(picoquic_stream_data));
+    if (ret == 0 && length > 0) {
+        picoquic_stream_data* stream_data = (picoquic_stream_data*)malloc(sizeof(picoquic_stream_data));
 
-        if (stream_data == 0)
-        {
+        if (stream_data == 0) {
             ret = -1;
-        }
-        else
-        {
-            stream_data->bytes = (uint8_t *)malloc(length);
+        } else {
+            stream_data->bytes = (uint8_t*)malloc(length);
 
-            if (stream_data->bytes == NULL)
-            {
+            if (stream_data->bytes == NULL) {
                 free(stream_data);
                 stream_data = NULL;
                 ret = -1;
-            }
-            else
-            {
-                picoquic_stream_data ** pprevious = &stream->send_queue;
-                picoquic_stream_data * next = stream->send_queue;
+            } else {
+                picoquic_stream_data** pprevious = &stream->send_queue;
+                picoquic_stream_data* next = stream->send_queue;
 
                 memcpy(stream_data->bytes, data, length);
                 stream_data->length = length;
                 stream_data->offset = 0;
                 stream_data->next_stream_data = NULL;
 
-                while (next != NULL)
-                {
+                while (next != NULL) {
                     pprevious = &next->next_stream_data;
                     next = next->next_stream_data;
                 }
@@ -165,62 +135,46 @@ int picoquic_add_to_stream(picoquic_cnx_t * cnx, uint64_t stream_id,
     return ret;
 }
 
-int picoquic_reset_stream(picoquic_cnx_t * cnx,
-	uint64_t stream_id, uint16_t local_stream_error)
-{
-	int ret = 0;
-	picoquic_stream_head * stream = NULL;
-
-	if (stream_id == 0)
-	{
-		ret = PICOQUIC_ERROR_CANNOT_RESET_STREAM_ZERO;
-	}
-	else
-	{
-		stream = picoquic_find_stream(cnx, stream_id, 1);
-
-		if (stream == NULL)
-		{
-			ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-		}
-		else if ((stream->stream_flags & picoquic_stream_flag_fin_sent) != 0)
-		{
-			ret = PICOQUIC_ERROR_STREAM_ALREADY_CLOSED;
-		}
-		else if ((stream->stream_flags&picoquic_stream_flag_reset_requested) == 0)
-		{
-			stream->local_error = local_stream_error;
-			stream->stream_flags |= picoquic_stream_flag_reset_requested;
-		}
-	}
-
-	return ret;
-}
-
-int picoquic_stop_sending(picoquic_cnx_t * cnx,
+int picoquic_reset_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint16_t local_stream_error)
 {
     int ret = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
 
-    if (stream_id == 0)
-    {
-        ret = PICOQUIC_ERROR_CANNOT_STOP_STREAM_ZERO;
-    }
-    else
-    {
+    if (stream_id == 0) {
+        ret = PICOQUIC_ERROR_CANNOT_RESET_STREAM_ZERO;
+    } else {
         stream = picoquic_find_stream(cnx, stream_id, 1);
 
-        if (stream == NULL)
-        {
+        if (stream == NULL) {
             ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-        }
-        else if ((stream->stream_flags & picoquic_stream_flag_reset_received) != 0)
-        {
+        } else if ((stream->stream_flags & picoquic_stream_flag_fin_sent) != 0) {
             ret = PICOQUIC_ERROR_STREAM_ALREADY_CLOSED;
+        } else if ((stream->stream_flags & picoquic_stream_flag_reset_requested) == 0) {
+            stream->local_error = local_stream_error;
+            stream->stream_flags |= picoquic_stream_flag_reset_requested;
         }
-        else if ((stream->stream_flags&picoquic_stream_flag_stop_sending_requested) == 0)
-        {
+    }
+
+    return ret;
+}
+
+int picoquic_stop_sending(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint16_t local_stream_error)
+{
+    int ret = 0;
+    picoquic_stream_head* stream = NULL;
+
+    if (stream_id == 0) {
+        ret = PICOQUIC_ERROR_CANNOT_STOP_STREAM_ZERO;
+    } else {
+        stream = picoquic_find_stream(cnx, stream_id, 1);
+
+        if (stream == NULL) {
+            ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
+        } else if ((stream->stream_flags & picoquic_stream_flag_reset_received) != 0) {
+            ret = PICOQUIC_ERROR_STREAM_ALREADY_CLOSED;
+        } else if ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) == 0) {
             stream->local_stop_error = local_stream_error;
             stream->stream_flags |= picoquic_stream_flag_stop_sending_requested;
         }
@@ -229,12 +183,11 @@ int picoquic_stop_sending(picoquic_cnx_t * cnx,
     return ret;
 }
 
-picoquic_packet * picoquic_create_packet()
+picoquic_packet* picoquic_create_packet()
 {
-    picoquic_packet * packet = (picoquic_packet *)malloc(sizeof(picoquic_packet));
+    picoquic_packet* packet = (picoquic_packet*)malloc(sizeof(picoquic_packet));
 
-    if (packet != NULL)
-    {
+    if (packet != NULL) {
         memset(packet, 0, sizeof(picoquic_packet));
     }
 
@@ -298,19 +251,16 @@ size_t picoquic_create_packet_header_05_07(
 #endif
 
 size_t picoquic_create_packet_header_08(
-    picoquic_cnx_t * cnx,
+    picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
     uint64_t cnx_id,
     uint64_t sequence_number,
-    uint8_t * bytes
-)
+    uint8_t* bytes)
 {
     size_t length = 0;
 
     /* Prepare the packet header */
-    if (packet_type == picoquic_packet_1rtt_protected_phi0 ||
-        packet_type == picoquic_packet_1rtt_protected_phi1)
-    {
+    if (packet_type == picoquic_packet_1rtt_protected_phi0 || packet_type == picoquic_packet_1rtt_protected_phi1) {
         /* Create a short packet -- using 32 bit sequence numbers for now */
         uint8_t C = (cnx->remote_parameters.omit_connection_id != 0) ? 0x40 : 0;
         uint8_t K = (packet_type == picoquic_packet_1rtt_protected_phi0) ? 0 : 0x20;
@@ -318,19 +268,15 @@ size_t picoquic_create_packet_header_08(
 
         length = 0;
         bytes[length++] = (C | K | PT);
-        if (C == 0)
-        {
+        if (C == 0) {
             picoformat_64(&bytes[length], cnx_id);
             length += 8;
         }
         picoformat_32(&bytes[length], (uint32_t)sequence_number);
         length += 4;
-    }
-    else
-    {
+    } else {
         /* Create a long packet */
-        switch (packet_type)
-        {
+        switch (packet_type) {
         case picoquic_packet_client_initial:
             bytes[0] = 0xFF;
             break;
@@ -350,14 +296,9 @@ size_t picoquic_create_packet_header_08(
         }
 
         picoformat_64(&bytes[1], cnx_id);
-        if ((cnx->cnx_state == picoquic_state_client_init ||
-            cnx->cnx_state == picoquic_state_client_init_sent) &&
-            packet_type == picoquic_packet_client_initial)
-        {
+        if ((cnx->cnx_state == picoquic_state_client_init || cnx->cnx_state == picoquic_state_client_init_sent) && packet_type == picoquic_packet_client_initial) {
             picoformat_32(&bytes[9], cnx->proposed_version);
-        }
-        else
-        {
+        } else {
             picoformat_32(&bytes[9],
                 picoquic_supported_versions[cnx->version_index].version);
         }
@@ -370,16 +311,14 @@ size_t picoquic_create_packet_header_08(
 }
 
 size_t picoquic_create_packet_header(
-    picoquic_cnx_t * cnx,
+    picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
     uint64_t cnx_id,
     uint64_t sequence_number,
-    uint8_t * bytes
-)
+    uint8_t* bytes)
 {
     size_t header_length = 0;
-    switch (picoquic_supported_versions[cnx->version_index].version_header_encoding)
-    {
+    switch (picoquic_supported_versions[cnx->version_index].version_header_encoding) {
     case picoquic_version_header_08:
         header_length = picoquic_create_packet_header_08(cnx, packet_type, cnx_id, sequence_number, bytes);
         break;
@@ -392,16 +331,13 @@ size_t picoquic_create_packet_header(
 /*
  * Management of protection of cleartext packets
  */
-size_t picoquic_get_checksum_length(picoquic_cnx_t * cnx, int is_cleartext_mode)
+size_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode)
 {
     size_t ret = 16;
 
-    if (is_cleartext_mode )
-    {
+    if (is_cleartext_mode) {
         ret = picoquic_aead_get_checksum_length(cnx->aead_encrypt_cleartext_ctx);
-    }
-    else
-    {
+    } else {
         ret = picoquic_aead_get_checksum_length(cnx->aead_encrypt_ctx);
     }
 
@@ -412,18 +348,16 @@ size_t picoquic_get_checksum_length(picoquic_cnx_t * cnx, int is_cleartext_mode)
  * Reset the pacing data after CWIN is updated
  */
 
-void picoquic_update_pacing_data(picoquic_cnx_t * cnx)
+void picoquic_update_pacing_data(picoquic_cnx_t* cnx)
 {
-    cnx->packet_time_nano_sec = cnx->smoothed_rtt * 1000ull *cnx->send_mtu;
+    cnx->packet_time_nano_sec = cnx->smoothed_rtt * 1000ull * cnx->send_mtu;
     cnx->packet_time_nano_sec /= cnx->cwin;
 
     cnx->pacing_margin_micros = 16 * cnx->packet_time_nano_sec;
-    if (cnx->pacing_margin_micros > (cnx->rtt_min / 4))
-    {
+    if (cnx->pacing_margin_micros > (cnx->rtt_min / 4)) {
         cnx->pacing_margin_micros = (cnx->rtt_min / 4);
     }
-    if (cnx->pacing_margin_micros < 1000)
-    {
+    if (cnx->pacing_margin_micros < 1000) {
         cnx->pacing_margin_micros = 1000;
     }
 }
@@ -431,15 +365,12 @@ void picoquic_update_pacing_data(picoquic_cnx_t * cnx)
 /* 
  * Update the pacing data after sending a packet
  */
-void picoquic_update_pacing_after_send(picoquic_cnx_t * cnx, uint64_t current_time)
+void picoquic_update_pacing_after_send(picoquic_cnx_t* cnx, uint64_t current_time)
 {
-    if (cnx->next_pacing_time < current_time)
-    {
+    if (cnx->next_pacing_time < current_time) {
         cnx->next_pacing_time = current_time;
         cnx->pacing_reminder_nano_sec = 0;
-    }
-    else
-    {
+    } else {
         cnx->pacing_reminder_nano_sec += cnx->packet_time_nano_sec;
         cnx->next_pacing_time += (cnx->pacing_reminder_nano_sec >> 10);
         cnx->pacing_reminder_nano_sec &= 0x3FF;
@@ -450,7 +381,7 @@ void picoquic_update_pacing_after_send(picoquic_cnx_t * cnx, uint64_t current_ti
  * Final steps in packet transmission: queue for retransmission, etc
  */
 
-void picoquic_queue_for_retransmit(picoquic_cnx_t * cnx, picoquic_packet * packet,
+void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_packet* packet,
     size_t length, uint64_t current_time)
 {
     /* Account for bytes in transit, for congestion control */
@@ -458,13 +389,10 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t * cnx, picoquic_packet * packe
 
     /* Manage the double linked packet list for retransmissions */
     packet->previous_packet = NULL;
-    if (cnx->retransmit_newest == NULL)
-    {
+    if (cnx->retransmit_newest == NULL) {
         packet->next_packet = NULL;
         cnx->retransmit_oldest = packet;
-    }
-    else
-    {
+    } else {
         packet->next_packet = cnx->retransmit_newest;
         packet->next_packet->previous_packet = packet;
     }
@@ -479,61 +407,49 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t * cnx, picoquic_packet * packe
  * retransmission. Also, prune the retransmit queue as needed.
  */
 
-static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t * cnx, 
-    picoquic_packet * p, uint64_t current_time, int * timer_based)
+static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
+    picoquic_packet* p, uint64_t current_time, int* timer_based)
 {
 
     int64_t delta_seq = cnx->highest_acknowledged - p->sequence_number;
     int should_retransmit = 0;
 
-    if (delta_seq > 3)
-    {
+    if (delta_seq > 3) {
         /*
          * SACK Logic.
          * more than N packets were seen at the receiver after this one.
          */
         should_retransmit = 1;
-    }
-    else
-    {
+    } else {
         int64_t delta_t = cnx->latest_time_acknowledged - p->send_time;
 
         /* TODO: out of order delivery time ought to be dynamic */
-        if (delta_t > 10000)
-        {
+        if (delta_t > 10000) {
             /*
              * RACK logic.
              * The latest acknowledged was sent more than X ms after this one.
              */
             should_retransmit = 1;
-        }
-        else if (delta_t > 0)
-        {
+        } else if (delta_t > 0) {
             /* If the delta-t is larger than zero, add the time since the
             * last ACK was received. If that is larger than the inter packet
             * time, consider that there is a loss */
             uint64_t time_from_last_ack = current_time - cnx->latest_time_acknowledged + delta_t;
 
-            if (time_from_last_ack > 10000)
-            {
+            if (time_from_last_ack > 10000) {
                 should_retransmit = 1;
             }
         }
 
-        if (should_retransmit == 0)
-        {
+        if (should_retransmit == 0) {
             /* Don't fire yet, because of possible out of order delivery */
             int64_t time_out = current_time - p->send_time;
-            uint64_t retransmit_timer = (cnx->nb_retransmit == 0) ?
-                cnx->retransmit_timer : (1000000 << (cnx->nb_retransmit - 1));
+            uint64_t retransmit_timer = (cnx->nb_retransmit == 0) ? cnx->retransmit_timer : (1000000 << (cnx->nb_retransmit - 1));
 
-            if ((uint64_t)time_out <= retransmit_timer)
-            {
+            if ((uint64_t)time_out <= retransmit_timer) {
                 /* Do not retransmit if the timer has not yet elapsed */
                 should_retransmit = 0;
-            }
-            else
-            {
+            } else {
                 should_retransmit = 1;
                 *timer_based = 1;
             }
@@ -543,127 +459,100 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t * cnx,
     return should_retransmit;
 }
 
-int picoquic_retransmit_needed(picoquic_cnx_t * cnx, uint64_t current_time, 
-	picoquic_packet * packet, int * is_cleartext_mode, size_t * header_length)
+int picoquic_retransmit_needed(picoquic_cnx_t* cnx, uint64_t current_time,
+    picoquic_packet* packet, int* is_cleartext_mode, size_t* header_length)
 {
-    picoquic_packet * p = cnx->retransmit_oldest;
-	size_t length = 0;
+    picoquic_packet* p = cnx->retransmit_oldest;
+    size_t length = 0;
 
-	/* TODO: while packets are pure ACK, drop them from retransmit queue */
-    while (p != NULL)
-    {
+    /* TODO: while packets are pure ACK, drop them from retransmit queue */
+    while (p != NULL) {
         int should_retransmit = 0;
         int timer_based_retransmit = 0;
         uint64_t lost_packet_number = p->sequence_number;
-        picoquic_packet * p_next = p->next_packet;
+        picoquic_packet* p_next = p->next_packet;
 
         length = 0;
 
         should_retransmit = picoquic_retransmit_needed_by_packet(cnx, p, current_time, &timer_based_retransmit);
 
-        if (should_retransmit == 0)
-        {
+        if (should_retransmit == 0) {
             /*
              * Always retransmit in order. If not this one, then nothing.
              */
             break;
-        }
-        else
-        {
+        } else {
             /* check if this is an ACK only packet */
             picoquic_packet_header ph;
             int ret = 0;
             int packet_is_pure_ack = 1;
             int do_not_detect_spurious = 1;
             int frame_is_pure_ack = 0;
-            uint8_t * bytes = packet->bytes;
+            uint8_t* bytes = packet->bytes;
             size_t frame_length = 0;
             size_t byte_index = 0; /* Used when parsing the old packet */
             size_t checksum_length = 0;
-            picoquic_cnx_t * pcnx = cnx;
+            picoquic_cnx_t* pcnx = cnx;
 
             *header_length = 0;
             /* Get the packet type */
             ret = picoquic_parse_packet_header(cnx->quic, p->bytes, (uint32_t)p->length, NULL, &ph, &pcnx);
 
-            if (ph.ptype == picoquic_packet_0rtt_protected)
-            {
-                if (cnx->cnx_state < picoquic_state_client_ready && cnx->client_mode)
-                {
+            if (ph.ptype == picoquic_packet_0rtt_protected) {
+                if (cnx->cnx_state < picoquic_state_client_ready && cnx->client_mode) {
                     should_retransmit = 0;
-                }
-                else
-                {
+                } else {
                     length = picoquic_create_packet_header(cnx, picoquic_packet_1rtt_protected_phi0,
                         cnx->server_cnxid, cnx->send_sequence, bytes);
                 }
-            }
-            else
-            {
+            } else {
                 length = picoquic_create_packet_header(cnx, ph.ptype,
                     ph.cnx_id, cnx->send_sequence, bytes);
             }
 
-            if (should_retransmit != 0)
-            {
+            if (should_retransmit != 0) {
                 packet->sequence_number = cnx->send_sequence;
 
                 *header_length = length;
 
-                if (ph.ptype == picoquic_packet_1rtt_protected_phi0 ||
-                    ph.ptype == picoquic_packet_1rtt_protected_phi1 ||
-                    ph.ptype == picoquic_packet_0rtt_protected)
-                {
+                if (ph.ptype == picoquic_packet_1rtt_protected_phi0 || ph.ptype == picoquic_packet_1rtt_protected_phi1 || ph.ptype == picoquic_packet_0rtt_protected) {
                     *is_cleartext_mode = 0;
-                }
-                else
-                {
+                } else {
                     *is_cleartext_mode = 1;
                 }
 
-                if ((p->length + p->checksum_overhead) > cnx->send_mtu)
-                {
+                if ((p->length + p->checksum_overhead) > cnx->send_mtu) {
                     /* MTU probe was lost, presumably because of packet too big */
                     cnx->mtu_probe_sent = 0;
                     cnx->send_mtu_max_tried = p->length + p->checksum_overhead;
                     /* MTU probes should not be retransmitted */
                     packet_is_pure_ack = 1;
                     do_not_detect_spurious = 0;
-                }
-                else if (ph.ptype == picoquic_packet_client_initial &&
-                    cnx->cnx_state >= picoquic_state_client_handshake_start)
-                {
+                } else if (ph.ptype == picoquic_packet_client_initial && cnx->cnx_state >= picoquic_state_client_handshake_start) {
                     /* pretending this is a pure ACK to avoid undue retransmission */
                     packet_is_pure_ack = 1;
-                }
-                else
-                {
+                } else {
                     checksum_length = picoquic_get_checksum_length(cnx, *is_cleartext_mode);
 
                     /* Copy the relevant bytes from one packet to the next */
                     byte_index = ph.offset;
 
-                    while (ret == 0 && byte_index < p->length)
-                    {
+                    while (ret == 0 && byte_index < p->length) {
                         ret = picoquic_skip_frame(&p->bytes[byte_index],
                             p->length - byte_index, &frame_length, &frame_is_pure_ack);
 
                         /* Check whether the data was already acked, which may happen in 
                          * case of spurious retransmissions */
-                        if (ret == 0 && frame_is_pure_ack == 0)
-                        {
+                        if (ret == 0 && frame_is_pure_ack == 0) {
                             ret = picoquic_check_stream_frame_already_acked(cnx, &p->bytes[byte_index],
                                 frame_length, &frame_is_pure_ack);
                         }
 
                         /* Prepare retransmission if needed */
-                        if (ret == 0 && !frame_is_pure_ack)
-                        {
-                            if (picoquic_test_stream_frame_unlimited(&p->bytes[byte_index]) != 0)
-                            {
+                        if (ret == 0 && !frame_is_pure_ack) {
+                            if (picoquic_test_stream_frame_unlimited(&p->bytes[byte_index]) != 0) {
                                 /* Need to PAD to the end of the frame to avoid sending extra bytes */
-                                while (checksum_length + length + frame_length < cnx->send_mtu)
-                                {
+                                while (checksum_length + length + frame_length < cnx->send_mtu) {
                                     bytes[length] = picoquic_frame_type_padding;
                                     length++;
                                 }
@@ -679,58 +568,44 @@ int picoquic_retransmit_needed(picoquic_cnx_t * cnx, uint64_t current_time,
                 /* Update the number of bytes in transit and remove old packet from queue */
                 /* If not pure ack, the packet will be placed in the "retransmitted" queue,
                  * in order to enable detection of spurious restransmissions */
-                picoquic_dequeue_retransmit_packet(cnx, p, packet_is_pure_ack&do_not_detect_spurious);
+                picoquic_dequeue_retransmit_packet(cnx, p, packet_is_pure_ack & do_not_detect_spurious);
 
                 /* If we have a good packet, return it */
-                if (packet_is_pure_ack)
-                {
+                if (packet_is_pure_ack) {
                     length = 0;
                     should_retransmit = 0;
-                }
-                else
-                {
-                    if (timer_based_retransmit != 0)
-                    {
-                        if (cnx->nb_retransmit > 4)
-                        {
+                } else {
+                    if (timer_based_retransmit != 0) {
+                        if (cnx->nb_retransmit > 4) {
                             /*
                              * Max retransmission count was exceeded. Disconnect.
                              */
                             cnx->cnx_state = picoquic_state_disconnected;
-                            if (cnx->callback_fn)
-                            {
+                            if (cnx->callback_fn) {
                                 (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
                             }
                             length = 0;
                             should_retransmit = 0;
                             break;
-                        }
-                        else
-                        {
+                        } else {
                             cnx->nb_retransmit++;
                             cnx->latest_retransmit_time = current_time;
                         }
                     }
 
-                    if (should_retransmit != 0)
-                    {
+                    if (should_retransmit != 0) {
                         /* special case for the client initial */
-                        if (ph.ptype == picoquic_packet_client_initial)
-                        {
-                            while (length < (cnx->send_mtu - checksum_length))
-                            {
+                        if (ph.ptype == picoquic_packet_client_initial) {
+                            while (length < (cnx->send_mtu - checksum_length)) {
                                 bytes[length++] = 0;
                             }
                         }
                         packet->length = length;
                         cnx->nb_retransmission_total++;
 
-                        if (cnx->congestion_alg != NULL)
-                        {
+                        if (cnx->congestion_alg != NULL) {
                             cnx->congestion_alg->alg_notify(cnx,
-                                (timer_based_retransmit == 0) ?
-                                picoquic_congestion_notification_repeat :
-                                picoquic_congestion_notification_timeout,
+                                (timer_based_retransmit == 0) ? picoquic_congestion_notification_repeat : picoquic_congestion_notification_timeout,
                                 0, 0, lost_packet_number, current_time);
                         }
 
@@ -746,26 +621,25 @@ int picoquic_retransmit_needed(picoquic_cnx_t * cnx, uint64_t current_time,
         p = p_next;
     }
 
-	return (int) length;
+    return (int)length;
 }
 
 /*
  * Returns true if there is nothing to repeat in the retransmission queue
  */
-int picoquic_is_cnx_backlog_empty(picoquic_cnx_t * cnx)
+int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx)
 {
-    picoquic_packet * p = cnx->retransmit_oldest;
+    picoquic_packet* p = cnx->retransmit_oldest;
     int backlog_empty = 1;
 
-    while (p != NULL && backlog_empty == 1)
-    {
+    while (p != NULL && backlog_empty == 1) {
         /* check if this is an ACK only packet */
         picoquic_packet_header ph;
         int ret = 0;
         int frame_is_pure_ack = 0;
         size_t frame_length = 0;
         size_t byte_index = 0; /* Used when parsing the old packet */
-        picoquic_cnx_t * pcnx = cnx;
+        picoquic_cnx_t* pcnx = cnx;
 
         /* Get the packet type */
         ret = picoquic_parse_packet_header(cnx->quic, p->bytes, (uint32_t)p->length, NULL, &ph, &pcnx);
@@ -773,13 +647,11 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t * cnx)
         /* Copy the relevant bytes from one packet to the next */
         byte_index = ph.offset;
 
-        while (ret == 0 && byte_index < p->length)
-        {
+        while (ret == 0 && byte_index < p->length) {
             ret = picoquic_skip_frame(&p->bytes[byte_index],
                 p->length - ph.offset, &frame_length, &frame_is_pure_ack);
 
-            if (!frame_is_pure_ack)
-            {
+            if (!frame_is_pure_ack) {
                 backlog_empty = 0;
                 break;
             }
@@ -793,7 +665,7 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t * cnx)
 }
 
 /* Decide whether MAX data need to be sent or not */
-int picoquic_should_send_max_data(picoquic_cnx_t * cnx)
+int picoquic_should_send_max_data(picoquic_cnx_t* cnx)
 {
     int ret = 0;
 
@@ -804,15 +676,10 @@ int picoquic_should_send_max_data(picoquic_cnx_t * cnx)
 }
 
 /* Decide whether to send an MTU probe */
-int picoquic_is_mtu_probe_needed(picoquic_cnx_t * cnx)
+int picoquic_is_mtu_probe_needed(picoquic_cnx_t* cnx)
 {
     int ret = 0;
-    if ((cnx->cnx_state == picoquic_state_client_ready ||
-        cnx->cnx_state == picoquic_state_server_ready) &&
-        cnx->mtu_probe_sent == 0 && 
-        (cnx->send_mtu_max_tried == 0 ||
-        (cnx->send_mtu + 10) < cnx->send_mtu_max_tried))
-    {
+    if ((cnx->cnx_state == picoquic_state_client_ready || cnx->cnx_state == picoquic_state_server_ready) && cnx->mtu_probe_sent == 0 && (cnx->send_mtu_max_tried == 0 || (cnx->send_mtu + 10) < cnx->send_mtu_max_tried)) {
         ret = 1;
     }
 
@@ -820,26 +687,20 @@ int picoquic_is_mtu_probe_needed(picoquic_cnx_t * cnx)
 }
 
 /* Prepare an MTU probe packet */
-size_t picoquic_prepare_mtu_probe(picoquic_cnx_t * cnx, size_t header_length, size_t checksum_length,
-    uint8_t * bytes)
+size_t picoquic_prepare_mtu_probe(picoquic_cnx_t* cnx, size_t header_length, size_t checksum_length,
+    uint8_t* bytes)
 {
     size_t probe_length;
     size_t length = header_length;
 
-    if (cnx->send_mtu_max_tried == 0)
-    {
+    if (cnx->send_mtu_max_tried == 0) {
         probe_length = cnx->remote_parameters.max_packet_size;
-        if (probe_length == 0)
-        {
+        if (probe_length == 0) {
+            probe_length = PICOQUIC_MAX_PACKET_SIZE;
+        } else if (probe_length > PICOQUIC_MAX_PACKET_SIZE) {
             probe_length = PICOQUIC_MAX_PACKET_SIZE;
         }
-        else if (probe_length > PICOQUIC_MAX_PACKET_SIZE)
-        {
-            probe_length = PICOQUIC_MAX_PACKET_SIZE;
-        }
-    }
-    else
-    {
+    } else {
         probe_length = (cnx->send_mtu + cnx->send_mtu_max_tried) / 2;
     }
 
@@ -851,86 +712,55 @@ size_t picoquic_prepare_mtu_probe(picoquic_cnx_t * cnx, size_t header_length, si
 }
 
 /* Decide the next time at which the connection should send data */
-void picoquic_cnx_set_next_wake_time(picoquic_cnx_t * cnx, uint64_t current_time)
+void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
 {
     uint64_t next_time = cnx->latest_progress_time + PICOQUIC_MICROSEC_SILENCE_MAX;
-    picoquic_packet * p = cnx->retransmit_oldest;
-    picoquic_stream_head * stream = NULL;
+    picoquic_packet* p = cnx->retransmit_oldest;
+    picoquic_stream_head* stream = NULL;
     int timer_based = 0;
     int blocked = 1;
     int pacing = 0;
 
-    if (cnx->cnx_state == picoquic_state_disconnecting ||
-        cnx->cnx_state == picoquic_state_handshake_failure)
-    {
+    if (cnx->cnx_state == picoquic_state_disconnecting || cnx->cnx_state == picoquic_state_handshake_failure) {
         blocked = 0;
-    }
-    else if (p != NULL && picoquic_retransmit_needed_by_packet(cnx, p, current_time, &timer_based))
-    {
+    } else if (p != NULL && picoquic_retransmit_needed_by_packet(cnx, p, current_time, &timer_based)) {
         blocked = 0;
-    }
-    else if (picoquic_is_ack_needed(cnx, current_time))
-    {
+    } else if (picoquic_is_ack_needed(cnx, current_time)) {
         blocked = 0;
-    }
-    else if (picoquic_is_mtu_probe_needed(cnx))
-    {
+    } else if (picoquic_is_mtu_probe_needed(cnx)) {
         blocked = 0;
-    }
-    else if (cnx->cwin > cnx->bytes_in_transit)
-    {
-        if (picoquic_should_send_max_data(cnx) ||
-            (stream = picoquic_find_ready_stream(cnx,
-            (cnx->cnx_state == picoquic_state_client_ready ||
-                cnx->cnx_state == picoquic_state_server_ready) ? 0 : 1)) != NULL)
-        {
-            if (cnx->next_pacing_time < current_time + cnx->pacing_margin_micros)
-            {
+    } else if (cnx->cwin > cnx->bytes_in_transit) {
+        if (picoquic_should_send_max_data(cnx) || (stream = picoquic_find_ready_stream(cnx, (cnx->cnx_state == picoquic_state_client_ready || cnx->cnx_state == picoquic_state_server_ready) ? 0 : 1)) != NULL) {
+            if (cnx->next_pacing_time < current_time + cnx->pacing_margin_micros) {
                 blocked = 0;
-            }
-            else
-            {
+            } else {
                 pacing = 1;
             }
         }
     }
 
-    if (blocked == 0)
-    {
+    if (blocked == 0) {
         next_time = current_time;
-    }
-    else if (pacing != 0)
-    {
+    } else if (pacing != 0) {
         next_time = cnx->next_pacing_time;
-    }
-    else
-    {
+    } else {
         /* Consider delayed ACK */
-        if (cnx->ack_needed)
-        {
+        if (cnx->ack_needed) {
             next_time = cnx->highest_ack_time + cnx->ack_delay_local;
         }
 
         /* Consider delayed RACK */
-        if (p != NULL)
-        {
-            if (cnx->latest_time_acknowledged > p->send_time &&
-                p->send_time + cnx->max_ack_delay < next_time)
-            {
+        if (p != NULL) {
+            if (cnx->latest_time_acknowledged > p->send_time && p->send_time + cnx->max_ack_delay < next_time) {
                 next_time = p->send_time + cnx->max_ack_delay;
             }
 
-            if (cnx->nb_retransmit == 0)
-            {
-                if (p->send_time + cnx->retransmit_timer < next_time)
-                {
+            if (cnx->nb_retransmit == 0) {
+                if (p->send_time + cnx->retransmit_timer < next_time) {
                     next_time = p->send_time + cnx->retransmit_timer;
                 }
-            }
-            else
-            {
-                if (p->send_time + (1000000ull << (cnx->nb_retransmit - 1)) < next_time)
-                {
+            } else {
+                if (p->send_time + (1000000ull << (cnx->nb_retransmit - 1)) < next_time) {
                     next_time = p->send_time + (1000000ull << (cnx->nb_retransmit - 1));
                 }
             }
@@ -946,22 +776,21 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t * cnx, uint64_t current_time
 /* Prepare the next packet to 0-RTT packet to send in the client initial
  * state, when 0-RTT is available
  */
-int picoquic_prepare_packet_0rtt(picoquic_cnx_t * cnx, picoquic_packet * packet,
-    uint64_t current_time, uint8_t * send_buffer, size_t * send_length)
+int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
     int ret = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     int stream_restricted = 0;
     picoquic_packet_type_enum packet_type = picoquic_packet_0rtt_protected;
     size_t data_bytes = 0;
     uint64_t cnx_id = cnx->initial_cnxid;
     size_t header_length = 0;
-    uint8_t * bytes = packet->bytes;
+    uint8_t* bytes = packet->bytes;
     size_t length = 0;
     size_t checksum_overhead = picoquic_aead_get_checksum_length(cnx->aead_0rtt_encrypt_ctx);
 
     stream = picoquic_find_ready_stream(cnx, stream_restricted);
-
 
     length = picoquic_create_packet_header(
         cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
@@ -969,42 +798,31 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t * cnx, picoquic_packet * packet,
     packet->sequence_number = cnx->send_sequence;
     packet->send_time = current_time;
 
-    if ((stream == NULL && cnx->first_misc_frame == NULL) || 
-        (PICOQUIC_DEFAULT_0RTT_WINDOW <= cnx->bytes_in_transit + cnx->send_mtu))
-    {
+    if ((stream == NULL && cnx->first_misc_frame == NULL) || (PICOQUIC_DEFAULT_0RTT_WINDOW <= cnx->bytes_in_transit + cnx->send_mtu)) {
         length = 0;
-    }
-    else
-    {
+    } else {
         /* If present, send misc frame */
-        while (cnx->first_misc_frame != NULL)
-        {
+        while (cnx->first_misc_frame != NULL) {
             ret = picoquic_prepare_misc_frame(cnx, &bytes[length],
                 cnx->send_mtu - checksum_overhead - length, &data_bytes);
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 length += data_bytes;
-            }
-            else
-            {
+            } else {
                 break;
             }
         }
         /* Encode the stream frame */
-        if (stream != NULL)
-        {
+        if (stream != NULL) {
             ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
                 cnx->send_mtu - checksum_overhead - length, &data_bytes);
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 length += data_bytes;
             }
         }
     }
 
-    if (ret == 0 && length > 0)
-    {
+    if (ret == 0 && length > 0) {
         packet->length = length;
         cnx->send_sequence++;
 
@@ -1022,9 +840,7 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t * cnx, picoquic_packet * packet,
 
         /* Accounting of zero rtt packets sent */
         cnx->nb_zero_rtt_sent++;
-    }
-    else
-    {
+    } else {
         *send_length = 0;
     }
 
@@ -1034,11 +850,11 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t * cnx, picoquic_packet * packet,
 }
 
 /* Prepare the next packet to send when in one the client initial states */
-int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * packet,
-    uint64_t current_time, uint8_t * send_buffer, size_t * send_length)
+int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
     int ret = 0;
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     int stream_restricted = 1;
     picoquic_packet_type_enum packet_type = 0;
     size_t checksum_overhead = 8;
@@ -1047,13 +863,12 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * 
     uint64_t cnx_id = cnx->server_cnxid;
     int retransmit_possible = 0;
     size_t header_length = 0;
-    uint8_t * bytes = packet->bytes;
+    uint8_t* bytes = packet->bytes;
     size_t length = 0;
 
     /* Prepare header -- depend on connection state */
     /* TODO: 0-RTT work. */
-    switch (cnx->cnx_state)
-    {
+    switch (cnx->cnx_state) {
     case picoquic_state_client_init:
         packet_type = picoquic_packet_client_initial;
         cnx_id = cnx->initial_cnxid;
@@ -1088,92 +903,67 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * 
 
     stream = picoquic_find_ready_stream(cnx, stream_restricted);
 
-    if (ret == 0 && retransmit_possible &&
-        (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0)
-    {
+    if (ret == 0 && retransmit_possible && (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
         /* Set the new checksum length */
         checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
         /* Check whether it makes sens to add an ACK at the end of the retransmission */
         if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            cnx->send_mtu - checksum_overhead - length, &data_bytes) == 0)
-        {
+                cnx->send_mtu - checksum_overhead - length, &data_bytes)
+            == 0) {
             length += data_bytes;
             packet->length = length;
         }
         /* document the send time & overhead */
         packet->send_time = current_time;
         packet->checksum_overhead = checksum_overhead;
-    }
-    else if (ret == 0 && is_cleartext_mode && stream == NULL)
-    {
+    } else if (ret == 0 && is_cleartext_mode && stream == NULL) {
         /* when in a clear text mode, only send packets if there is
         * actually something to send, or resend */
 
         packet->length = 0;
-    }
-    else if (ret == 0)
-    {
+    } else if (ret == 0) {
         length = picoquic_create_packet_header(
             cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
         header_length = length;
         packet->sequence_number = cnx->send_sequence;
         packet->send_time = current_time;
 
-        if (((stream == NULL) || cnx->cwin <= cnx->bytes_in_transit) &&
-            (cnx->cnx_state == picoquic_state_client_almost_ready ||
-            picoquic_is_ack_needed(cnx, current_time) == 0))
-        {
+        if (((stream == NULL) || cnx->cwin <= cnx->bytes_in_transit) && (cnx->cnx_state == picoquic_state_client_almost_ready || picoquic_is_ack_needed(cnx, current_time) == 0)) {
             length = 0;
-        }
-        else
-        {
-            if (cnx->cnx_state != picoquic_state_client_almost_ready)
-            {
+        } else {
+            if (cnx->cnx_state != picoquic_state_client_almost_ready) {
                 ret = picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
                     cnx->send_mtu - checksum_overhead - length, &data_bytes);
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     length += data_bytes;
-                }
-                else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                {
+                } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                     ret = 0;
                 }
             }
 
-            if (ret == 0 && cnx->cwin > cnx->bytes_in_transit)
-            {
+            if (ret == 0 && cnx->cwin > cnx->bytes_in_transit) {
                 /* Encode the stream frame */
-                if (stream != NULL)
-                {
+                if (stream != NULL) {
                     ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
                         cnx->send_mtu - checksum_overhead - length, &data_bytes);
 
-                    if (ret == 0)
-                    {
+                    if (ret == 0) {
                         length += data_bytes;
-                    }
-                    else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                    {
+                    } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                         ret = 0;
                     }
                 }
 
-                if (packet_type == picoquic_packet_client_initial)
-                {
-                    while (length < cnx->send_mtu - checksum_overhead)
-                    {
+                if (packet_type == picoquic_packet_client_initial) {
+                    while (length < cnx->send_mtu - checksum_overhead) {
                         bytes[length++] = 0;
                     }
                 }
             }
 
             /* If stream zero packets are sent, progress the state */
-            if (ret == 0 && stream != NULL && stream->stream_id == 0 && data_bytes > 0 &&
-                stream->send_queue == NULL)
-            {
-                switch (cnx->cnx_state)
-                {
+            if (ret == 0 && stream != NULL && stream->stream_id == 0 && data_bytes > 0 && stream->send_queue == NULL) {
+                switch (cnx->cnx_state) {
                 case picoquic_state_client_init:
                     cnx->cnx_state = picoquic_state_client_init_sent;
                     cnx->next_pacing_time = current_time + 10000;
@@ -1191,29 +981,22 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * 
         }
     }
 
-    if (ret == 0 && length == 0 && cnx->aead_0rtt_encrypt_ctx != NULL)
-    {
+    if (ret == 0 && length == 0 && cnx->aead_0rtt_encrypt_ctx != NULL) {
         /* Consider sending 0-RTT */
         ret = picoquic_prepare_packet_0rtt(cnx, packet, current_time, send_buffer, send_length);
-    }
-    else
-    {
-        if (ret == 0 && length > 0)
-        {
+    } else {
+        if (ret == 0 && length > 0) {
             packet->length = length;
             cnx->send_sequence++;
 
-            if (is_cleartext_mode)
-            {
+            if (is_cleartext_mode) {
                 /* AEAD Encrypt, to the send buffer */
                 memcpy(send_buffer, packet->bytes, header_length);
                 length = picoquic_aead_cleartext_encrypt(cnx, send_buffer + header_length,
                     packet->bytes + header_length, length - header_length,
                     packet->sequence_number, send_buffer, header_length);
                 length += header_length;
-            }
-            else
-            {
+            } else {
                 /* AEAD Encrypt, to the send buffer */
                 memcpy(send_buffer, packet->bytes, header_length);
                 length = picoquic_aead_encrypt(cnx, send_buffer + header_length,
@@ -1226,14 +1009,11 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * 
             *send_length = length;
 
             picoquic_queue_for_retransmit(cnx, packet, length, current_time);
-        }
-        else
-        {
+        } else {
             *send_length = 0;
         }
 
-        if (cnx->cnx_state != picoquic_state_draining)
-        {
+        if (cnx->cnx_state != picoquic_state_draining) {
             picoquic_cnx_set_next_wake_time(cnx, current_time);
         }
     }
@@ -1241,15 +1021,13 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t * cnx, picoquic_packet * 
     return ret;
 }
 
-
-
 /* Prepare the next packet to send when in one the server initial states */
-int picoquic_prepare_packet_server_init(picoquic_cnx_t * cnx, picoquic_packet * packet,
-    uint64_t current_time, uint8_t * send_buffer, size_t * send_length)
+int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
     int ret = 0;
     /* TODO: manage multiple streams. */
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     int stream_restricted = 1;
     picoquic_packet_type_enum packet_type = picoquic_packet_server_cleartext;
     size_t checksum_overhead = 8;
@@ -1258,80 +1036,62 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t * cnx, picoquic_packet * 
     uint64_t cnx_id = cnx->server_cnxid;
     int retransmit_possible = 0;
     size_t header_length = 0;
-    uint8_t * bytes = packet->bytes;
+    uint8_t* bytes = packet->bytes;
     size_t length = 0;
 
     checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
     stream = picoquic_find_ready_stream(cnx, stream_restricted);
 
-    if (ret == 0 && retransmit_possible &&
-        (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0)
-    {
+    if (ret == 0 && retransmit_possible && (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
         /* Set the new checksum length */
         checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
         /* Check whether it makes sens to add an ACK at the end of the retransmission */
         if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            cnx->send_mtu - checksum_overhead - length, &data_bytes) == 0)
-        {
+                cnx->send_mtu - checksum_overhead - length, &data_bytes)
+            == 0) {
             length += data_bytes;
             packet->length = length;
         }
         /* document the send time & overhead */
         packet->send_time = current_time;
         packet->checksum_overhead = checksum_overhead;
-    }
-    else if (ret == 0 && is_cleartext_mode && stream == NULL)
-    {
+    } else if (ret == 0 && is_cleartext_mode && stream == NULL) {
         /* when in a clear text mode, only send packets if there is
         * actually something to send, or resend */
 
         packet->length = 0;
-    }
-    else if (ret == 0)
-    {
+    } else if (ret == 0) {
         length = picoquic_create_packet_header(
             cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
         header_length = length;
         packet->sequence_number = cnx->send_sequence;
         packet->send_time = current_time;
 
-        if (((stream == NULL && cnx->first_misc_frame == NULL) || cnx->cwin <= cnx->bytes_in_transit) &&
-            picoquic_is_ack_needed(cnx, current_time) == 0)
-        {
+        if (((stream == NULL && cnx->first_misc_frame == NULL) || cnx->cwin <= cnx->bytes_in_transit) && picoquic_is_ack_needed(cnx, current_time) == 0) {
             length = 0;
-        }
-        else
-        {
+        } else {
             if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-                cnx->send_mtu - checksum_overhead - length, &data_bytes) == 0)
-            {
+                    cnx->send_mtu - checksum_overhead - length, &data_bytes)
+                == 0) {
                 length += data_bytes;
             }
 
-            if (cnx->cwin > cnx->bytes_in_transit)
-            {
+            if (cnx->cwin > cnx->bytes_in_transit) {
                 /* Encode the stream frame */
-                if (stream != NULL)
-                {
+                if (stream != NULL) {
                     ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
                         cnx->send_mtu - checksum_overhead - length, &data_bytes);
-                    if (ret == 0)
-                    {
+                    if (ret == 0) {
                         length += data_bytes;
-                    }
-                    else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                    {
+                    } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                         ret = 0;
                     }
                 }
             }
             /* If stream zero packets are sent, progress the state */
-            if (ret == 0 && stream != NULL && stream->stream_id == 0 && data_bytes > 0 &&
-                stream->send_queue == NULL)
-            {
-                switch (cnx->cnx_state)
-                {
+            if (ret == 0 && stream != NULL && stream->stream_id == 0 && data_bytes > 0 && stream->send_queue == NULL) {
+                switch (cnx->cnx_state) {
                 case picoquic_state_server_almost_ready:
                     cnx->cnx_state = picoquic_state_server_ready;
                     break;
@@ -1342,22 +1102,18 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t * cnx, picoquic_packet * 
         }
     }
 
-    if (ret == 0 && length > 0)
-    {
+    if (ret == 0 && length > 0) {
         packet->length = length;
         cnx->send_sequence++;
 
-        if (is_cleartext_mode)
-        {
+        if (is_cleartext_mode) {
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
             length = picoquic_aead_cleartext_encrypt(cnx, send_buffer + header_length,
                 packet->bytes + header_length, length - header_length,
                 packet->sequence_number, send_buffer, header_length);
             length += header_length;
-        }
-        else
-        {
+        } else {
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
             length = picoquic_aead_encrypt(cnx, send_buffer + header_length,
@@ -1370,9 +1126,7 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t * cnx, picoquic_packet * 
         *send_length = length;
 
         picoquic_queue_for_retransmit(cnx, packet, length, current_time);
-    }
-    else
-    {
+    } else {
         *send_length = 0;
     }
 
@@ -1382,8 +1136,8 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t * cnx, picoquic_packet * 
 }
 
 /* Prepare the next packet to send when in one the closing states */
-int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * packet,
-    uint64_t current_time, uint8_t * send_buffer, size_t * send_length)
+int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
     int ret = 0;
     /* TODO: manage multiple streams. */
@@ -1392,18 +1146,14 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
     int is_cleartext_mode = 1;
     uint64_t cnx_id = cnx->server_cnxid;
     size_t header_length = 0;
-    uint8_t * bytes = packet->bytes;
+    uint8_t* bytes = packet->bytes;
     size_t length = 0;
-
-
 
     /* Prepare header -- depend on connection state */
     /* TODO: 0-RTT work. */
-    switch (cnx->cnx_state)
-    {
+    switch (cnx->cnx_state) {
     case picoquic_state_handshake_failure:
-        packet_type = cnx->client_mode ?
-            picoquic_packet_client_cleartext : picoquic_packet_server_cleartext;
+        packet_type = cnx->client_mode ? picoquic_packet_client_cleartext : picoquic_packet_server_cleartext;
         break;
     case picoquic_state_disconnecting:
         packet_type = picoquic_packet_1rtt_protected_phi0;
@@ -1431,8 +1181,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
 
     checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
-    if (ret == 0 && cnx->cnx_state == picoquic_state_closing_received)
-    {
+    if (ret == 0 && cnx->cnx_state == picoquic_state_closing_received) {
         /* Send a closing frame, move to closing state */
         size_t consumed = 0;
         uint64_t exit_time = cnx->latest_progress_time + 3 * cnx->retransmit_timer;
@@ -1447,32 +1196,24 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
         ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
             cnx->send_mtu - checksum_overhead - length, &consumed);
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             length += consumed;
         }
         cnx->cnx_state = picoquic_state_draining;
         cnx->next_wake_time = exit_time;
-    }
-    else if (ret == 0 && cnx->cnx_state == picoquic_state_closing)
-    {
+    } else if (ret == 0 && cnx->cnx_state == picoquic_state_closing) {
         /* if more than 3*RTO is elapsed, move to disconnected */
         uint64_t exit_time = cnx->latest_progress_time + 3 * cnx->retransmit_timer;
 
-        if (current_time >= exit_time)
-        {
+        if (current_time >= exit_time) {
             cnx->cnx_state = picoquic_state_disconnected;
-        }
-        else if (current_time > cnx->next_wake_time)
-        {
+        } else if (current_time > cnx->next_wake_time) {
             uint64_t delta_t = cnx->rtt_min;
-            if (delta_t * 2 < cnx->retransmit_timer)
-            {
+            if (delta_t * 2 < cnx->retransmit_timer) {
                 delta_t = cnx->retransmit_timer / 2;
             }
             /* if more than N packet received, repeat and erase */
-            if (cnx->ack_needed)
-            {
+            if (cnx->ack_needed) {
                 size_t consumed = 0;
                 length = picoquic_create_packet_header(
                     cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
@@ -1481,48 +1222,35 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
                 packet->send_time = current_time;
 
                 /* Resend the disconnect frame */
-                if (cnx->local_error == 0)
-                {
+                if (cnx->local_error == 0) {
                     ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
                         cnx->send_mtu - checksum_overhead - length, &consumed);
-                }
-                else
-                {
+                } else {
                     ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
                         cnx->send_mtu - checksum_overhead - length, &consumed);
                 }
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     length += consumed;
                 }
                 cnx->ack_needed = 0;
             }
             cnx->next_wake_time = current_time + delta_t;
-            if (cnx->next_wake_time > exit_time)
-            {
+            if (cnx->next_wake_time > exit_time) {
                 cnx->next_wake_time = exit_time;
             }
         }
-    }
-    else if (ret == 0 && cnx->cnx_state == picoquic_state_draining)
-    {
+    } else if (ret == 0 && cnx->cnx_state == picoquic_state_draining) {
         /* Nothing is ever sent in the draining state */
         /* if more than 3*RTO is elapsed, move to disconnected */
         uint64_t exit_time = cnx->latest_progress_time + 3 * cnx->retransmit_timer;
 
-        if (current_time >= exit_time)
-        {
+        if (current_time >= exit_time) {
             cnx->cnx_state = picoquic_state_disconnected;
-        }
-        else
-        {
+        } else {
             cnx->next_wake_time = exit_time;
         }
         length = 0;
-    }
-    else if (ret == 0 && (cnx->cnx_state == picoquic_state_disconnecting ||
-        cnx->cnx_state == picoquic_state_handshake_failure))
-    {
+    } else if (ret == 0 && (cnx->cnx_state == picoquic_state_disconnecting || cnx->cnx_state == picoquic_state_handshake_failure)) {
         length = picoquic_create_packet_header(
             cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
         header_length = length;
@@ -1533,75 +1261,59 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
         size_t consumed = 0;
         uint64_t delta_t = cnx->rtt_min;
 
-        if (2 * delta_t < cnx->retransmit_timer)
-        {
+        if (2 * delta_t < cnx->retransmit_timer) {
             delta_t = cnx->retransmit_timer / 2;
         }
 
         /* add a final ack so receiver gets clean state */
         ret = picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
             cnx->send_mtu - checksum_overhead - length, &consumed);
-        if (ret == 0)
-        {
+        if (ret == 0) {
             length += consumed;
         }
 
         consumed = 0;
         /* Send the disconnect frame */
-        if (cnx->local_error == 0)
-        {
+        if (cnx->local_error == 0) {
             ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
                 cnx->send_mtu - checksum_overhead - length, &consumed);
-        }
-        else
-        {
+        } else {
             ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
                 cnx->send_mtu - checksum_overhead - length, &consumed);
         }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             length += consumed;
         }
 
-        if (cnx->cnx_state == picoquic_state_handshake_failure)
-        {
+        if (cnx->cnx_state == picoquic_state_handshake_failure) {
             cnx->cnx_state = picoquic_state_disconnected;
-        }
-        else
-        {
+        } else {
             cnx->cnx_state = picoquic_state_closing;
         }
         cnx->latest_progress_time = current_time;
         cnx->next_wake_time = current_time + delta_t;
         cnx->ack_needed = 0;
 
-        if (cnx->callback_fn)
-        {
+        if (cnx->callback_fn) {
             (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
         }
-    }
-    else
-    {
+    } else {
         length = 0;
     }
 
-    if (ret == 0 && length > 0)
-    {
+    if (ret == 0 && length > 0) {
         packet->length = length;
         cnx->send_sequence++;
 
-        if (is_cleartext_mode)
-        {
+        if (is_cleartext_mode) {
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
             length = picoquic_aead_cleartext_encrypt(cnx, send_buffer + header_length,
                 packet->bytes + header_length, length - header_length,
                 packet->sequence_number, send_buffer, header_length);
             length += header_length;
-        }
-        else
-        {
+        } else {
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
             length = picoquic_aead_encrypt(cnx, send_buffer + header_length,
@@ -1614,9 +1326,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
         *send_length = length;
 
         picoquic_queue_for_retransmit(cnx, packet, length, current_time);
-    }
-    else
-    {
+    } else {
         *send_length = 0;
     }
 
@@ -1624,36 +1334,33 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t * cnx, picoquic_packet * pack
 }
 
 /*  Prepare the next packet to send when in one the ready states */
-int picoquic_prepare_packet_ready(picoquic_cnx_t * cnx, picoquic_packet * packet,
-    uint64_t current_time, uint8_t * send_buffer, size_t * send_length)
+int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
     int ret = 0;
     /* TODO: manage multiple streams. */
-    picoquic_stream_head * stream = NULL;
+    picoquic_stream_head* stream = NULL;
     picoquic_packet_type_enum packet_type = picoquic_packet_1rtt_protected_phi0;
     int is_cleartext_mode = 0;
     size_t data_bytes = 0;
     uint64_t cnx_id = cnx->server_cnxid;
     int retransmit_possible = 1;
     size_t header_length = 0;
-    uint8_t * bytes = packet->bytes;
+    uint8_t* bytes = packet->bytes;
     size_t length = 0;
     size_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
     stream = picoquic_find_ready_stream(cnx, 0);
 
-    if (ret == 0 && retransmit_possible &&
-        (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0)
-    {
+    if (ret == 0 && retransmit_possible && (length = picoquic_retransmit_needed(cnx, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
         /* Set the new checksum length */
         checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
         /* Check whether it makes sense to add an ACK at the end of the retransmission */
         /* Don't do that if it risks mixing clear text and encrypted ack */
-        if (is_cleartext_mode == 0)
-        {
+        if (is_cleartext_mode == 0) {
             if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-                cnx->send_mtu - checksum_overhead - length, &data_bytes) == 0)
-            {
+                    cnx->send_mtu - checksum_overhead - length, &data_bytes)
+                == 0) {
                 length += data_bytes;
                 packet->length = length;
             }
@@ -1661,69 +1368,50 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t * cnx, picoquic_packet * packet
         /* document the send time & overhead */
         packet->send_time = current_time;
         packet->checksum_overhead = checksum_overhead;
-    }
-    else if (ret == 0)
-    {
+    } else if (ret == 0) {
         length = picoquic_create_packet_header(
             cnx, packet_type, cnx_id, cnx->send_sequence, bytes);
         header_length = length;
         packet->sequence_number = cnx->send_sequence;
         packet->send_time = current_time;
 
-        if (((stream == NULL && cnx->first_misc_frame == NULL) || cnx->cwin <= cnx->bytes_in_transit) &&
-            picoquic_is_ack_needed(cnx, current_time) == 0)
-        {
-            if (ret == 0 && cnx->cwin > cnx->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx))
-            {
+        if (((stream == NULL && cnx->first_misc_frame == NULL) || cnx->cwin <= cnx->bytes_in_transit) && picoquic_is_ack_needed(cnx, current_time) == 0) {
+            if (ret == 0 && cnx->cwin > cnx->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx)) {
                 length = picoquic_prepare_mtu_probe(cnx, header_length, checksum_overhead, bytes);
                 packet->length = length;
                 cnx->mtu_probe_sent = 1;
-            }
-            else
-            {
+            } else {
                 length = 0;
             }
-        }
-        else
-        {
+        } else {
             if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-                cnx->send_mtu - checksum_overhead - length, &data_bytes) == 0)
-            {
+                    cnx->send_mtu - checksum_overhead - length, &data_bytes)
+                == 0) {
                 length += data_bytes;
             }
 
-            if (cnx->cwin > cnx->bytes_in_transit)
-            {
+            if (cnx->cwin > cnx->bytes_in_transit) {
                 /* If present, send misc frame */
-                while (cnx->first_misc_frame != NULL)
-                {
+                while (cnx->first_misc_frame != NULL) {
                     ret = picoquic_prepare_misc_frame(cnx, &bytes[length],
                         cnx->send_mtu - checksum_overhead - length, &data_bytes);
-                    if (ret == 0)
-                    {
+                    if (ret == 0) {
                         length += data_bytes;
-                    }
-                    else
-                    {
-                        if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                        {
+                    } else {
+                        if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                             ret = 0;
                         }
                         break;
                     }
                 }
                 /* If necessary, encode the max data frame */
-                if (ret == 0 && 2 * cnx->data_received > cnx->maxdata_local)
-                {
+                if (ret == 0 && 2 * cnx->data_received > cnx->maxdata_local) {
                     ret = picoquic_prepare_max_data_frame(cnx, 2 * cnx->data_received, &bytes[length],
                         cnx->send_mtu - checksum_overhead - length, &data_bytes);
 
-                    if (ret == 0)
-                    {
+                    if (ret == 0) {
                         length += data_bytes;
-                    }
-                    else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                    {
+                    } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                         ret = 0;
                     }
                 }
@@ -1731,45 +1419,37 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t * cnx, picoquic_packet * packet
                 ret = picoquic_prepare_required_max_stream_data_frames(cnx, &bytes[length],
                     cnx->send_mtu - checksum_overhead - length, &data_bytes);
 
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     length += data_bytes;
                 }
                 /* Encode the stream frame */
-                if (stream != NULL)
-                {
+                if (stream != NULL) {
                     ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
                         cnx->send_mtu - checksum_overhead - length, &data_bytes);
 
-                    if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL)
-                    {
+                    if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                         ret = 0;
                     }
                 }
             }
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 length += data_bytes;
             }
         }
     }
 
-    if (ret == 0 && length > 0)
-    {
+    if (ret == 0 && length > 0) {
         packet->length = length;
         cnx->send_sequence++;
 
-        if (is_cleartext_mode)
-        {
+        if (is_cleartext_mode) {
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
             length = picoquic_aead_cleartext_encrypt(cnx, send_buffer + header_length,
                 packet->bytes + header_length, length - header_length,
                 packet->sequence_number, send_buffer, header_length);
             length += header_length;
-        }
-        else
-        {
+        } else {
 
             /* AEAD Encrypt, to the send buffer */
             memcpy(send_buffer, packet->bytes, header_length);
@@ -1783,12 +1463,10 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t * cnx, picoquic_packet * packet
         *send_length = length;
 
         picoquic_queue_for_retransmit(cnx, packet, length, current_time);
-    }
-    else
-    {
+    } else {
         *send_length = 0;
     }
-    
+
     picoquic_cnx_set_next_wake_time(cnx, current_time);
 
     return ret;
@@ -2241,32 +1919,24 @@ int picoquic_prepare_packet(picoquic_cnx_t * cnx, picoquic_packet * packet,
     return ret;
 }
 #else
-int picoquic_prepare_packet(picoquic_cnx_t * cnx, picoquic_packet * packet,
-	uint64_t current_time, uint8_t * send_buffer, size_t send_buffer_max, size_t * send_length)
+int picoquic_prepare_packet(picoquic_cnx_t* cnx, picoquic_packet* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
 
     /* Check that the connection is still alive */
-    if (cnx->cnx_state < picoquic_state_disconnecting &&
-        (current_time - cnx->latest_progress_time) > PICOQUIC_MICROSEC_SILENCE_MAX)
-    {
+    if (cnx->cnx_state < picoquic_state_disconnecting && (current_time - cnx->latest_progress_time) > PICOQUIC_MICROSEC_SILENCE_MAX) {
         /* Too long silence, break it. */
         cnx->cnx_state = picoquic_state_disconnected;
-        if (cnx->callback_fn)
-        {
+        if (cnx->callback_fn) {
             (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
         }
-    }
-    else if (send_buffer_max < cnx->send_mtu)
-    {
+    } else if (send_buffer_max < cnx->send_mtu) {
         ret = PICOQUIC_ERROR_SEND_BUFFER_TOO_SMALL;
-    }
-    else
-    {
+    } else {
         /* Prepare header -- depend on connection state */
         /* TODO: 0-RTT work. */
-        switch (cnx->cnx_state)
-        {
+        switch (cnx->cnx_state) {
         case picoquic_state_client_init:
         case picoquic_state_client_init_sent:
         case picoquic_state_client_init_resent:
@@ -2304,27 +1974,21 @@ int picoquic_prepare_packet(picoquic_cnx_t * cnx, picoquic_packet * packet,
         }
     }
 
-	return ret;
+    return ret;
 }
 #endif
 
-int picoquic_close(picoquic_cnx_t * cnx, uint16_t reason_code)
+int picoquic_close(picoquic_cnx_t* cnx, uint16_t reason_code)
 {
     int ret = 0;
 
-    if (cnx->cnx_state == picoquic_state_server_ready ||
-        cnx->cnx_state == picoquic_state_client_ready)
-    {
+    if (cnx->cnx_state == picoquic_state_server_ready || cnx->cnx_state == picoquic_state_client_ready) {
         cnx->cnx_state = picoquic_state_disconnecting;
         cnx->application_error = reason_code;
-    }
-    else if (cnx->cnx_state < picoquic_state_client_ready)
-    {
+    } else if (cnx->cnx_state < picoquic_state_client_ready) {
         cnx->cnx_state = picoquic_state_handshake_failure;
         cnx->application_error = reason_code;
-    }
-    else
-    {
+    } else {
         ret = -1;
     }
 

--- a/picoquic/ticket_store.c
+++ b/picoquic/ticket_store.c
@@ -19,24 +19,21 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stddef.h>
-#include <string.h>
-#include <stdlib.h>
 #include "picoquic_internal.h"
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 
-int picoquic_store_ticket(picoquic_stored_ticket_t ** pp_first_ticket,
+int picoquic_store_ticket(picoquic_stored_ticket_t** pp_first_ticket,
     uint64_t current_time,
-    char const * sni, uint16_t sni_length, char const * alpn, uint16_t alpn_length,
-    uint8_t * ticket, uint16_t ticket_length)
+    char const* sni, uint16_t sni_length, char const* alpn, uint16_t alpn_length,
+    uint8_t* ticket, uint16_t ticket_length)
 {
     int ret = 0;
 
-    if (ticket_length < 17)
-    {
+    if (ticket_length < 17) {
         ret = PICOQUIC_ERROR_INVALID_TICKET;
-    }
-    else
-    {
+    } else {
         uint64_t ticket_issued_time;
         uint64_t ttl_seconds;
         uint64_t time_valid_until;
@@ -44,33 +41,24 @@ int picoquic_store_ticket(picoquic_stored_ticket_t ** pp_first_ticket,
         ticket_issued_time = PICOPARSE_64(ticket);
         ttl_seconds = PICOPARSE_32(ticket + 13);
 
-        if (ttl_seconds > (7 * 24 * 3600))
-        {
+        if (ttl_seconds > (7 * 24 * 3600)) {
             ttl_seconds = (7 * 24 * 3600);
         }
 
         time_valid_until = (ticket_issued_time * 1000) + (ttl_seconds * 1000000);
 
-        if (current_time != 0 && time_valid_until < current_time)
-        {
+        if (current_time != 0 && time_valid_until < current_time) {
             ret = PICOQUIC_ERROR_INVALID_TICKET;
-        }
-        else
-        {
-            size_t ticket_size =
-                sizeof(picoquic_stored_ticket_t) +
-                sni_length + 1 + alpn_length + 1 + ticket_length;
-            picoquic_stored_ticket_t * stored = (picoquic_stored_ticket_t *)malloc(ticket_size);
-            char * next_p = ((char *)stored) + sizeof(picoquic_stored_ticket_t);
+        } else {
+            size_t ticket_size = sizeof(picoquic_stored_ticket_t) + sni_length + 1 + alpn_length + 1 + ticket_length;
+            picoquic_stored_ticket_t* stored = (picoquic_stored_ticket_t*)malloc(ticket_size);
+            char* next_p = ((char*)stored) + sizeof(picoquic_stored_ticket_t);
 
-            if (stored == NULL)
-            {
+            if (stored == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
-            }
-            else
-            {
-                picoquic_stored_ticket_t * next;
-                picoquic_stored_ticket_t ** pprevious;
+            } else {
+                picoquic_stored_ticket_t* next;
+                picoquic_stored_ticket_t** pprevious;
 
                 stored->time_valid_until = time_valid_until;
                 stored->sni = next_p;
@@ -85,7 +73,7 @@ int picoquic_store_ticket(picoquic_stored_ticket_t ** pp_first_ticket,
                 next_p += alpn_length;
                 *next_p++ = 0;
 
-                stored->ticket = (uint8_t *)next_p;
+                stored->ticket = (uint8_t*)next_p;
                 stored->ticket_length = ticket_length;
                 memcpy(next_p, ticket, ticket_length);
 
@@ -94,22 +82,14 @@ int picoquic_store_ticket(picoquic_stored_ticket_t ** pp_first_ticket,
                 pprevious = &stored->next_ticket;
 
                 /* Now remove the old tickets for that SNI & ALPN */
-                while (next != NULL)
-                {
-                    if (next->time_valid_until <= stored->time_valid_until &&
-                        next->sni_length == sni_length &&
-                        next->alpn_length == alpn_length &&
-                        memcmp(next->sni, sni, sni_length) == 0 &&
-                        memcmp(next->alpn, alpn, alpn_length) == 0)
-                    {
-                        picoquic_stored_ticket_t * deleted = next;
+                while (next != NULL) {
+                    if (next->time_valid_until <= stored->time_valid_until && next->sni_length == sni_length && next->alpn_length == alpn_length && memcmp(next->sni, sni, sni_length) == 0 && memcmp(next->alpn, alpn, alpn_length) == 0) {
+                        picoquic_stored_ticket_t* deleted = next;
                         next = next->next_ticket;
                         *pprevious = next;
                         memset(&deleted->ticket, 0, deleted->ticket_length);
                         free(deleted);
-                    }
-                    else
-                    {
+                    } else {
                         pprevious = &next->next_ticket;
                         next = next->next_ticket;
                     }
@@ -121,38 +101,27 @@ int picoquic_store_ticket(picoquic_stored_ticket_t ** pp_first_ticket,
     return ret;
 }
 
-int picoquic_get_ticket(picoquic_stored_ticket_t * p_first_ticket,
+int picoquic_get_ticket(picoquic_stored_ticket_t* p_first_ticket,
     uint64_t current_time,
-    char const * sni, uint16_t sni_length, char const * alpn, uint16_t alpn_length,
-    uint8_t ** ticket, uint16_t * ticket_length)
+    char const* sni, uint16_t sni_length, char const* alpn, uint16_t alpn_length,
+    uint8_t** ticket, uint16_t* ticket_length)
 {
     int ret = 0;
-    picoquic_stored_ticket_t * next = p_first_ticket;
+    picoquic_stored_ticket_t* next = p_first_ticket;
 
-    while (next != NULL)
-    {
-        if (next->time_valid_until > current_time &&
-            next->sni_length == sni_length &&
-            next->alpn_length == alpn_length &&
-            memcmp(next->sni, sni, sni_length) == 0 &&
-            memcmp(next->alpn, alpn, alpn_length) == 0)
-        {
+    while (next != NULL) {
+        if (next->time_valid_until > current_time && next->sni_length == sni_length && next->alpn_length == alpn_length && memcmp(next->sni, sni, sni_length) == 0 && memcmp(next->alpn, alpn, alpn_length) == 0) {
             break;
-        }
-        else
-        {
+        } else {
             next = next->next_ticket;
         }
     }
 
-    if (next == NULL)
-    {
+    if (next == NULL) {
         *ticket = NULL;
         *ticket_length = 0;
         ret = -1;
-    }
-    else
-    {
+    } else {
         *ticket = next->ticket;
         *ticket_length = next->ticket_length;
     }
@@ -160,13 +129,13 @@ int picoquic_get_ticket(picoquic_stored_ticket_t * p_first_ticket,
     return ret;
 }
 
-int picoquic_save_tickets(picoquic_stored_ticket_t * first_ticket,
+int picoquic_save_tickets(picoquic_stored_ticket_t* first_ticket,
     uint64_t current_time,
-    char const  * ticket_file_name)
+    char const* ticket_file_name)
 {
     int ret = 0;
-    FILE * F = NULL;
-    picoquic_stored_ticket_t * next = first_ticket;
+    FILE* F = NULL;
+    picoquic_stored_ticket_t* next = first_ticket;
 #ifdef _WINDOWS
     errno_t err = fopen_s(&F, ticket_file_name, "wb");
     if (err != 0) {
@@ -179,21 +148,15 @@ int picoquic_save_tickets(picoquic_stored_ticket_t * first_ticket,
     }
 #endif
 
-    while (ret == 0 && next != NULL)
-    {
+    while (ret == 0 && next != NULL) {
         /* Only store the tickets that are valid going forward */
-        if (next->time_valid_until > current_time)
-        {
+        if (next->time_valid_until > current_time) {
             /* Compute the serialized size */
-            uint32_t record_size =
-                sizeof(picoquic_stored_ticket_t) 
-                - offsetof(struct st_picoquic_stored_ticket_t, time_valid_until) +
-                next->sni_length + 1 + next->alpn_length + 1 + next->ticket_length;
-            char * record_start = ((char *)next) + offsetof(struct st_picoquic_stored_ticket_t, time_valid_until);
+            uint32_t record_size = sizeof(picoquic_stored_ticket_t)
+                - offsetof(struct st_picoquic_stored_ticket_t, time_valid_until) + next->sni_length + 1 + next->alpn_length + 1 + next->ticket_length;
+            char* record_start = ((char*)next) + offsetof(struct st_picoquic_stored_ticket_t, time_valid_until);
 
-            if (fwrite(&record_size, 4, 1, F) != 1 ||
-                fwrite(record_start, 1, record_size, F) != record_size)
-            {
+            if (fwrite(&record_size, 4, 1, F) != 1 || fwrite(record_start, 1, record_size, F) != record_size) {
                 ret = PICOQUIC_ERROR_INVALID_FILE;
                 break;
             }
@@ -201,21 +164,20 @@ int picoquic_save_tickets(picoquic_stored_ticket_t * first_ticket,
         next = next->next_ticket;
     }
 
-    if (F != NULL)
-    {
+    if (F != NULL) {
         fclose(F);
     }
 
     return ret;
 }
 
-int picoquic_load_tickets(picoquic_stored_ticket_t ** pp_first_ticket,
-    uint64_t current_time, char const * ticket_file_name)
+int picoquic_load_tickets(picoquic_stored_ticket_t** pp_first_ticket,
+    uint64_t current_time, char const* ticket_file_name)
 {
     int ret = 0;
-    FILE * F = NULL;
-    picoquic_stored_ticket_t * previous = NULL;
-    picoquic_stored_ticket_t * next;
+    FILE* F = NULL;
+    picoquic_stored_ticket_t* previous = NULL;
+    picoquic_stored_ticket_t* next;
     uint32_t record_size;
     uint32_t storage_size;
 
@@ -230,47 +192,33 @@ int picoquic_load_tickets(picoquic_stored_ticket_t ** pp_first_ticket,
         ret = -1;
     }
 #endif
-    while (ret == 0)
-    {
-        if (fread(&storage_size, 4, 1, F) != 1)
-        {
+    while (ret == 0) {
+        if (fread(&storage_size, 4, 1, F) != 1) {
             /* end of file */
             break;
-        }
-        else
-        {
+        } else {
             record_size = storage_size + offsetof(struct st_picoquic_stored_ticket_t, time_valid_until);
-            next = (picoquic_stored_ticket_t *)malloc(record_size);
+            next = (picoquic_stored_ticket_t*)malloc(record_size);
 
-            if (next == NULL)
-            {
+            if (next == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
                 break;
-            }
-            else
-            {
+            } else {
                 if (fread(((char*)next) + offsetof(struct st_picoquic_stored_ticket_t, time_valid_until),
-                    1, storage_size, F) != storage_size)
-                {
+                        1, storage_size, F)
+                    != storage_size) {
                     ret = PICOQUIC_ERROR_INVALID_FILE;
                     free(next);
-                }
-                else if (next->time_valid_until < current_time)
-                {
+                } else if (next->time_valid_until < current_time) {
                     free(next);
-                }
-                else
-                {
+                } else {
                     next->sni = ((char*)next) + sizeof(picoquic_stored_ticket_t);
                     next->alpn = next->sni + next->sni_length + 1;
-                    next->ticket = (uint8_t *)(next->alpn + next->alpn_length + 1);
+                    next->ticket = (uint8_t*)(next->alpn + next->alpn_length + 1);
                     next->next_ticket = NULL;
-                    if (previous == NULL)
-                    {
+                    if (previous == NULL) {
                         *pp_first_ticket = next;
-                    }
-                    else
-                    {
+                    } else {
                         previous->next_ticket = next;
                     }
 
@@ -278,23 +226,20 @@ int picoquic_load_tickets(picoquic_stored_ticket_t ** pp_first_ticket,
                 }
             }
         }
-    } 
+    }
 
-    if (F != NULL)
-    {
+    if (F != NULL) {
         fclose(F);
     }
 
     return ret;
 }
 
-
-void picoquic_free_tickets(picoquic_stored_ticket_t ** pp_first_ticket)
+void picoquic_free_tickets(picoquic_stored_ticket_t** pp_first_ticket)
 {
-    picoquic_stored_ticket_t * next;
+    picoquic_stored_ticket_t* next;
 
-    while ((next = *pp_first_ticket) != NULL)
-    {
+    while ((next = *pp_first_ticket) != NULL) {
         *pp_first_ticket = next->next_ticket;
 
         free(next);

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -22,13 +22,12 @@
 #ifdef _WINDOWS
 #include "wincompat.h"
 #endif
-#include <string.h>
-#include <stdio.h>
-#include <openssl/pem.h>
-#include "picotls.h"
-#include "picotls/openssl.h"
 #include "picoquic_internal.h"
+#include "picotls/openssl.h"
 #include "tls_api.h"
+#include <openssl/pem.h>
+#include <stdio.h>
+#include <string.h>
 
 #define PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION 26
 #define PICOQUIC_TRANSPORT_PARAMETERS_MAX_SIZE 512
@@ -38,108 +37,100 @@
 #define PICOQUIC_LABEL_1RTT_SERVER "EXPORTER-QUIC server 1-RTT Secret"
 
 typedef struct st_picoquic_tls_ctx_t {
-	ptls_t *tls;
-	picoquic_cnx_t * cnx;
-	int client_mode;
-	ptls_raw_extension_t ext[2];
-	ptls_handshake_properties_t handshake_properties;
-	ptls_iovec_t alpn_vec;
-	uint8_t ext_data[128];
-	uint8_t ext_received[128];
-	size_t ext_received_length;
-	int ext_received_return;
+    ptls_t* tls;
+    picoquic_cnx_t* cnx;
+    int client_mode;
+    ptls_raw_extension_t ext[2];
+    ptls_handshake_properties_t handshake_properties;
+    ptls_iovec_t alpn_vec;
+    uint8_t ext_data[128];
+    uint8_t ext_received[128];
+    size_t ext_received_length;
+    int ext_received_return;
 } picoquic_tls_ctx_t;
 
-int picoquic_receive_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed);
+int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed);
+int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-static size_t picoquic_aead_decrypt_generic(uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length, void * aead_ctx);
+static size_t picoquic_aead_decrypt_generic(uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length, void* aead_ctx);
 
-int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t * quic,
-    ptls_context_t *tls_ctx,
-    const uint8_t * secret, size_t secret_length);
+int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t* quic,
+    ptls_context_t* tls_ctx,
+    const uint8_t* secret, size_t secret_length);
 
 /*
  * Provide access to transport received transport extension for
  * logging purpose.
  */
-void picoquic_provide_received_transport_extensions(picoquic_cnx_t * cnx,
-	uint8_t ** ext_received,
-	size_t * ext_received_length,
-	int * ext_received_return,
-	int * client_mode)
+void picoquic_provide_received_transport_extensions(picoquic_cnx_t* cnx,
+    uint8_t** ext_received,
+    size_t* ext_received_length,
+    int* ext_received_return,
+    int* client_mode)
 {
-	picoquic_tls_ctx_t * ctx = cnx->tls_ctx;
+    picoquic_tls_ctx_t* ctx = cnx->tls_ctx;
 
-	*ext_received = ctx->ext_received;
-	*ext_received_length = ctx->ext_received_length;
-	*ext_received_return = ctx->ext_received_return;
-	*client_mode = ctx->client_mode;
+    *ext_received = ctx->ext_received;
+    *ext_received_length = ctx->ext_received_length;
+    *ext_received_return = ctx->ext_received_return;
+    *client_mode = ctx->client_mode;
 }
 
-static int SetSignCertificate(char const * keypem, ptls_context_t * ctx)
+static int SetSignCertificate(char const* keypem, ptls_context_t* ctx)
 {
-	int ret = 0;
-    ptls_openssl_sign_certificate_t * signer;
-	EVP_PKEY *pkey = EVP_PKEY_new();
+    int ret = 0;
+    ptls_openssl_sign_certificate_t* signer;
+    EVP_PKEY* pkey = EVP_PKEY_new();
 
-	signer = (ptls_openssl_sign_certificate_t *)malloc(sizeof(ptls_openssl_sign_certificate_t));
+    signer = (ptls_openssl_sign_certificate_t*)malloc(sizeof(ptls_openssl_sign_certificate_t));
 
-	if (signer == NULL || pkey == NULL)
-	{
-		ret = -1;
-	}
-	else
-	{
-		BIO* bio_key = BIO_new_file(keypem, "rb");
-		EVP_PKEY * ret_pkey = PEM_read_bio_PrivateKey(bio_key, &pkey, NULL, NULL);
-		if (ret_pkey == NULL)
-		{
-			ret = -1;
-		}
-		else
-		{
-			ret = ptls_openssl_init_sign_certificate(signer, pkey);
-		}
-		ctx->sign_certificate = &signer->super;
-	}
+    if (signer == NULL || pkey == NULL) {
+        ret = -1;
+    } else {
+        BIO* bio_key = BIO_new_file(keypem, "rb");
+        EVP_PKEY* ret_pkey = PEM_read_bio_PrivateKey(bio_key, &pkey, NULL, NULL);
+        if (ret_pkey == NULL) {
+            ret = -1;
+        } else {
+            ret = ptls_openssl_init_sign_certificate(signer, pkey);
+        }
+        ctx->sign_certificate = &signer->super;
+    }
 
-	if (pkey != NULL)
-	{
-		EVP_PKEY_free(pkey);
-	}
+    if (pkey != NULL) {
+        EVP_PKEY_free(pkey);
+    }
 
-	if (ret != 0 && signer != NULL)
-	{
-		free(signer);
-	}
+    if (ret != 0 && signer != NULL) {
+        free(signer);
+    }
 
-	return ret;
+    return ret;
 }
 
 /* Crypto random number generator */
 
-void picoquic_crypto_random(picoquic_quic_t * quic, void * buf, size_t len)
+void picoquic_crypto_random(picoquic_quic_t* quic, void* buf, size_t len)
 {
-    ptls_context_t *ctx = (ptls_context_t *)quic->tls_master_ctx;
+    ptls_context_t* ctx = (ptls_context_t*)quic->tls_master_ctx;
 
     ctx->random_bytes(buf, len);
 }
 
-uint64_t picoquic_crypto_uniform_random(picoquic_quic_t * quic, uint64_t rnd_max)
+uint64_t picoquic_crypto_uniform_random(picoquic_quic_t* quic, uint64_t rnd_max)
 {
-	uint64_t rnd;
-	uint64_t rnd_min = ((uint64_t)((int64_t)-1)) % rnd_max;
+    uint64_t rnd;
+    uint64_t rnd_min = ((uint64_t)((int64_t)-1)) % rnd_max;
 
-	do {
-		picoquic_crypto_random(quic, &rnd, sizeof(rnd));
-	} while (rnd < rnd_min);
+    do {
+        picoquic_crypto_random(quic, &rnd, sizeof(rnd));
+    } while (rnd < rnd_min);
 
-	return rnd%rnd_max;
+    return rnd % rnd_max;
 }
 
 /*
@@ -165,7 +156,7 @@ uint64_t picoquic_crypto_uniform_random(picoquic_quic_t * quic, uint64_t rnd_max
 static uint64_t public_random_seed[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 static int public_random_index = 0;
 
-uint64_t picoquic_public_random_64(void) 
+uint64_t picoquic_public_random_64(void)
 {
     const uint64_t s0 = public_random_seed[public_random_index++];
     uint64_t s1 = public_random_seed[public_random_index &= 15];
@@ -176,29 +167,26 @@ uint64_t picoquic_public_random_64(void)
     return s1 * (uint64_t)1181783497276652981;
 }
 
-void picoquic_public_random_seed(picoquic_quic_t * quic)
+void picoquic_public_random_seed(picoquic_quic_t* quic)
 {
     uint64_t seed;
     picoquic_crypto_random(quic, &seed, sizeof(seed));
 
     public_random_seed[public_random_index] ^= seed;
 
-    for (int i = 0; i < 16; i++)
-    {
+    for (int i = 0; i < 16; i++) {
         (void)picoquic_public_random_64();
     }
 }
 
-void picoquic_public_random(void * buf, size_t len)
+void picoquic_public_random(void* buf, size_t len)
 {
-    uint8_t *x = buf;
+    uint8_t* x = buf;
 
-    while (len > 0)
-    {
+    while (len > 0) {
         uint64_t y = picoquic_public_random_64();
-        for (int i = 0; i < 8 && len > 0; i++)
-        {
-            *x++ = (uint8_t)( y & 255);
+        for (int i = 0; i < 8 && len > 0; i++) {
+            *x++ = (uint8_t)(y & 255);
             y >>= 8;
             len--;
         }
@@ -214,7 +202,7 @@ uint64_t picoquic_public_uniform_random(uint64_t rnd_max)
         rnd = picoquic_public_random_64();
     } while (rnd < rnd_min);
 
-    return rnd%rnd_max;
+    return rnd % rnd_max;
 }
 
 /*
@@ -223,35 +211,31 @@ uint64_t picoquic_public_uniform_random(uint64_t rnd_max)
  * if the stack can process the extension, false (0) otherwise.
  */
 
-int picoquic_tls_collect_extensions_cb(ptls_t *tls, struct st_ptls_handshake_properties_t *properties, uint16_t type)
+int picoquic_tls_collect_extensions_cb(ptls_t* tls, struct st_ptls_handshake_properties_t* properties, uint16_t type)
 {
-	return type == PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION;
+    return type == PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION;
 }
 
-
-void picoquic_tls_set_extensions(picoquic_cnx_t * cnx, picoquic_tls_ctx_t *tls_ctx)
+void picoquic_tls_set_extensions(picoquic_cnx_t* cnx, picoquic_tls_ctx_t* tls_ctx)
 {
-	size_t consumed;
-	int ret = picoquic_prepare_transport_extensions(cnx, (tls_ctx->client_mode)?0:1,
-		tls_ctx->ext_data, sizeof(tls_ctx->ext_data), &consumed);
+    size_t consumed;
+    int ret = picoquic_prepare_transport_extensions(cnx, (tls_ctx->client_mode) ? 0 : 1,
+        tls_ctx->ext_data, sizeof(tls_ctx->ext_data), &consumed);
 
-	if (ret == 0)
-	{
-		tls_ctx->ext[0].type = PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION;
-		tls_ctx->ext[0].data.base = tls_ctx->ext_data;
-		tls_ctx->ext[0].data.len = consumed;
-		tls_ctx->ext[1].type = 0xFFFF;
-		tls_ctx->ext[1].data.base = NULL;
-		tls_ctx->ext[1].data.len = 0;
-	}
-	else
-	{
-		tls_ctx->ext[0].type = 0xFFFF;
-		tls_ctx->ext[0].data.base = NULL;
-		tls_ctx->ext[0].data.len = 0;
-	}
+    if (ret == 0) {
+        tls_ctx->ext[0].type = PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION;
+        tls_ctx->ext[0].data.base = tls_ctx->ext_data;
+        tls_ctx->ext[0].data.len = consumed;
+        tls_ctx->ext[1].type = 0xFFFF;
+        tls_ctx->ext[1].data.base = NULL;
+        tls_ctx->ext[1].data.len = 0;
+    } else {
+        tls_ctx->ext[0].type = 0xFFFF;
+        tls_ctx->ext[0].data.base = NULL;
+        tls_ctx->ext[0].data.len = 0;
+    }
 
-	tls_ctx->handshake_properties.additional_extensions = tls_ctx->ext;
+    tls_ctx->handshake_properties.additional_extensions = tls_ctx->ext;
 }
 
 /*
@@ -259,40 +243,37 @@ void picoquic_tls_set_extensions(picoquic_cnx_t * cnx, picoquic_tls_ctx_t *tls_c
  * reception of a handshake message containing supported extensions.
  */
 
-int picoquic_tls_collected_extensions_cb(ptls_t *tls, ptls_handshake_properties_t *properties,
-	ptls_raw_extension_t *slots)
+int picoquic_tls_collected_extensions_cb(ptls_t* tls, ptls_handshake_properties_t* properties,
+    ptls_raw_extension_t* slots)
 {
-	int ret = 0;
-	size_t consumed = 0;
-	/* Find the context from the TLS context */
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)
-		((char *)properties - offsetof(struct st_picoquic_tls_ctx_t, handshake_properties));
+    int ret = 0;
+    size_t consumed = 0;
+    /* Find the context from the TLS context */
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)((char*)properties - offsetof(struct st_picoquic_tls_ctx_t, handshake_properties));
 
-	if (slots[0].type == PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION && slots[1].type == 0xFFFF)
-	{
-		size_t copied_length = sizeof(ctx->ext_received);
+    if (slots[0].type == PICOQUIC_TRANSPORT_PARAMETERS_TLS_EXTENSION && slots[1].type == 0xFFFF) {
+        size_t copied_length = sizeof(ctx->ext_received);
 
-		/* Retrieve the transport parameters */
-		ret = picoquic_receive_transport_extensions(ctx->cnx, (ctx->client_mode)?1:0,
-			slots[0].data.base, slots[0].data.len, &consumed);
+        /* Retrieve the transport parameters */
+        ret = picoquic_receive_transport_extensions(ctx->cnx, (ctx->client_mode) ? 1 : 0,
+            slots[0].data.base, slots[0].data.len, &consumed);
 
-		/* Copy the extensions in the local context for further debugging */
-		ctx->ext_received_length = slots[0].data.len;
-		if (copied_length > ctx->ext_received_length)
-			copied_length = ctx->ext_received_length;
-		memcpy(ctx->ext_received, slots[0].data.base, copied_length);
-		ctx->ext_received_return = ret;
-		/* For now, override the value in case of default */
-		ret = 0;
+        /* Copy the extensions in the local context for further debugging */
+        ctx->ext_received_length = slots[0].data.len;
+        if (copied_length > ctx->ext_received_length)
+            copied_length = ctx->ext_received_length;
+        memcpy(ctx->ext_received, slots[0].data.base, copied_length);
+        ctx->ext_received_return = ret;
+        /* For now, override the value in case of default */
+        ret = 0;
 
-		/* In server mode, only compose the extensions if properly received from client */
-		if (ctx->client_mode == 0)
-		{
-			picoquic_tls_set_extensions(ctx->cnx, ctx);
-		}
-	}
+        /* In server mode, only compose the extensions if properly received from client */
+        if (ctx->client_mode == 0) {
+            picoquic_tls_set_extensions(ctx->cnx, ctx);
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 /*
@@ -303,50 +284,42 @@ int picoquic_tls_collected_extensions_cb(ptls_t *tls, ptls_handshake_properties_
  * TODO: check the ALPN in case several are supported.
  */
 
-int picoquic_client_hello_call_back(ptls_on_client_hello_t * on_hello_cb_ctx,
-	ptls_t *tls, ptls_iovec_t server_name, const ptls_iovec_t *negotiated_protocols,
-	size_t num_negotiated_protocols, const uint16_t *signature_algorithms, size_t num_signature_algorithms)
+int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
+    ptls_t* tls, ptls_iovec_t server_name, const ptls_iovec_t* negotiated_protocols,
+    size_t num_negotiated_protocols, const uint16_t* signature_algorithms, size_t num_signature_algorithms)
 {
-	int alpn_found = 0;
-	picoquic_quic_t ** ppquic = (picoquic_quic_t **)(
-		((char*)on_hello_cb_ctx) + sizeof(ptls_on_client_hello_t));
-	picoquic_quic_t * quic = *ppquic;
+    int alpn_found = 0;
+    picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)on_hello_cb_ctx) + sizeof(ptls_on_client_hello_t));
+    picoquic_quic_t* quic = *ppquic;
 
-	/* Check if the client is proposing the expected ALPN */
-	if (quic->default_alpn != NULL)
-	{
-		size_t len = strlen(quic->default_alpn);
+    /* Check if the client is proposing the expected ALPN */
+    if (quic->default_alpn != NULL) {
+        size_t len = strlen(quic->default_alpn);
 
-		for (size_t i = 0; i < num_negotiated_protocols; i++)
-		{
-			if (negotiated_protocols[i].len == len &&
-				memcmp(negotiated_protocols[i].base, quic->default_alpn, len) == 0)
-			{
-				alpn_found = 1;
-				ptls_set_negotiated_protocol(tls, quic->default_alpn, len);
-				break;
-			}
-		}
-	}
+        for (size_t i = 0; i < num_negotiated_protocols; i++) {
+            if (negotiated_protocols[i].len == len && memcmp(negotiated_protocols[i].base, quic->default_alpn, len) == 0) {
+                alpn_found = 1;
+                ptls_set_negotiated_protocol(tls, quic->default_alpn, len);
+                break;
+            }
+        }
+    }
 
-	/* If no common ALPN found, pick the first choice of the client. 
+    /* If no common ALPN found, pick the first choice of the client. 
 	 * This could be problematic, but right now alpn use in quic is in flux.
 	 */
 
-	if (alpn_found == 0)
-	{
-		for (size_t i = 0; i < num_negotiated_protocols; i++)
-		{
-			if (negotiated_protocols[i].len > 0)
-			{
-				ptls_set_negotiated_protocol(tls,
-					(char const *)negotiated_protocols[i].base, negotiated_protocols[i].len);
-				break;
-			}
-		}
-	}
+    if (alpn_found == 0) {
+        for (size_t i = 0; i < num_negotiated_protocols; i++) {
+            if (negotiated_protocols[i].len > 0) {
+                ptls_set_negotiated_protocol(tls,
+                    (char const*)negotiated_protocols[i].base, negotiated_protocols[i].len);
+                break;
+            }
+        }
+    }
 
-	return 0;
+    return 0;
 }
 
 /*
@@ -363,8 +336,8 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t * on_hello_cb_ctx,
  * Should return 0 if the ticket is good, etc.
  */
 
-int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t * encrypt_ticket_ctx,
-    ptls_t *tls, int is_encrypt, ptls_buffer_t *dst, ptls_iovec_t src)
+int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_ticket_ctx,
+    ptls_t* tls, int is_encrypt, ptls_buffer_t* dst, ptls_iovec_t src)
 {
 
     /* Assume that the keys are in the quic context 
@@ -372,20 +345,15 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t * encrypt_tic
      * followed by the result of the clear text encryption.
      */
     int ret = 0;
-    picoquic_quic_t ** ppquic = (picoquic_quic_t **)(
-        ((char*)encrypt_ticket_ctx) + sizeof(ptls_encrypt_ticket_t));
-    picoquic_quic_t * quic = *ppquic;
+    picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)encrypt_ticket_ctx) + sizeof(ptls_encrypt_ticket_t));
+    picoquic_quic_t* quic = *ppquic;
 
-    if (is_encrypt != 0)
-    {
-        ptls_aead_context_t * aead_enc = (ptls_aead_context_t *)quic->aead_encrypt_ticket_ctx;
+    if (is_encrypt != 0) {
+        ptls_aead_context_t* aead_enc = (ptls_aead_context_t*)quic->aead_encrypt_ticket_ctx;
         /* Encoding*/
-        if (aead_enc == NULL)
-        {
+        if (aead_enc == NULL) {
             ret = -1;
-        }
-        else if ((ret = ptls_buffer_reserve(dst, 8 + src.len + aead_enc->algo->tag_size)) == 0)
-        {
+        } else if ((ret = ptls_buffer_reserve(dst, 8 + src.len + aead_enc->algo->tag_size)) == 0) {
             /* Create and store the ticket sequence number */
             uint64_t seq_num = picoquic_public_random_64();
             picoformat_64(dst->base + dst->off, seq_num);
@@ -394,34 +362,24 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t * encrypt_tic
             dst->off += ptls_aead_encrypt(aead_enc, dst->base + dst->off,
                 src.base, src.len, seq_num, NULL, 0);
         }
-    }
-    else
-    {
-        ptls_aead_context_t * aead_dec = (ptls_aead_context_t *)quic->aead_decrypt_ticket_ctx;
+    } else {
+        ptls_aead_context_t* aead_dec = (ptls_aead_context_t*)quic->aead_decrypt_ticket_ctx;
         /* Encoding*/
-        if (aead_dec == NULL)
-        {
+        if (aead_dec == NULL) {
             ret = -1;
-        }
-        else if (src.len < 8 + aead_dec->algo->tag_size)
-        {
+        } else if (src.len < 8 + aead_dec->algo->tag_size) {
             ret = -1;
-        }
-        else if ((ret = ptls_buffer_reserve(dst, src.len)) == 0)
-        {
+        } else if ((ret = ptls_buffer_reserve(dst, src.len)) == 0) {
             /* Decode the ticket sequence number */
             uint64_t seq_num = PICOPARSE_64(src.base);
             /* Decrypt */
             size_t decrypted = ptls_aead_decrypt(aead_dec, dst->base + dst->off,
                 src.base + 8, src.len - 8, seq_num, NULL, 0);
 
-            if (decrypted > src.len - 8)
-            {
+            if (decrypted > src.len - 8) {
                 /* decryption error */
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 dst->off += decrypted;
             }
         }
@@ -435,29 +393,24 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t * encrypt_tic
  * the "save ticket" callback in the client's quic context.
  */
 
-int picoquic_client_save_ticket_call_back(ptls_save_ticket_t * save_ticket_ctx,
-    ptls_t *tls, ptls_iovec_t input)
+int picoquic_client_save_ticket_call_back(ptls_save_ticket_t* save_ticket_ctx,
+    ptls_t* tls, ptls_iovec_t input)
 {
     int ret = 0;
-    picoquic_quic_t * quic = *((picoquic_quic_t **)(
-        ((char*)save_ticket_ctx) + sizeof(ptls_save_ticket_t)));
-    const char * sni = ptls_get_server_name(tls);
-    const char * alpn = ptls_get_negotiated_protocol(tls);
+    picoquic_quic_t* quic = *((picoquic_quic_t**)(((char*)save_ticket_ctx) + sizeof(ptls_save_ticket_t)));
+    const char* sni = ptls_get_server_name(tls);
+    const char* alpn = ptls_get_negotiated_protocol(tls);
 
-    if (alpn == NULL && quic != NULL)
-    {
+    if (alpn == NULL && quic != NULL) {
         alpn = quic->default_alpn;
     }
 
-    if (sni != NULL && alpn != NULL)
-    {
+    if (sni != NULL && alpn != NULL) {
         ret = picoquic_store_ticket(&quic->p_first_ticket, 0, sni, (uint16_t)strlen(sni),
             alpn, (uint16_t)strlen(alpn), input.base, (uint16_t)input.len);
-    }
-    else
-    {
-        DBG_PRINTF("Received incorrect session resume ticket, sni = %s, alpn = %s, length = %d\n", 
-            (sni == NULL)?"NULL":sni, (alpn == NULL)?"NULL":alpn, (int) input.len);
+    } else {
+        DBG_PRINTF("Received incorrect session resume ticket, sni = %s, alpn = %s, length = %d\n",
+            (sni == NULL) ? "NULL" : sni, (alpn == NULL) ? "NULL" : alpn, (int)input.len);
     }
 
     return ret;
@@ -466,58 +419,47 @@ int picoquic_client_save_ticket_call_back(ptls_save_ticket_t * save_ticket_ctx,
 /*
  * Time get callback
  */
-uint64_t picoquic_get_simulated_time_cb(ptls_get_time_t *self)
+uint64_t picoquic_get_simulated_time_cb(ptls_get_time_t* self)
 {
-    uint64_t ** pp_simulated_time = (uint64_t **)(((char *)self) + sizeof(ptls_get_time_t));
-    return ((**pp_simulated_time)/1000);
+    uint64_t** pp_simulated_time = (uint64_t**)(((char*)self) + sizeof(ptls_get_time_t));
+    return ((**pp_simulated_time) / 1000);
 }
-
 
 /*
  * Setting the master TLS context.
  * On servers, this implies setting the "on hello" call back
  */
 
-int picoquic_master_tlscontext(picoquic_quic_t * quic,
-    char const * cert_file_name, char const * key_file_name,
-    const uint8_t * ticket_key, size_t ticket_key_length)
+int picoquic_master_tlscontext(picoquic_quic_t* quic,
+    char const* cert_file_name, char const* key_file_name,
+    const uint8_t* ticket_key, size_t ticket_key_length)
 {
     /* Create a client context or a server context */
     int ret = 0;
-    ptls_context_t *ctx;
-    ptls_openssl_verify_certificate_t * verifier = NULL;
-	ptls_on_client_hello_t * och = NULL;
-    ptls_encrypt_ticket_t *encrypt_ticket = NULL;
-    ptls_save_ticket_t *save_ticket = NULL;
+    ptls_context_t* ctx;
+    ptls_openssl_verify_certificate_t* verifier = NULL;
+    ptls_on_client_hello_t* och = NULL;
+    ptls_encrypt_ticket_t* encrypt_ticket = NULL;
+    ptls_save_ticket_t* save_ticket = NULL;
 
-    ctx = (ptls_context_t *)malloc(sizeof(ptls_context_t));
+    ctx = (ptls_context_t*)malloc(sizeof(ptls_context_t));
 
-    if (ctx == NULL)
-    {
+    if (ctx == NULL) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         memset(ctx, 0, sizeof(ptls_context_t));
         ctx->random_bytes = ptls_openssl_random_bytes;
         ctx->key_exchanges = ptls_openssl_key_exchanges;
         ctx->cipher_suites = ptls_openssl_cipher_suites;
 
-        if (quic->p_simulated_time == NULL)
-        {
+        if (quic->p_simulated_time == NULL) {
             ctx->get_time = &ptls_get_time;
-        }
-        else
-        {
-            ptls_get_time_t * time_getter = (ptls_get_time_t *)malloc(sizeof(ptls_get_time_t) +
-                sizeof(uint64_t *));
-            if (time_getter == NULL)
-            {
+        } else {
+            ptls_get_time_t* time_getter = (ptls_get_time_t*)malloc(sizeof(ptls_get_time_t) + sizeof(uint64_t*));
+            if (time_getter == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
-            }
-            else
-            {
-                uint64_t ** pp_simulated_time = (uint64_t **)(((char *)time_getter) + sizeof(ptls_get_time_t));
+            } else {
+                uint64_t** pp_simulated_time = (uint64_t**)(((char*)time_getter) + sizeof(ptls_get_time_t));
 
                 time_getter->cb = picoquic_get_simulated_time_cb;
                 *pp_simulated_time = quic->p_simulated_time;
@@ -525,26 +467,18 @@ int picoquic_master_tlscontext(picoquic_quic_t * quic,
             }
         }
 
-        if (cert_file_name != NULL && key_file_name != NULL)
-        {
+        if (cert_file_name != NULL && key_file_name != NULL) {
             /* Read the certificate file */
-            if (ptls_load_certificates(ctx, (char *)cert_file_name) != 0)
-            {
+            if (ptls_load_certificates(ctx, (char*)cert_file_name) != 0) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 ret = SetSignCertificate(key_file_name, ctx);
             }
 
-            if (ret == 0)
-            {
-                och = (ptls_on_client_hello_t *)malloc(sizeof(ptls_on_client_hello_t) +
-                    sizeof(picoquic_quic_t *));
-                if (och != NULL)
-                {
-                    picoquic_quic_t ** ppquic = (picoquic_quic_t **)(
-                        ((char*)och) + sizeof(ptls_on_client_hello_t));
+            if (ret == 0) {
+                och = (ptls_on_client_hello_t*)malloc(sizeof(ptls_on_client_hello_t) + sizeof(picoquic_quic_t*));
+                if (och != NULL) {
+                    picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)och) + sizeof(ptls_on_client_hello_t));
 
                     och->cb = picoquic_client_hello_call_back;
                     ctx->on_client_hello = och;
@@ -552,23 +486,16 @@ int picoquic_master_tlscontext(picoquic_quic_t * quic,
                 }
             }
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 ret = picoquic_server_setup_ticket_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
             }
 
-            if (ret == 0)
-            {
-                encrypt_ticket = (ptls_encrypt_ticket_t *)malloc(sizeof(ptls_encrypt_ticket_t) +
-                    sizeof(picoquic_quic_t *));
-                if (encrypt_ticket == NULL)
-                {
+            if (ret == 0) {
+                encrypt_ticket = (ptls_encrypt_ticket_t*)malloc(sizeof(ptls_encrypt_ticket_t) + sizeof(picoquic_quic_t*));
+                if (encrypt_ticket == NULL) {
                     ret = PICOQUIC_ERROR_MEMORY;
-                }
-                else
-                {
-                    picoquic_quic_t ** ppquic = (picoquic_quic_t **)(
-                        ((char*)encrypt_ticket) + sizeof(ptls_encrypt_ticket_t));
+                } else {
+                    picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)encrypt_ticket) + sizeof(ptls_encrypt_ticket_t));
 
                     encrypt_ticket->cb = picoquic_server_encrypt_ticket_call_back;
                     *ppquic = quic;
@@ -581,39 +508,29 @@ int picoquic_master_tlscontext(picoquic_quic_t * quic,
             }
         }
 
-            verifier = (ptls_openssl_verify_certificate_t *)malloc(sizeof(ptls_openssl_verify_certificate_t));
-			if (verifier == NULL)
-			{
-				ctx->verify_certificate = NULL;
-			}
-			else
-			{
-				ptls_openssl_init_verify_certificate(verifier, NULL);
-				ctx->verify_certificate = &verifier->super;
-			}
+        verifier = (ptls_openssl_verify_certificate_t*)malloc(sizeof(ptls_openssl_verify_certificate_t));
+        if (verifier == NULL) {
+            ctx->verify_certificate = NULL;
+        } else {
+            ptls_openssl_init_verify_certificate(verifier, NULL);
+            ctx->verify_certificate = &verifier->super;
+        }
 
-            if (quic->ticket_file_name != NULL)
-            {
-                save_ticket = (ptls_save_ticket_t *)malloc(sizeof(ptls_save_ticket_t) +
-                    sizeof(picoquic_quic_t *));
-                if (save_ticket != NULL)
-                {
-                    picoquic_quic_t ** ppquic = (picoquic_quic_t **)(
-                        ((char*)save_ticket) + sizeof(ptls_save_ticket_t));
+        if (quic->ticket_file_name != NULL) {
+            save_ticket = (ptls_save_ticket_t*)malloc(sizeof(ptls_save_ticket_t) + sizeof(picoquic_quic_t*));
+            if (save_ticket != NULL) {
+                picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)save_ticket) + sizeof(ptls_save_ticket_t));
 
-                    save_ticket->cb = picoquic_client_save_ticket_call_back;
-                    ctx->save_ticket = save_ticket;
-                    *ppquic = quic;
-                }
+                save_ticket->cb = picoquic_client_save_ticket_call_back;
+                ctx->save_ticket = save_ticket;
+                *ppquic = quic;
             }
+        }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             quic->tls_master_ctx = ctx;
             picoquic_public_random_seed(quic);
-        }
-        else
-        {
+        } else {
             free(ctx);
         }
     }
@@ -621,39 +538,33 @@ int picoquic_master_tlscontext(picoquic_quic_t * quic,
     return ret;
 }
 
-void picoquic_master_tlscontext_free(picoquic_quic_t * quic)
+void picoquic_master_tlscontext_free(picoquic_quic_t* quic)
 {
-	if (quic->tls_master_ctx != NULL)
-	{
-		ptls_context_t *ctx = (ptls_context_t *)quic->tls_master_ctx;
+    if (quic->tls_master_ctx != NULL) {
+        ptls_context_t* ctx = (ptls_context_t*)quic->tls_master_ctx;
 
-        if (quic->p_simulated_time != NULL && ctx->get_time != NULL)
-        {
+        if (quic->p_simulated_time != NULL && ctx->get_time != NULL) {
             free(ctx->get_time);
             ctx->get_time = NULL;
         }
 
-			if (ctx->certificates.list != NULL)
-			{
-				free(ctx->certificates.list);
-			}
+        if (ctx->certificates.list != NULL) {
+            free(ctx->certificates.list);
+        }
 
-		if (ctx->verify_certificate != NULL)
-		{
-			free(ctx->verify_certificate);
-			ctx->verify_certificate = NULL;
-		}
+        if (ctx->verify_certificate != NULL) {
+            free(ctx->verify_certificate);
+            ctx->verify_certificate = NULL;
+        }
 
-		if (ctx->on_client_hello != NULL)
-		{
-			free(ctx->on_client_hello);
-		}
+        if (ctx->on_client_hello != NULL) {
+            free(ctx->on_client_hello);
+        }
 
-        if (ctx->encrypt_ticket != NULL)
-        {
+        if (ctx->encrypt_ticket != NULL) {
             free(ctx->encrypt_ticket);
         }
-	}
+    }
 }
 
 /*
@@ -661,62 +572,53 @@ void picoquic_master_tlscontext_free(picoquic_quic_t * quic)
  * This includes setting the handshake properties that will later be
  * used during the TLS handshake.
  */
-int picoquic_tlscontext_create(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uint64_t current_time)
+int picoquic_tlscontext_create(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t current_time)
 {
     int ret = 0;
-	/* allocate a context structure */
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)malloc(sizeof(picoquic_tls_ctx_t));
+    /* allocate a context structure */
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)malloc(sizeof(picoquic_tls_ctx_t));
 
-	/* Create the TLS context */
-	if (ctx == NULL)
-	{
-		ret = -1;
-	}
-	else
-	{
-		memset(ctx, 0, sizeof(picoquic_tls_ctx_t));
+    /* Create the TLS context */
+    if (ctx == NULL) {
+        ret = -1;
+    } else {
+        memset(ctx, 0, sizeof(picoquic_tls_ctx_t));
 
-		ctx->cnx = cnx;
+        ctx->cnx = cnx;
 
-		ctx->handshake_properties.collect_extension = picoquic_tls_collect_extensions_cb;
-		ctx->handshake_properties.collected_extensions = picoquic_tls_collected_extensions_cb;
-		ctx->client_mode = cnx->client_mode;
+        ctx->handshake_properties.collect_extension = picoquic_tls_collect_extensions_cb;
+        ctx->handshake_properties.collected_extensions = picoquic_tls_collected_extensions_cb;
+        ctx->client_mode = cnx->client_mode;
 
-		ctx->tls = ptls_new((ptls_context_t *)quic->tls_master_ctx,
-			(ctx->client_mode)?0:1);
+        ctx->tls = ptls_new((ptls_context_t*)quic->tls_master_ctx,
+            (ctx->client_mode) ? 0 : 1);
 
-		if (ctx->tls == NULL)
-		{
-			free(ctx);
-			ctx = NULL;
-			ret = -1;
-		}
-		else if (ctx->client_mode)
-		{
-			if (cnx->sni != NULL)
-			{
-				ptls_set_server_name(ctx->tls, cnx->sni, strlen(cnx->sni));
-			}
+        if (ctx->tls == NULL) {
+            free(ctx);
+            ctx = NULL;
+            ret = -1;
+        } else if (ctx->client_mode) {
+            if (cnx->sni != NULL) {
+                ptls_set_server_name(ctx->tls, cnx->sni, strlen(cnx->sni));
+            }
 
-			if (cnx->alpn != NULL)
-			{
-				ctx->alpn_vec.base = (uint8_t *) cnx->alpn;
-				ctx->alpn_vec.len = strlen(cnx->alpn);
-				ctx->handshake_properties.client.negotiated_protocols.count = 1;
-				ctx->handshake_properties.client.negotiated_protocols.list = &ctx->alpn_vec;
-			}
+            if (cnx->alpn != NULL) {
+                ctx->alpn_vec.base = (uint8_t*)cnx->alpn;
+                ctx->alpn_vec.len = strlen(cnx->alpn);
+                ctx->handshake_properties.client.negotiated_protocols.count = 1;
+                ctx->handshake_properties.client.negotiated_protocols.list = &ctx->alpn_vec;
+            }
 
-			picoquic_tls_set_extensions(cnx, ctx);
+            picoquic_tls_set_extensions(cnx, ctx);
 
-            if (cnx->sni != NULL && cnx->alpn != NULL)
-            {
-                uint8_t * ticket = NULL;
+            if (cnx->sni != NULL && cnx->alpn != NULL) {
+                uint8_t* ticket = NULL;
                 uint16_t ticket_length = 0;
 
                 if (picoquic_get_ticket(cnx->quic->p_first_ticket, current_time,
-                    cnx->sni, (uint16_t)strlen(cnx->sni), cnx->alpn, (uint16_t)strlen(cnx->alpn),
-                    &ticket, &ticket_length) == 0)
-                {
+                        cnx->sni, (uint16_t)strlen(cnx->sni), cnx->alpn, (uint16_t)strlen(cnx->alpn),
+                        &ticket, &ticket_length)
+                    == 0) {
                     ctx->handshake_properties.client.session_ticket.base = ticket;
                     ctx->handshake_properties.client.session_ticket.len = ticket_length;
 
@@ -725,73 +627,64 @@ int picoquic_tlscontext_create(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uin
                     cnx->psk_cipher_suite_id = PICOPARSE_16(ticket + 8);
                 }
             }
-		}
-        else
-        {
+        } else {
             /* A server side connection, but no cert/key where given for the master context */
-            if (((ptls_context_t *)quic->tls_master_ctx)->encrypt_ticket == NULL) {
+            if (((ptls_context_t*)quic->tls_master_ctx)->encrypt_ticket == NULL) {
                 ret = PICOQUIC_ERROR_TLS_SERVER_CON_WITHOUT_CERT;
                 picoquic_tlscontext_free(ctx);
                 ctx = NULL;
             }
             /* Enable server side HRR if cookie mode is required */
-            else if ((quic->flags&picoquic_context_check_cookie) != 0)
-            {
+            else if ((quic->flags & picoquic_context_check_cookie) != 0) {
                 /* if the server should enforce the client to do a stateless retry */
-                ctx->handshake_properties.server.cookie.send_mode = 
-                    PTLS_COOKIE_SEND_ALWAYS;
-            }
-            else
-            {
+                ctx->handshake_properties.server.cookie.send_mode = PTLS_COOKIE_SEND_ALWAYS;
+            } else {
                 /* send cookie and do a stateless retry if cannot find suitable key share */
-                ctx->handshake_properties.server.cookie.send_mode =
-                    PTLS_COOKIE_SEND_ON_HRR;
-
+                ctx->handshake_properties.server.cookie.send_mode = PTLS_COOKIE_SEND_ON_HRR;
             }
             /* secret used for signing / verifying the cookie(internally uses HMAC) */
             ctx->handshake_properties.server.cookie.key = cnx->quic->retry_seed;
             /* additional data to be used for signing / verification */
             ctx->handshake_properties.server.cookie.additional_data.base
-                = (uint8_t *)&cnx->peer_addr;
+                = (uint8_t*)&cnx->peer_addr;
             ctx->handshake_properties.server.cookie.additional_data.len
                 = cnx->peer_addr_len;
         }
-	}
+    }
 
-	cnx->tls_ctx = (void *)ctx;
+    cnx->tls_ctx = (void*)ctx;
 
     return ret;
 }
 
-void picoquic_tlscontext_free(void * vctx)
+void picoquic_tlscontext_free(void* vctx)
 {
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)vctx;
-	if (ctx->tls != NULL)
-	{
-		ptls_free((ptls_t *)ctx->tls);
-		ctx->tls = NULL;
-	}
-	free(ctx);
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)vctx;
+    if (ctx->tls != NULL) {
+        ptls_free((ptls_t*)ctx->tls);
+        ctx->tls = NULL;
+    }
+    free(ctx);
 }
 
-char const * picoquic_tls_get_negotiated_alpn(picoquic_cnx_t * cnx)
+char const* picoquic_tls_get_negotiated_alpn(picoquic_cnx_t* cnx)
 {
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
 
-	return ptls_get_negotiated_protocol(ctx->tls);
+    return ptls_get_negotiated_protocol(ctx->tls);
 }
 
-char const * picoquic_tls_get_sni(picoquic_cnx_t * cnx)
+char const* picoquic_tls_get_sni(picoquic_cnx_t* cnx)
 {
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
 
-	return ptls_get_server_name(ctx->tls);
+    return ptls_get_server_name(ctx->tls);
 }
 
-int picoquic_tls_is_psk_handshake(picoquic_cnx_t * cnx)
+int picoquic_tls_is_psk_handshake(picoquic_cnx_t* cnx)
 {
     /* int ret = cnx->is_psk_handshake; */
-    int ret = ptls_is_psk_handshake(((picoquic_tls_ctx_t *)(cnx->tls_ctx))->tls);
+    int ret = ptls_is_psk_handshake(((picoquic_tls_ctx_t*)(cnx->tls_ctx))->tls);
     return ret;
 }
 
@@ -809,25 +702,21 @@ int picoquic_tls_is_psk_handshake(picoquic_cnx_t * cnx)
  *   May provide 1-RTT init
  */
 
-int picoquic_tlsinput_segment(picoquic_cnx_t * cnx,
-    uint8_t * bytes, size_t length, size_t * consumed, struct st_ptls_buffer_t * sendbuf)
+int picoquic_tlsinput_segment(picoquic_cnx_t* cnx,
+    uint8_t* bytes, size_t length, size_t* consumed, struct st_ptls_buffer_t* sendbuf)
 {
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
     size_t inlen = 0, roff = 0;
     int ret = 0;
 
     ptls_buffer_init(sendbuf, "", 0);
 
     /* Provide the data */
-    while (roff < length && (ret == 0 || ret == PTLS_ERROR_IN_PROGRESS))
-    {
+    while (roff < length && (ret == 0 || ret == PTLS_ERROR_IN_PROGRESS)) {
         inlen = length - roff;
-        if (ptls_handshake_is_complete(ctx->tls))
-        {
+        if (ptls_handshake_is_complete(ctx->tls)) {
             ret = ptls_receive(ctx->tls, sendbuf, bytes + roff, &inlen);
-        }
-        else
-        {
+        } else {
             ret = ptls_handshake(ctx->tls, sendbuf, bytes + roff, &inlen, &ctx->handshake_properties);
         }
         roff += inlen;
@@ -838,27 +727,23 @@ int picoquic_tlsinput_segment(picoquic_cnx_t * cnx,
     return ret;
 }
 
-int picoquic_initialize_stream_zero(picoquic_cnx_t * cnx)
+int picoquic_initialize_stream_zero(picoquic_cnx_t* cnx)
 {
     int ret = 0;
     struct st_ptls_buffer_t sendbuf;
-	picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
 
     ptls_buffer_init(&sendbuf, "", 0);
     ret = ptls_handshake(ctx->tls, &sendbuf, NULL, NULL, &ctx->handshake_properties);
 
-    if ((ret == 0 || ret == PTLS_ERROR_IN_PROGRESS))
-    {
-        if (sendbuf.off > 0)
-        {
+    if ((ret == 0 || ret == PTLS_ERROR_IN_PROGRESS)) {
+        if (sendbuf.off > 0) {
             ret = picoquic_add_to_stream(cnx, 0, sendbuf.base, sendbuf.off, 0);
         }
         ret = 0;
 
         picoquic_setup_0RTT_aead_contexts(cnx, 0);
-    }
-    else
-    {
+    } else {
         ret = -1;
     }
 
@@ -885,51 +770,43 @@ Decrypt returns size_t_max (-1) if decryption fails, number of bytes in output o
 
 void picoquic_aead_free(void* aead_context)
 {
-    ptls_aead_free((ptls_aead_context_t *)aead_context);
+    ptls_aead_free((ptls_aead_context_t*)aead_context);
 }
 
 size_t picoquic_aead_get_checksum_length(void* aead_context)
 {
-    return ((ptls_aead_context_t *)aead_context)->algo->tag_size;
+    return ((ptls_aead_context_t*)aead_context)->algo->tag_size;
 }
 
 /* Computation of the encryption and decryption methods for 0-RTT data */
 
-int picoquic_setup_0RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server)
+int picoquic_setup_0RTT_aead_contexts(picoquic_cnx_t* cnx, int is_server)
 {
     int ret = 0;
     uint8_t secret[256]; /* secret_max */
-    picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
-    ptls_cipher_suite_t * cipher = ptls_get_cipher(ctx->tls);
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
+    ptls_cipher_suite_t* cipher = ptls_get_cipher(ctx->tls);
 
-    if (cipher == NULL)
-    {
+    if (cipher == NULL) {
         ret = -1;
-    }
-    else if (cipher->hash->digest_size > sizeof(secret))
-    {
+    } else if (cipher->hash->digest_size > sizeof(secret)) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-    }
-    else
-    {
+    } else {
         /* Set up the encryption AEAD */
         ret = ptls_export_secret(ctx->tls, secret, cipher->hash->digest_size,
             PICOQUIC_LABEL_0RTT, ptls_iovec_init(NULL, 0), 1);
 
-        if (ret == 0 && is_server == 0)
-        {
-            cnx->aead_0rtt_encrypt_ctx = (void *)
+        if (ret == 0 && is_server == 0) {
+            cnx->aead_0rtt_encrypt_ctx = (void*)
                 ptls_aead_new(cipher->aead, cipher->hash, 1, secret);
 
-            if (cnx->aead_0rtt_encrypt_ctx == NULL)
-            {
+            if (cnx->aead_0rtt_encrypt_ctx == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
             }
         }
 
-        if (ret == 0)
-        {
-            cnx->aead_0rtt_decrypt_ctx = (void *)
+        if (ret == 0) {
+            cnx->aead_0rtt_decrypt_ctx = (void*)
                 ptls_aead_new(cipher->aead, cipher->hash, 0, secret);
         }
     }
@@ -937,58 +814,47 @@ int picoquic_setup_0RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server)
     return ret;
 }
 
-
 /* Computation of the encryption and decryption methods for 1-RTT data */
-int picoquic_setup_1RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server)
+int picoquic_setup_1RTT_aead_contexts(picoquic_cnx_t* cnx, int is_server)
 {
     int ret = 0;
     uint8_t secret[256]; /* secret_max */
-    picoquic_tls_ctx_t * ctx = (picoquic_tls_ctx_t *)cnx->tls_ctx;
-    ptls_cipher_suite_t * cipher = ptls_get_cipher(ctx->tls);
+    picoquic_tls_ctx_t* ctx = (picoquic_tls_ctx_t*)cnx->tls_ctx;
+    ptls_cipher_suite_t* cipher = ptls_get_cipher(ctx->tls);
 
-    if (cipher == NULL)
-    {
+    if (cipher == NULL) {
         ret = -1;
-    }
-    else if (cipher->hash->digest_size > sizeof(secret))
-    {
+    } else if (cipher->hash->digest_size > sizeof(secret)) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-    }
-    else
-    {
+    } else {
         /* Set up the encryption AEAD */
         ret = ptls_export_secret(ctx->tls, secret, cipher->hash->digest_size,
             (is_server == 0) ? PICOQUIC_LABEL_1RTT_CLIENT : PICOQUIC_LABEL_1RTT_SERVER,
             ptls_iovec_init(NULL, 0), 0);
 
-        if (ret == 0)
-        {
-            cnx->aead_encrypt_ctx = (void *)
+        if (ret == 0) {
+            cnx->aead_encrypt_ctx = (void*)
                 ptls_aead_new(cipher->aead, cipher->hash, 1, secret);
 
-            if (cnx->aead_encrypt_ctx == NULL)
-            {
+            if (cnx->aead_encrypt_ctx == NULL) {
                 ret = PICOQUIC_ERROR_MEMORY;
             }
 
-            cnx->aead_de_encrypt_ctx = (void *)
+            cnx->aead_de_encrypt_ctx = (void*)
                 ptls_aead_new(cipher->aead, cipher->hash, 0, secret);
         }
 
         /* Now set up the corresponding decryption */
-        if (ret == 0)
-        {
+        if (ret == 0) {
             ret = ptls_export_secret(ctx->tls, secret, cipher->hash->digest_size,
                 (is_server != 0) ? PICOQUIC_LABEL_1RTT_CLIENT : PICOQUIC_LABEL_1RTT_SERVER,
                 ptls_iovec_init(NULL, 0), 0);
         }
 
-        if (ret == 0)
-        {
-            cnx->aead_decrypt_ctx = (void *)ptls_aead_new(cipher->aead, cipher->hash, 0, secret);
+        if (ret == 0) {
+            cnx->aead_decrypt_ctx = (void*)ptls_aead_new(cipher->aead, cipher->hash, 0, secret);
 
-            if (cnx->aead_decrypt_ctx == NULL)
-            {
+            if (cnx->aead_decrypt_ctx == NULL) {
                 ret = -1;
             }
         }
@@ -997,37 +863,30 @@ int picoquic_setup_1RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server)
     return ret;
 }
 
-int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t * quic,
-    ptls_context_t *tls_ctx,
-    const uint8_t * secret, size_t secret_length)
+int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t* quic,
+    ptls_context_t* tls_ctx,
+    const uint8_t* secret, size_t secret_length)
 {
     int ret = 0;
     uint8_t temp_secret[256]; /* secret_max */
-    ptls_hash_algorithm_t * algo = &ptls_openssl_sha256;
-    ptls_aead_algorithm_t * aead = &ptls_openssl_aes128gcm;
+    ptls_hash_algorithm_t* algo = &ptls_openssl_sha256;
+    ptls_aead_algorithm_t* aead = &ptls_openssl_aes128gcm;
 
-    if (algo->digest_size > sizeof(temp_secret))
-    {
+    if (algo->digest_size > sizeof(temp_secret)) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
-    }
-    else
-    {
-        if (secret != NULL && secret_length > 0)
-        {
+    } else {
+        if (secret != NULL && secret_length > 0) {
             memset(temp_secret, 0, algo->digest_size);
             memcpy(temp_secret, secret, (secret_length > algo->digest_size) ? algo->digest_size : secret_length);
-        }
-        else
-        {
+        } else {
             tls_ctx->random_bytes(temp_secret, algo->digest_size);
         }
 
         /* Create the AEAD contexts */
-        quic->aead_encrypt_ticket_ctx = (void *)ptls_aead_new(aead, algo, 1, temp_secret);
-        quic->aead_decrypt_ticket_ctx = (void *)ptls_aead_new(aead, algo, 0, temp_secret);
+        quic->aead_encrypt_ticket_ctx = (void*)ptls_aead_new(aead, algo, 1, temp_secret);
+        quic->aead_decrypt_ticket_ctx = (void*)ptls_aead_new(aead, algo, 0, temp_secret);
 
-        if (quic->aead_encrypt_ticket_ctx == NULL || quic->aead_decrypt_ticket_ctx == NULL)
-        {
+        if (quic->aead_encrypt_ticket_ctx == NULL || quic->aead_decrypt_ticket_ctx == NULL) {
             ret = PICOQUIC_ERROR_MEMORY;
         }
 
@@ -1039,94 +898,89 @@ int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t * quic,
 }
 
 /* AEAD encrypt/decrypt routines */
-static size_t picoquic_aead_decrypt_generic(uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length, void * aead_ctx)
+static size_t picoquic_aead_decrypt_generic(uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length, void* aead_ctx)
 {
     size_t decrypted = 0;
 
-    if (aead_ctx == NULL)
-    {
+    if (aead_ctx == NULL) {
         decrypted = (uint64_t)(-1ll);
-    }
-    else
-    {
-        decrypted = ptls_aead_decrypt((ptls_aead_context_t *)aead_ctx,
-            (void*)output, (const void *)input, input_length, seq_num,
-            (void *)auth_data, auth_data_length);
+    } else {
+        decrypted = ptls_aead_decrypt((ptls_aead_context_t*)aead_ctx,
+            (void*)output, (const void*)input, input_length, seq_num,
+            (void*)auth_data, auth_data_length);
     }
 
     return decrypted;
 }
 
-size_t picoquic_aead_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_decrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_decrypt_ctx);
 }
 
-size_t picoquic_aead_de_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_de_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_decrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_de_encrypt_ctx);
 }
 
-size_t picoquic_aead_0rtt_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_0rtt_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_decrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_0rtt_decrypt_ctx);
 }
 
-size_t picoquic_aead_cleartext_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_cleartext_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_decrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_decrypt_cleartext_ctx);
 }
 
-size_t picoquic_aead_cleartext_de_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_cleartext_de_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_decrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_de_encrypt_cleartext_ctx);
 }
 
-size_t picoquic_aead_encrypt_generic(uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length, void * aead_ctx)
+size_t picoquic_aead_encrypt_generic(uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length, void* aead_ctx)
 {
     size_t encrypted = 0;
 
-    encrypted = ptls_aead_encrypt((ptls_aead_context_t *)aead_ctx,
-            (void*)output, (const void *)input, input_length, seq_num,
-            (void *)auth_data, auth_data_length);
+    encrypted = ptls_aead_encrypt((ptls_aead_context_t*)aead_ctx,
+        (void*)output, (const void*)input, input_length, seq_num,
+        (void*)auth_data, auth_data_length);
 
     return encrypted;
 }
 
-size_t picoquic_aead_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
-    return picoquic_aead_encrypt_generic(output, input, input_length, seq_num, 
+    return picoquic_aead_encrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_encrypt_ctx);
 }
 
-size_t picoquic_aead_0rtt_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_0rtt_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_encrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_0rtt_encrypt_ctx);
 }
 
-
-size_t picoquic_aead_cleartext_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length)
+size_t picoquic_aead_cleartext_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length)
 {
     return picoquic_aead_encrypt_generic(output, input, input_length, seq_num,
         auth_data, auth_data_length, cnx->aead_encrypt_cleartext_ctx);
 }
-
 
 /* Computation of the clear text AEAD encryption based on per version secret */
 #define PICOQUIC_LABEL_HANDSHAKE_CLIENT "tls13 QUIC client handshake secret"
@@ -1135,9 +989,9 @@ size_t picoquic_aead_cleartext_encrypt(picoquic_cnx_t *cnx, uint8_t * output, ui
 #define PICOQUIC_LABEL_CLEAR_TEXT_IV "tls13 iv"
 
 uint8_t picoquic_cleartext_null_salt[] = {
-    0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,
-    0,0,0,0
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0
 };
 
 /*
@@ -1172,19 +1026,18 @@ uint8_t picoquic_cleartext_null_salt[] = {
 */
 
 static size_t picoquic_setup_clear_text_aead_label(
-    size_t out_len, uint8_t label[256], char const * label_text)
+    size_t out_len, uint8_t label[256], char const* label_text)
 {
     size_t text_length = strlen(label_text);
     size_t byte_index = 0;
 
-    if (text_length > 252)
-    {
+    if (text_length > 252) {
         /* There are practical limits to what we want to do */
         return 0;
     }
-    picoformat_16(label, (uint16_t) out_len);
+    picoformat_16(label, (uint16_t)out_len);
     byte_index += 2;
-    label[byte_index++] = (uint8_t) text_length;
+    label[byte_index++] = (uint8_t)text_length;
     memcpy(&label[byte_index], label_text, text_length);
     byte_index += text_length;
     label[byte_index++] = 0;
@@ -1192,34 +1045,30 @@ static size_t picoquic_setup_clear_text_aead_label(
     return byte_index;
 }
 
-static void picoquic_setup_cleartext_aead_salt(size_t version_index, ptls_iovec_t * salt)
-{ 
-    if (picoquic_supported_versions[version_index].version_aead_key != NULL &&
-        picoquic_supported_versions[version_index].version_aead_key_length > 0)
-    {
+static void picoquic_setup_cleartext_aead_salt(size_t version_index, ptls_iovec_t* salt)
+{
+    if (picoquic_supported_versions[version_index].version_aead_key != NULL && picoquic_supported_versions[version_index].version_aead_key_length > 0) {
         salt->base = picoquic_supported_versions[version_index].version_aead_key;
         salt->len = picoquic_supported_versions[version_index].version_aead_key_length;
-    }
-    else
-    {
+    } else {
         salt->base = picoquic_cleartext_null_salt;
         salt->len = sizeof(picoquic_cleartext_null_salt);
     }
 }
 
-int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx)
+int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t* cnx)
 {
     int ret = 0;
     uint8_t master_secret[256]; /* secret_max */
     uint8_t cnx_id[8]; /* serialized cnx_id */
-    ptls_hash_algorithm_t * algo = &ptls_openssl_sha256;
-    ptls_aead_algorithm_t * aead = &ptls_openssl_aes128gcm;
+    ptls_hash_algorithm_t* algo = &ptls_openssl_sha256;
+    ptls_aead_algorithm_t* aead = &ptls_openssl_aes128gcm;
     ptls_iovec_t salt;
     ptls_iovec_t ikm;
     uint8_t label[256];
     uint8_t client_secret[256];
     uint8_t server_secret[256];
-    uint8_t * secret1, * secret2;
+    uint8_t *secret1, *secret2;
     ptls_iovec_t prk;
     ptls_iovec_t info;
 
@@ -1230,8 +1079,7 @@ int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx)
 
     /* Extract the master key -- key length will be 32 per SHA256 */
     ret = ptls_hkdf_extract(algo, master_secret, salt, ikm);
-    if (ret == 0)
-    {
+    if (ret == 0) {
         prk.base = master_secret;
         prk.len = algo->digest_size;
         /* Compose the client label */
@@ -1241,38 +1089,32 @@ int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx)
         /* extract the client key */
         ret = ptls_hkdf_expand(algo, client_secret, algo->digest_size, prk, info);
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             /* Compose the server label */
             info.base = label;
-            info.len = picoquic_setup_clear_text_aead_label(algo->digest_size, 
+            info.len = picoquic_setup_clear_text_aead_label(algo->digest_size,
                 label, PICOQUIC_LABEL_HANDSHAKE_SERVER);
             /* extract the server key */
             ret = ptls_hkdf_expand(algo, server_secret, algo->digest_size, prk, info);
         }
     }
 
-    if (ret == 0)
-    {
-        if (!cnx->client_mode)
-        {
+    if (ret == 0) {
+        if (!cnx->client_mode) {
             secret1 = server_secret;
             secret2 = client_secret;
-        }
-        else
-        {
+        } else {
             secret1 = client_secret;
             secret2 = server_secret;
         }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             /* Create the AEAD contexts */
-            cnx->aead_encrypt_cleartext_ctx = (void *)
+            cnx->aead_encrypt_cleartext_ctx = (void*)
                 ptls_aead_new(aead, algo, 1, secret1);
-            cnx->aead_decrypt_cleartext_ctx = (void *)
+            cnx->aead_decrypt_cleartext_ctx = (void*)
                 ptls_aead_new(aead, algo, 0, secret2);
-            cnx->aead_de_encrypt_cleartext_ctx = (void *)
+            cnx->aead_de_encrypt_cleartext_ctx = (void*)
                 ptls_aead_new(aead, algo, 0, secret1);
         }
     }
@@ -1280,28 +1122,23 @@ int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx)
     return ret;
 }
 
-
 /* Input stream zero data to TLS context
  */
 
-int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx)
+int picoquic_tlsinput_stream_zero(picoquic_cnx_t* cnx)
 {
     int ret = 0;
-    picoquic_stream_data * data = cnx->first_stream.stream_data;
+    picoquic_stream_data* data = cnx->first_stream.stream_data;
     struct st_ptls_buffer_t sendbuf;
 
-    if (data == NULL ||
-        data->offset > cnx->first_stream.consumed_offset)
-    {
+    if (data == NULL || data->offset > cnx->first_stream.consumed_offset) {
         return 0;
     }
 
     ptls_buffer_init(&sendbuf, "", 0);
 
     while (
-        (ret == 0 || ret == PTLS_ERROR_IN_PROGRESS) && 
-        data != NULL && data->offset <= cnx->first_stream.consumed_offset)
-    {
+        (ret == 0 || ret == PTLS_ERROR_IN_PROGRESS) && data != NULL && data->offset <= cnx->first_stream.consumed_offset) {
         size_t start = (size_t)(cnx->first_stream.consumed_offset - data->offset);
         size_t consumed = 0;
 
@@ -1309,9 +1146,8 @@ int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx)
             data->length - start, &consumed, &sendbuf);
 
         cnx->first_stream.consumed_offset += consumed;
-        
-        if (start + consumed >= data->length)
-        {
+
+        if (start + consumed >= data->length) {
             free(data->bytes);
             cnx->first_stream.stream_data = data->next_stream_data;
             free(data);
@@ -1319,26 +1155,21 @@ int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx)
         }
     }
 
-    if (ret == 0)
-    {
-        switch (cnx->cnx_state)
-        {
-		case picoquic_state_client_hrr_received:
-			/* This is not supposed to happen -- HRR should generate "error in progress" */
-			break;
+    if (ret == 0) {
+        switch (cnx->cnx_state) {
+        case picoquic_state_client_hrr_received:
+            /* This is not supposed to happen -- HRR should generate "error in progress" */
+            break;
         case picoquic_state_client_init:
-		case picoquic_state_client_init_sent:
+        case picoquic_state_client_init_sent:
         case picoquic_state_client_renegotiate:
         case picoquic_state_client_init_resent:
         case picoquic_state_client_handshake_start:
         case picoquic_state_client_handshake_progress:
-            if (cnx->remote_parameters_received == 0)
-            {
+            if (cnx->remote_parameters_received == 0) {
                 ret = picoquic_connection_error(cnx,
                     PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-            }
-            else
-            {
+            } else {
                 /* Extract and install the client 1-RTT key */
                 cnx->cnx_state = picoquic_state_client_almost_ready;
                 ret = picoquic_setup_1RTT_aead_contexts(cnx, 0);
@@ -1365,52 +1196,37 @@ int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx)
             DBG_PRINTF("Unexpected connection state: %d\n", cnx->cnx_state);
             break;
         }
-    }
-    else if (ret == PTLS_ERROR_IN_PROGRESS && 
-        (cnx->cnx_state == picoquic_state_client_init ||
-            cnx->cnx_state == picoquic_state_client_init_sent ||
-            cnx->cnx_state == picoquic_state_client_init_resent))
-    {
+    } else if (ret == PTLS_ERROR_IN_PROGRESS && (cnx->cnx_state == picoquic_state_client_init || cnx->cnx_state == picoquic_state_client_init_sent || cnx->cnx_state == picoquic_state_client_init_resent)) {
         /* Extract and install the client 0-RTT key */
-    }
-	else if (ret == PTLS_ERROR_IN_PROGRESS &&
-		(cnx->cnx_state == picoquic_state_client_hrr_received))
-	{
-		/* Need to reset the transport state of the connection */
-		cnx->cnx_state = picoquic_state_client_init;
-		/* Delete the packets queued for retransmission */
-		while (cnx->retransmit_newest != NULL)
-		{
-			picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
-		}
+    } else if (ret == PTLS_ERROR_IN_PROGRESS && (cnx->cnx_state == picoquic_state_client_hrr_received)) {
+        /* Need to reset the transport state of the connection */
+        cnx->cnx_state = picoquic_state_client_init;
+        /* Delete the packets queued for retransmission */
+        while (cnx->retransmit_newest != NULL) {
+            picoquic_dequeue_retransmit_packet(cnx, cnx->retransmit_newest, 1);
+        }
 
-		/* Reset the streams */
-		picoquic_clear_stream(&cnx->first_stream);
-		cnx->first_stream.consumed_offset = 0;
-		cnx->first_stream.stream_flags = 0;
-		cnx->first_stream.fin_offset = 0;
-		cnx->first_stream.sent_offset = 0;
-	}
-    else if (ret == PTLS_ERROR_STATELESS_RETRY)
-    {
+        /* Reset the streams */
+        picoquic_clear_stream(&cnx->first_stream);
+        cnx->first_stream.consumed_offset = 0;
+        cnx->first_stream.stream_flags = 0;
+        cnx->first_stream.fin_offset = 0;
+        cnx->first_stream.sent_offset = 0;
+    } else if (ret == PTLS_ERROR_STATELESS_RETRY) {
         cnx->cnx_state = picoquic_state_server_send_hrr;
-    }/*
+    } /*
     else if (ret == PTLS_ERROR_IN_PROGRESS &&
         cnx->cnx_state == picoquic_state_server_init)
     {
         cnx->cnx_state = picoquic_state_server_send_hrr;
     }*/
 
-    if ((ret == 0 || ret == PTLS_ERROR_IN_PROGRESS || ret == PTLS_ERROR_STATELESS_RETRY))
-    {
-        if (sendbuf.off > 0)
-        {
+    if ((ret == 0 || ret == PTLS_ERROR_IN_PROGRESS || ret == PTLS_ERROR_STATELESS_RETRY)) {
+        if (sendbuf.off > 0) {
             ret = picoquic_add_to_stream(cnx, 0, sendbuf.base, sendbuf.off, 0);
         }
         ret = 0;
-    }
-    else
-    {
+    } else {
         ret = -1;
     }
 
@@ -1428,27 +1244,24 @@ int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx)
  * decide to use the minicrypto API.
  */
 
-int picoquic_create_cnxid_reset_secret(picoquic_quic_t * quic, uint64_t cnx_id,
-	uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE])
+int picoquic_create_cnxid_reset_secret(picoquic_quic_t* quic, uint64_t cnx_id,
+    uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE])
 {
-	/* Using OpenSSL for now: ptls_hash_algorithm_t ptls_openssl_sha256 */
-	int ret = 0;
-	ptls_hash_algorithm_t *algo = &ptls_openssl_sha256;
-	ptls_hash_context_t *hash_ctx = algo->create();
-	uint8_t final_hash[PTLS_MAX_DIGEST_SIZE];
+    /* Using OpenSSL for now: ptls_hash_algorithm_t ptls_openssl_sha256 */
+    int ret = 0;
+    ptls_hash_algorithm_t* algo = &ptls_openssl_sha256;
+    ptls_hash_context_t* hash_ctx = algo->create();
+    uint8_t final_hash[PTLS_MAX_DIGEST_SIZE];
 
-	if (hash_ctx == NULL)
-	{
-		ret = -1;
-		memset(reset_secret, 0, PICOQUIC_RESET_SECRET_SIZE);
-	}
-	else
-	{
-		hash_ctx->update(hash_ctx, quic->reset_seed, sizeof(quic->reset_seed));
-		hash_ctx->update(hash_ctx, &cnx_id, sizeof(cnx_id));
-		hash_ctx->final(hash_ctx, final_hash, PTLS_HASH_FINAL_MODE_FREE);
-		memcpy(reset_secret, final_hash, PICOQUIC_RESET_SECRET_SIZE);
-	}
+    if (hash_ctx == NULL) {
+        ret = -1;
+        memset(reset_secret, 0, PICOQUIC_RESET_SECRET_SIZE);
+    } else {
+        hash_ctx->update(hash_ctx, quic->reset_seed, sizeof(quic->reset_seed));
+        hash_ctx->update(hash_ctx, &cnx_id, sizeof(cnx_id));
+        hash_ctx->final(hash_ctx, final_hash, PTLS_HASH_FINAL_MODE_FREE);
+        memcpy(reset_secret, final_hash, PICOQUIC_RESET_SECRET_SIZE);
+    }
 
-	return(ret);
+    return (ret);
 }

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -23,70 +23,70 @@
 #define TLS_API_H
 #include "picoquic_internal.h"
 
-int picoquic_master_tlscontext(picoquic_quic_t * quic, char const * cert_file_name, char const * key_file_name,
-    const uint8_t * ticket_key, size_t ticket_key_length);
+int picoquic_master_tlscontext(picoquic_quic_t* quic, char const* cert_file_name, char const* key_file_name,
+    const uint8_t* ticket_key, size_t ticket_key_length);
 
-void picoquic_master_tlscontext_free(picoquic_quic_t * quic);
+void picoquic_master_tlscontext_free(picoquic_quic_t* quic);
 
-int picoquic_tlscontext_create(picoquic_quic_t * quic, picoquic_cnx_t * cnx, uint64_t current_time);
+int picoquic_tlscontext_create(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t current_time);
 
-void picoquic_tlscontext_free(void * ctx);
+void picoquic_tlscontext_free(void* ctx);
 
-int picoquic_tlsinput_stream_zero(picoquic_cnx_t * cnx);
+int picoquic_tlsinput_stream_zero(picoquic_cnx_t* cnx);
 
-int picoquic_initialize_stream_zero(picoquic_cnx_t * cnx);
+int picoquic_initialize_stream_zero(picoquic_cnx_t* cnx);
 
-void picoquic_crypto_random(picoquic_quic_t * quic, void * buf, size_t len);
-uint64_t picoquic_crypto_uniform_random(picoquic_quic_t * quic, uint64_t rnd_max);
+void picoquic_crypto_random(picoquic_quic_t* quic, void* buf, size_t len);
+uint64_t picoquic_crypto_uniform_random(picoquic_quic_t* quic, uint64_t rnd_max);
 
 uint64_t picoquic_public_random_64(void);
-void picoquic_public_random_seed(picoquic_quic_t * quic);
-void picoquic_public_random(void * buf, size_t len);
+void picoquic_public_random_seed(picoquic_quic_t* quic);
+void picoquic_public_random(void* buf, size_t len);
 uint64_t picoquic_public_uniform_random(uint64_t rnd_max);
 
-int picoquic_setup_0RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server);
-int picoquic_setup_1RTT_aead_contexts(picoquic_cnx_t * cnx, int is_server);
+int picoquic_setup_0RTT_aead_contexts(picoquic_cnx_t* cnx, int is_server);
+int picoquic_setup_1RTT_aead_contexts(picoquic_cnx_t* cnx, int is_server);
 
 size_t picoquic_aead_get_checksum_length(void* aead_context);
 
-size_t picoquic_aead_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_de_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_de_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_0rtt_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_0rtt_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_0rtt_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, size_t input_length,
-    uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_0rtt_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input, size_t input_length,
+    uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t * cnx);
+int picoquic_setup_cleartext_aead_contexts(picoquic_cnx_t* cnx);
 
-size_t picoquic_aead_cleartext_decrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, 
-    size_t input_length, uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_cleartext_decrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input,
+    size_t input_length, uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_cleartext_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, 
-    size_t input_length, uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_cleartext_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input,
+    size_t input_length, uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
-size_t picoquic_aead_cleartext_de_encrypt(picoquic_cnx_t *cnx, uint8_t * output, uint8_t * input, 
-    size_t input_length, uint64_t seq_num, uint8_t * auth_data, size_t auth_data_length);
+size_t picoquic_aead_cleartext_de_encrypt(picoquic_cnx_t* cnx, uint8_t* output, uint8_t* input,
+    size_t input_length, uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length);
 
 void picoquic_aead_free(void* aead_context);
 
-int picoquic_create_cnxid_reset_secret(picoquic_quic_t * quic, uint64_t cnx_id,
-	uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE]);
+int picoquic_create_cnxid_reset_secret(picoquic_quic_t* quic, uint64_t cnx_id,
+    uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE]);
 
-void picoquic_provide_received_transport_extensions(picoquic_cnx_t * cnx,
-	uint8_t ** ext_received,
-	size_t * ext_received_length,
-	int * ext_received_return,
-	int * client_mode);
+void picoquic_provide_received_transport_extensions(picoquic_cnx_t* cnx,
+    uint8_t** ext_received,
+    size_t* ext_received_length,
+    int* ext_received_return,
+    int* client_mode);
 
-char const * picoquic_tls_get_negotiated_alpn(picoquic_cnx_t * cnx);
-char const * picoquic_tls_get_sni(picoquic_cnx_t * cnx);
+char const* picoquic_tls_get_negotiated_alpn(picoquic_cnx_t* cnx);
+char const* picoquic_tls_get_sni(picoquic_cnx_t* cnx);
 
 #endif /* TLS_API_H */

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -57,116 +57,104 @@
  *   } TransportParameters;
  */
 
-#include <string.h>
 #include "picoquic_internal.h"
+#include <string.h>
 
 typedef enum {
-	picoquic_transport_parameter_initial_max_stream_data = 0,
-	picoquic_transport_parameter_initial_max_data = 1,
-	picoquic_transport_parameter_initial_max_stream_id_bidir = 2,
-	picoquic_transport_parameter_idle_timeout = 3,
-	picoquic_transport_parameter_omit_connection_id = 4,
-	picoquic_transport_parameter_max_packet_size = 5,
-	picoquic_transport_parameter_reset_secret = 6,
+    picoquic_transport_parameter_initial_max_stream_data = 0,
+    picoquic_transport_parameter_initial_max_data = 1,
+    picoquic_transport_parameter_initial_max_stream_id_bidir = 2,
+    picoquic_transport_parameter_idle_timeout = 3,
+    picoquic_transport_parameter_omit_connection_id = 4,
+    picoquic_transport_parameter_max_packet_size = 5,
+    picoquic_transport_parameter_reset_secret = 6,
     picoquic_transport_parameter_ack_delay_exponent = 7,
     picoquic_transport_parameter_initial_max_stream_id_unidir = 8,
 } picoquic_transport_parameter_enum;
 
-int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
-	int ret = 0;
-	size_t byte_index = 0;
-	size_t min_size = 0;
-	uint16_t param_size = 0;
+    int ret = 0;
+    size_t byte_index = 0;
+    size_t min_size = 0;
+    uint16_t param_size = 0;
 
     /* TODO: version code dependent on version type */
 
-	switch (extension_mode)
-	{
-	case 0: // Client hello
+    switch (extension_mode) {
+    case 0: // Client hello
         min_size = 4;
-		break;
-	case 1: // Server encrypted extension
-		min_size = 1 + 4 + 4 * picoquic_nb_supported_versions;
-		break;
-	default: // New session ticket
-		break;
-	}
-	/* add the mandatory parameters */
-	param_size = (2 + 2 + 4) + (2 + 2 + 4) + (2 + 2 + 2) + (2 + 2 + 2);
-    if (cnx->local_parameters.initial_max_stream_id_bidir != 0)
-    {
+        break;
+    case 1: // Server encrypted extension
+        min_size = 1 + 4 + 4 * picoquic_nb_supported_versions;
+        break;
+    default: // New session ticket
+        break;
+    }
+    /* add the mandatory parameters */
+    param_size = (2 + 2 + 4) + (2 + 2 + 4) + (2 + 2 + 2) + (2 + 2 + 2);
+    if (cnx->local_parameters.initial_max_stream_id_bidir != 0) {
         param_size += (2 + 2 + 4);
     }
-	if (cnx->local_parameters.omit_connection_id)
-	{
-		param_size += 2 + 2;
-	}
-	if (extension_mode == 1)
-	{
-		param_size += 2 + 2 + PICOQUIC_RESET_SECRET_SIZE;
-	}
-    if (cnx->local_parameters.ack_delay_exponent != 3)
-    {
+    if (cnx->local_parameters.omit_connection_id) {
+        param_size += 2 + 2;
+    }
+    if (extension_mode == 1) {
+        param_size += 2 + 2 + PICOQUIC_RESET_SECRET_SIZE;
+    }
+    if (cnx->local_parameters.ack_delay_exponent != 3) {
         param_size += (2 + 2 + 1);
     }
-    if (cnx->local_parameters.initial_max_stream_id_unidir != 0)
-    {
+    if (cnx->local_parameters.initial_max_stream_id_unidir != 0) {
         param_size += (2 + 2 + 4);
     }
 
-	min_size += param_size + 2;
+    min_size += param_size + 2;
 
-	*consumed = min_size;
+    *consumed = min_size;
 
-	if (min_size > bytes_max)
-	{
-		ret = PICOQUIC_ERROR_EXTENSION_BUFFER_TOO_SMALL;
-	}
-	else
-	{
-		switch (extension_mode)
-		{
-		case 0: // Client hello
-			picoformat_32(bytes + byte_index, cnx->proposed_version);
-			byte_index += 4;
-			break;
-		case 1: // Server encrypted extension
+    if (min_size > bytes_max) {
+        ret = PICOQUIC_ERROR_EXTENSION_BUFFER_TOO_SMALL;
+    } else {
+        switch (extension_mode) {
+        case 0: // Client hello
+            picoformat_32(bytes + byte_index, cnx->proposed_version);
+            byte_index += 4;
+            break;
+        case 1: // Server encrypted extension
             picoformat_32(bytes + byte_index,
-                    picoquic_supported_versions[cnx->version_index].version);
+                picoquic_supported_versions[cnx->version_index].version);
             byte_index += 4;
 
-			bytes[byte_index++] = (uint8_t) (4 * picoquic_nb_supported_versions);
-			for (size_t i = 0; i < picoquic_nb_supported_versions; i++)
-			{
-				picoformat_32(bytes + byte_index, picoquic_supported_versions[i].version);
-				byte_index += 4;
-			}
-			break;
-		default: // New session ticket
-			break;
-		}
+            bytes[byte_index++] = (uint8_t)(4 * picoquic_nb_supported_versions);
+            for (size_t i = 0; i < picoquic_nb_supported_versions; i++) {
+                picoformat_32(bytes + byte_index, picoquic_supported_versions[i].version);
+                byte_index += 4;
+            }
+            break;
+        default: // New session ticket
+            break;
+        }
 
-		picoformat_16(bytes + byte_index, param_size);
-		byte_index += 2;
+        picoformat_16(bytes + byte_index, param_size);
+        byte_index += 2;
 
-		picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_stream_data);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, 4);
-		byte_index += 2;
-		picoformat_32(bytes + byte_index, cnx->local_parameters.initial_max_stream_data);
-		byte_index += 4;
+        picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_stream_data);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, 4);
+        byte_index += 2;
+        picoformat_32(bytes + byte_index, cnx->local_parameters.initial_max_stream_data);
+        byte_index += 4;
 
-		picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_data);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, 4);
-		byte_index += 2;
-		picoformat_32(bytes + byte_index, cnx->local_parameters.initial_max_data);
-		byte_index += 4;
+        picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_data);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, 4);
+        byte_index += 2;
+        picoformat_32(bytes + byte_index, cnx->local_parameters.initial_max_data);
+        byte_index += 4;
 
-        if (cnx->local_parameters.initial_max_stream_id_bidir > 0)
-        {
+        if (cnx->local_parameters.initial_max_stream_id_bidir > 0) {
             picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_stream_id_bidir);
             byte_index += 2;
             picoformat_16(bytes + byte_index, 4);
@@ -175,40 +163,37 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mo
             byte_index += 4;
         }
 
-		picoformat_16(bytes + byte_index, picoquic_transport_parameter_idle_timeout);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, 2);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, (uint16_t) cnx->local_parameters.idle_timeout);
-		byte_index += 2;
+        picoformat_16(bytes + byte_index, picoquic_transport_parameter_idle_timeout);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, 2);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, (uint16_t)cnx->local_parameters.idle_timeout);
+        byte_index += 2;
 
-		if (cnx->local_parameters.omit_connection_id)
-		{
-			picoformat_16(bytes + byte_index, picoquic_transport_parameter_omit_connection_id);
-			byte_index += 2;
-			picoformat_16(bytes + byte_index, 0);
-			byte_index += 2;
-		}
+        if (cnx->local_parameters.omit_connection_id) {
+            picoformat_16(bytes + byte_index, picoquic_transport_parameter_omit_connection_id);
+            byte_index += 2;
+            picoformat_16(bytes + byte_index, 0);
+            byte_index += 2;
+        }
 
-		picoformat_16(bytes + byte_index, picoquic_transport_parameter_max_packet_size);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, 2);
-		byte_index += 2;
-		picoformat_16(bytes + byte_index, (uint16_t) cnx->local_parameters.max_packet_size);
-		byte_index += 2;
+        picoformat_16(bytes + byte_index, picoquic_transport_parameter_max_packet_size);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, 2);
+        byte_index += 2;
+        picoformat_16(bytes + byte_index, (uint16_t)cnx->local_parameters.max_packet_size);
+        byte_index += 2;
 
-		if (extension_mode == 1)
-		{
-			picoformat_16(bytes + byte_index, picoquic_transport_parameter_reset_secret);
-			byte_index += 2;
-			picoformat_16(bytes + byte_index, PICOQUIC_RESET_SECRET_SIZE);
-			byte_index += 2;
-			memcpy(bytes + byte_index, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
-			byte_index += PICOQUIC_RESET_SECRET_SIZE;
-		}
+        if (extension_mode == 1) {
+            picoformat_16(bytes + byte_index, picoquic_transport_parameter_reset_secret);
+            byte_index += 2;
+            picoformat_16(bytes + byte_index, PICOQUIC_RESET_SECRET_SIZE);
+            byte_index += 2;
+            memcpy(bytes + byte_index, cnx->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
+            byte_index += PICOQUIC_RESET_SECRET_SIZE;
+        }
 
-        if (cnx->local_parameters.ack_delay_exponent != 3)
-        {
+        if (cnx->local_parameters.ack_delay_exponent != 3) {
             picoformat_16(bytes + byte_index, picoquic_transport_parameter_ack_delay_exponent);
             byte_index += 2;
             picoformat_16(bytes + byte_index, 1);
@@ -216,8 +201,7 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mo
             bytes[byte_index++] = cnx->local_parameters.ack_delay_exponent;
         }
 
-        if (cnx->local_parameters.initial_max_stream_id_unidir > 0)
-        {
+        if (cnx->local_parameters.initial_max_stream_id_unidir > 0) {
             picoformat_16(bytes + byte_index, picoquic_transport_parameter_initial_max_stream_id_unidir);
             byte_index += 2;
             picoformat_16(bytes + byte_index, 4);
@@ -225,315 +209,227 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t * cnx, int extension_mo
             picoformat_32(bytes + byte_index, cnx->local_parameters.initial_max_stream_id_unidir);
             byte_index += 4;
         }
-	}
-	
-	return ret;
+    }
+
+    return ret;
 }
 
-int picoquic_receive_transport_extensions(picoquic_cnx_t * cnx, int extension_mode,
-	uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
+    uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
-	int ret = 0;
-	size_t byte_index = 0;
+    int ret = 0;
+    size_t byte_index = 0;
     uint32_t present_flag = 0;
 
     cnx->remote_parameters_received = 1;
 
-    switch (extension_mode)
-    {
+    switch (extension_mode) {
     case 0: // Client hello
-        if (bytes_max < 4)
-        {
+        if (bytes_max < 4) {
             ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-        }
-        else
-        {
+        } else {
             uint32_t proposed_version;
 
             proposed_version = PICOPARSE_32(bytes + byte_index);
             byte_index += 4;
 
-            if (picoquic_supported_versions[cnx->version_index].version != proposed_version)
-            {
-                for (size_t i = 0; ret == 0 && i < picoquic_nb_supported_versions; i++)
-                {
-                    if (proposed_version == picoquic_supported_versions[i].version)
-                    {
+            if (picoquic_supported_versions[cnx->version_index].version != proposed_version) {
+                for (size_t i = 0; ret == 0 && i < picoquic_nb_supported_versions; i++) {
+                    if (proposed_version == picoquic_supported_versions[i].version) {
                         ret = PICOQUIC_ERROR_VERSION_NEGOTIATION_SPOOFED;
                         break;
                     }
                 }
             }
         }
-		break;
-	case 1: // Server encrypted extension
-	{
-		if (bytes_max < 1)
-		{
-			ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-		}
-		else
-		{
-            if (bytes_max < byte_index + 4)
-            {
+        break;
+    case 1: // Server encrypted extension
+    {
+        if (bytes_max < 1) {
+            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+        } else {
+            if (bytes_max < byte_index + 4) {
                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-            }
-            else
-            {
+            } else {
                 uint32_t version;
 
                 version = PICOPARSE_32(bytes + byte_index);
                 byte_index += 4;
 
-                if (version != picoquic_supported_versions[cnx->version_index].version)
-                {
+                if (version != picoquic_supported_versions[cnx->version_index].version) {
                     ret = PICOQUIC_ERROR_VERSION_NEGOTIATION_SPOOFED;
                 }
             }
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 size_t supported_versions_size = bytes[byte_index++];
 
-                if ((supported_versions_size & 3) != 0 ||
-                    supported_versions_size > 252 ||
-                    byte_index + supported_versions_size > bytes_max)
-                {
+                if ((supported_versions_size & 3) != 0 || supported_versions_size > 252 || byte_index + supported_versions_size > bytes_max) {
                     ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-                }
-                else if (cnx->proposed_version ==
-                    picoquic_supported_versions[cnx->version_index].version)
-                {
+                } else if (cnx->proposed_version == picoquic_supported_versions[cnx->version_index].version) {
                     byte_index += supported_versions_size;
-                }
-                else
-                {
+                } else {
                     size_t nb_supported_versions = supported_versions_size / 4;
 
-                    for (size_t i = 0; ret == 0 && i < nb_supported_versions; i++)
-                    {
+                    for (size_t i = 0; ret == 0 && i < nb_supported_versions; i++) {
                         uint32_t supported_version = PICOPARSE_32(bytes + byte_index);
                         byte_index += 4;
-                        if (supported_version == cnx->proposed_version)
-                        {
+                        if (supported_version == cnx->proposed_version) {
                             ret = PICOQUIC_ERROR_VERSION_NEGOTIATION_SPOOFED;
                         }
                     }
                 }
             }
-		}
-		break;
-	}
-	default: // New session ticket
-		break;
-	}
+        }
+        break;
+    }
+    default: // New session ticket
+        break;
+    }
 
-	if (ret == 0 && byte_index + 2 > bytes_max)
-	{
-		ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-	}
-	else
-	{
-		uint16_t extensions_size = PICOPARSE_16(bytes + byte_index);
-		size_t extensions_end; 
-		byte_index += 2;
-		extensions_end = byte_index + extensions_size;
+    if (ret == 0 && byte_index + 2 > bytes_max) {
+        ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+    } else {
+        uint16_t extensions_size = PICOPARSE_16(bytes + byte_index);
+        size_t extensions_end;
+        byte_index += 2;
+        extensions_end = byte_index + extensions_size;
 
         /* Set the parameters to default value zero */
         memset(&cnx->remote_parameters, 0, sizeof(picoquic_transport_parameters));
         /* Except for ack_delay_exponent, whose default is 3 */
         cnx->remote_parameters.ack_delay_exponent = 3;
 
-		if (extensions_end > bytes_max)
-		{
-			ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-		}
-		else while (ret == 0 && byte_index < extensions_end)
-		{
-			if (byte_index + 4 > extensions_end)
-			{
-				ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-			}
-			else
-			{
-				uint16_t extension_type = PICOPARSE_16(bytes + byte_index);
-				uint16_t extension_length = PICOPARSE_16(bytes + byte_index + 2);
-				byte_index += 4;
+        if (extensions_end > bytes_max) {
+            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+        } else
+            while (ret == 0 && byte_index < extensions_end) {
+                if (byte_index + 4 > extensions_end) {
+                    ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                } else {
+                    uint16_t extension_type = PICOPARSE_16(bytes + byte_index);
+                    uint16_t extension_length = PICOPARSE_16(bytes + byte_index + 2);
+                    byte_index += 4;
 
-				if (byte_index + extension_length > extensions_end)
-				{
-					ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-				}
-				else
-				{
-                    if (extension_type < 64)
-                    {
-                        if ((present_flag & (1 << extension_type)) != 0)
-                        {
-                            /* Malformed, already present */
-                            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                    if (byte_index + extension_length > extensions_end) {
+                        ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                    } else {
+                        if (extension_type < 64) {
+                            if ((present_flag & (1 << extension_type)) != 0) {
+                                /* Malformed, already present */
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                present_flag |= (1 << extension_type);
+                            }
                         }
-                        else
-                        {
-                            present_flag |= (1 << extension_type);
-                        }
-                    }
 
-					switch (extension_type)
-					{
-					case picoquic_transport_parameter_initial_max_stream_data:
-						if (extension_length != 4)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							cnx->remote_parameters.initial_max_stream_data = PICOPARSE_32(bytes + byte_index);
-						}
-                        /* If we sent zero rtt data, the streams were created with the
+                        switch (extension_type) {
+                        case picoquic_transport_parameter_initial_max_stream_data:
+                            if (extension_length != 4) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->remote_parameters.initial_max_stream_data = PICOPARSE_32(bytes + byte_index);
+                            }
+                            /* If we sent zero rtt data, the streams were created with the
                          * old value of the remote parameter. We need to update that.
                          */
-                        picoquic_update_stream_initial_remote(cnx);
-						break;
-					case picoquic_transport_parameter_initial_max_data:
-						if (extension_length != 4)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							cnx->remote_parameters.initial_max_data = PICOPARSE_32(bytes + byte_index);
-                            cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
-							cnx->max_stream_id_bidir_remote = cnx->local_parameters.initial_max_stream_id_bidir;
-						}
-						break;
-					case picoquic_transport_parameter_initial_max_stream_id_bidir:
-						if (extension_length != 4)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							cnx->remote_parameters.initial_max_stream_id_bidir = PICOPARSE_32(bytes + byte_index);
-                            cnx->max_stream_id_bidir_remote = cnx->remote_parameters.initial_max_stream_id_bidir;
-                            
-                            if (cnx->remote_parameters.initial_max_stream_id_bidir != 0 &&
-                                (((extension_mode == 0) && (cnx->remote_parameters.initial_max_stream_id_bidir & 1) == 0) ||
-                                ((extension_mode == 1) && (cnx->remote_parameters.initial_max_stream_id_bidir & 1) != 0) ||
-                                    ((cnx->remote_parameters.initial_max_stream_id_bidir & 2) != 0)))
-                            {
+                            picoquic_update_stream_initial_remote(cnx);
+                            break;
+                        case picoquic_transport_parameter_initial_max_data:
+                            if (extension_length != 4) {
                                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->remote_parameters.initial_max_data = PICOPARSE_32(bytes + byte_index);
+                                cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
+                                cnx->max_stream_id_bidir_remote = cnx->local_parameters.initial_max_stream_id_bidir;
                             }
-						}
-						break;
-					case picoquic_transport_parameter_idle_timeout:
-						if (extension_length != 2)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							cnx->remote_parameters.idle_timeout = PICOPARSE_16(bytes + byte_index);
-						}
-						break;
-					case picoquic_transport_parameter_omit_connection_id:
-						if (extension_length != 0)
-						{
-                            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							if ((cnx->quic->flags & picoquic_context_unconditional_cnx_id) == 0)
-								cnx->remote_parameters.omit_connection_id = 1;
-						}
-						break;
-					case picoquic_transport_parameter_max_packet_size:
-						if (extension_length != 2)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							cnx->remote_parameters.max_packet_size = PICOPARSE_16(bytes + byte_index);
-						}
-						break;
-					case picoquic_transport_parameter_reset_secret:
-						if (extension_mode != 1)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else if (extension_length != PICOQUIC_RESET_SECRET_SIZE)
-						{
-							ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-						}
-						else
-						{
-							memcpy(cnx->reset_secret, bytes + byte_index, PICOQUIC_RESET_SECRET_SIZE);
-						}
-						break;
-                    case picoquic_transport_parameter_ack_delay_exponent:
-                        if (extension_length != 1)
-                        {
-                            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-                        }
-                        else
-                        {
-                            cnx->local_parameters.ack_delay_exponent = bytes[byte_index];
-                        }
-                        break;
-                    case picoquic_transport_parameter_initial_max_stream_id_unidir:
-                        if (extension_length != 4)
-                        {
-                            ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-                        }
-                        else
-                        {
-                            cnx->remote_parameters.initial_max_stream_id_unidir = PICOPARSE_32(bytes + byte_index);
-                            cnx->max_stream_id_unidir_remote = cnx->remote_parameters.initial_max_stream_id_unidir;
-                            
-                            if (cnx->remote_parameters.initial_max_stream_id_unidir != 0 &&
-                                (((extension_mode == 0) && (cnx->remote_parameters.initial_max_stream_id_unidir & 1) == 0) ||
-                                ((extension_mode == 1) && (cnx->remote_parameters.initial_max_stream_id_unidir & 1) != 0) ||
-                                    ((cnx->remote_parameters.initial_max_stream_id_unidir & 2) == 0)))
-                            {
+                            break;
+                        case picoquic_transport_parameter_initial_max_stream_id_bidir:
+                            if (extension_length != 4) {
                                 ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
-                            }
-                        }
-                        break;
-					default:
-						/* ignore unknown extensions */				
-						break;
-					}
+                            } else {
+                                cnx->remote_parameters.initial_max_stream_id_bidir = PICOPARSE_32(bytes + byte_index);
+                                cnx->max_stream_id_bidir_remote = cnx->remote_parameters.initial_max_stream_id_bidir;
 
-					if (ret == 0)
-					{
-						byte_index += extension_length;
-					}
-				}
-			}
-		}
-	}
+                                if (cnx->remote_parameters.initial_max_stream_id_bidir != 0 && (((extension_mode == 0) && (cnx->remote_parameters.initial_max_stream_id_bidir & 1) == 0) || ((extension_mode == 1) && (cnx->remote_parameters.initial_max_stream_id_bidir & 1) != 0) || ((cnx->remote_parameters.initial_max_stream_id_bidir & 2) != 0))) {
+                                    ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                                }
+                            }
+                            break;
+                        case picoquic_transport_parameter_idle_timeout:
+                            if (extension_length != 2) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->remote_parameters.idle_timeout = PICOPARSE_16(bytes + byte_index);
+                            }
+                            break;
+                        case picoquic_transport_parameter_omit_connection_id:
+                            if (extension_length != 0) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                if ((cnx->quic->flags & picoquic_context_unconditional_cnx_id) == 0)
+                                    cnx->remote_parameters.omit_connection_id = 1;
+                            }
+                            break;
+                        case picoquic_transport_parameter_max_packet_size:
+                            if (extension_length != 2) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->remote_parameters.max_packet_size = PICOPARSE_16(bytes + byte_index);
+                            }
+                            break;
+                        case picoquic_transport_parameter_reset_secret:
+                            if (extension_mode != 1) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else if (extension_length != PICOQUIC_RESET_SECRET_SIZE) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                memcpy(cnx->reset_secret, bytes + byte_index, PICOQUIC_RESET_SECRET_SIZE);
+                            }
+                            break;
+                        case picoquic_transport_parameter_ack_delay_exponent:
+                            if (extension_length != 1) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->local_parameters.ack_delay_exponent = bytes[byte_index];
+                            }
+                            break;
+                        case picoquic_transport_parameter_initial_max_stream_id_unidir:
+                            if (extension_length != 4) {
+                                ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                            } else {
+                                cnx->remote_parameters.initial_max_stream_id_unidir = PICOPARSE_32(bytes + byte_index);
+                                cnx->max_stream_id_unidir_remote = cnx->remote_parameters.initial_max_stream_id_unidir;
+
+                                if (cnx->remote_parameters.initial_max_stream_id_unidir != 0 && (((extension_mode == 0) && (cnx->remote_parameters.initial_max_stream_id_unidir & 1) == 0) || ((extension_mode == 1) && (cnx->remote_parameters.initial_max_stream_id_unidir & 1) != 0) || ((cnx->remote_parameters.initial_max_stream_id_unidir & 2) == 0))) {
+                                    ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
+                                }
+                            }
+                            break;
+                        default:
+                            /* ignore unknown extensions */
+                            break;
+                        }
+
+                        if (ret == 0) {
+                            byte_index += extension_length;
+                        }
+                    }
+                }
+            }
+    }
 
     /* TODO: check that all required parameters are present, and
      * set default values for optional parameters */
 
-    if (ret == 0 &&
-        (present_flag & ((1<<picoquic_transport_parameter_initial_max_stream_data) |
-            (1<<picoquic_transport_parameter_initial_max_data) |
-            (1<<picoquic_transport_parameter_idle_timeout)))
-        != ((1 << picoquic_transport_parameter_initial_max_stream_data) |
-            (1 << picoquic_transport_parameter_initial_max_data) |
-            (1 << picoquic_transport_parameter_idle_timeout)))
-    {
+    if (ret == 0 && (present_flag & ((1 << picoquic_transport_parameter_initial_max_stream_data) | (1 << picoquic_transport_parameter_initial_max_data) | (1 << picoquic_transport_parameter_idle_timeout))) != ((1 << picoquic_transport_parameter_initial_max_stream_data) | (1 << picoquic_transport_parameter_initial_max_data) | (1 << picoquic_transport_parameter_idle_timeout))) {
         ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
     }
-    if (ret == 0 && extension_mode == 1 &&
-        (present_flag & (1 << picoquic_transport_parameter_reset_secret)) == 0)
-    {
+    if (ret == 0 && extension_mode == 1 && (present_flag & (1 << picoquic_transport_parameter_reset_secret)) == 0) {
         ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_TRANSPORT_PARAMETER_ERROR);
     }
 
-	*consumed = byte_index;
+    *consumed = byte_index;
 
-	return ret;
+    return ret;
 }

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -21,52 +21,46 @@
 
 /* Simple set of utilities */
 
+#include "picoquic_internal.h"
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
-#include "picoquic_internal.h"
 
-char * picoquic_string_create(const char * original, size_t len)
+char* picoquic_string_create(const char* original, size_t len)
 {
-	char * str = (char *)malloc(len + 1);
+    char* str = (char*)malloc(len + 1);
 
-	if (str != NULL)
-	{
-		if (original == NULL || len == 0)
-		{
-			str[0] = 0;
-		}
-		else
-		{
-			memcpy(str, original, len);
-			str[len] = 0;
-		}
-	}
+    if (str != NULL) {
+        if (original == NULL || len == 0) {
+            str[0] = 0;
+        } else {
+            memcpy(str, original, len);
+            str[len] = 0;
+        }
+    }
 
-	return str;
+    return str;
 }
 
-char * picoquic_string_duplicate(const char * original)
+char* picoquic_string_duplicate(const char* original)
 {
-	char * str = NULL;
+    char* str = NULL;
 
-	if (original != NULL)
-	{
-		size_t len = strlen(original);
+    if (original != NULL) {
+        size_t len = strlen(original);
 
-		str = picoquic_string_create(original, len);
-	}
+        str = picoquic_string_create(original, len);
+    }
 
-	return str;
+    return str;
 }
 
-static FILE *debug_out;
+static FILE* debug_out;
 static int debug_suspended = 0;
 
-void debug_printf(const char *fmt, ...)
+void debug_printf(const char* fmt, ...)
 {
-    if (debug_suspended == 0)
-    {
+    if (debug_suspended == 0) {
         va_list args;
         va_start(args, fmt);
         vfprintf(debug_out ? debug_out : stderr, fmt, args);
@@ -74,24 +68,22 @@ void debug_printf(const char *fmt, ...)
     }
 }
 
-void debug_printf_push_stream(FILE *f)
+void debug_printf_push_stream(FILE* f)
 {
-	if (debug_out)
-	{
-		fprintf(stderr, "Nested err out not supported\n");
-		exit(1);
-	}
-	debug_out = f;
+    if (debug_out) {
+        fprintf(stderr, "Nested err out not supported\n");
+        exit(1);
+    }
+    debug_out = f;
 }
 
 void debug_printf_pop_stream(void)
 {
-	if (debug_out == NULL)
-	{
-		fprintf(stderr, "No current err out\n");
-		exit(1);
-	}
-	debug_out = NULL;
+    if (debug_out == NULL) {
+        fprintf(stderr, "No current err out\n");
+        exit(1);
+    }
+    debug_out = NULL;
 }
 
 void debug_printf_suspend(void)

--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -25,35 +25,38 @@
 #include <stdio.h>
 
 #ifdef WIN32
-# define PRIst "Iu"
+#define PRIst "Iu"
 #ifndef PRIu64
-# define PRIu64 "I64u"
+#define PRIu64 "I64u"
 #endif
 #ifndef PRIx64
-# define PRIx64 "I64x"
+#define PRIx64 "I64x"
 #endif
 #else
-# include <inttypes.h>
-# define PRIst "zu"
+#include <inttypes.h>
+#define PRIst "zu"
 #endif
 
-void debug_printf(const char *fmt, ...);
-void debug_printf_push_stream(FILE *f);
+void debug_printf(const char* fmt, ...);
+void debug_printf_push_stream(FILE* f);
 void debug_printf_pop_stream(void);
 void debug_printf_suspend(void);
 void debug_printf_resume(void);
 
 #ifndef MIN
-# define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #define DBG_PRINTF_FILENAME_MAX 24
-#define DBG_PRINTF(fmt, ...) \
-    debug_printf("%s:%u [%s]: " fmt "\n", \
+#define DBG_PRINTF(fmt, ...)                                                                 \
+    debug_printf("%s:%u [%s]: " fmt "\n",                                                    \
         __FILE__ + MAX(DBG_PRINTF_FILENAME_MAX, sizeof(__FILE__)) - DBG_PRINTF_FILENAME_MAX, \
         __LINE__, __FUNCTION__, __VA_ARGS__)
 
-#define DBG_FATAL_PRINTF(fmt, ...) \
-  do { DBG_PRINTF("(FATAL) " fmt "\n", __VA_ARGS__); exit(1); } while(0)
+#define DBG_FATAL_PRINTF(fmt, ...)                    \
+    do {                                              \
+        DBG_PRINTF("(FATAL) " fmt "\n", __VA_ARGS__); \
+        exit(1);                                      \
+    } while (0)
 
 #endif

--- a/picoquic/wincompat.h
+++ b/picoquic/wincompat.h
@@ -29,20 +29,16 @@
 #ifndef gettimeofday
 #define gettimeofday wintimeofday
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
-    int wintimeofday(struct timeval* tv, struct timezone* tz);
+int wintimeofday(struct timeval* tv, struct timezone* tz);
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 } /* extern "C" */
 #endif
 
-
-
-
 #endif
-
 
 #endif /* WINCOMPAT_H */

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -19,15 +19,15 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdio.h>
-#include <string.h>
 #include "../picoquic/picoquic.h"
 #include "../picoquic/util.h"
 #include "../picoquictest/picoquictest.h"
+#include <stdio.h>
+#include <string.h>
 
 typedef struct st_picoquic_test_def_t {
-    char const * test_name;
-    int(*test_fn)();
+    char const* test_name;
+    int (*test_fn)();
 } picoquic_test_def_t;
 
 static picoquic_test_def_t test_table[] = {
@@ -35,8 +35,8 @@ static picoquic_test_def_t test_table[] = {
     { "cnxcreation", cnxcreation_test },
     { "parseheader", parseheadertest },
     { "pn2pn64", pn2pn64test },
-    { "intformat", intformattest},
-    { "fnv1a", fnv1atest},
+    { "intformat", intformattest },
+    { "fnv1a", fnv1atest },
     { "float16", float16test },
     { "varint", varint_test },
     { "skip_frames", skip_frame_test },
@@ -49,7 +49,7 @@ static picoquic_test_def_t test_table[] = {
     { "logger", logger_test },
     { "tls_api", tls_api_test },
     { "silence_test", tls_api_silence_test },
-    { "tls_api_version_negotiation", tls_api_version_negotiation_test},
+    { "tls_api_version_negotiation", tls_api_version_negotiation_test },
     { "first_loss", tls_api_client_first_loss_test },
     { "second_loss", tls_api_client_second_loss_test },
     { "client_losses", tls_api_client_losses_test },
@@ -76,7 +76,7 @@ static picoquic_test_def_t test_table[] = {
     { "transport_parameter_client_error", transport_parameter_client_error_test },
     { "sockets", socket_test },
     { "ticket_store", ticket_store_test },
-    { "session_resume", session_resume_test},
+    { "session_resume", session_resume_test },
     { "zero_rtt", zero_rtt_test },
     { "stop_sending", stop_sending_test },
     { "unidir", unidir_test },
@@ -87,28 +87,22 @@ static picoquic_test_def_t test_table[] = {
 
 static size_t nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);
 
-static int do_one_test(size_t i, FILE * F)
+static int do_one_test(size_t i, FILE* F)
 {
     int ret = 0;
 
-    if (i >= nb_tests)
-    {
+    if (i >= nb_tests) {
         fprintf(F, "Invalid test number %" PRIst "\n", i);
         ret = -1;
-    }
-    else
-    {
+    } else {
         fprintf(F, "Starting test number %" PRIst ", %s\n", i, test_table[i].test_name);
 
         fflush(F);
-       
+
         ret = test_table[i].test_fn();
-        if (ret == 0)
-        {
+        if (ret == 0) {
             fprintf(F, "    Success.\n");
-        }
-        else
-        {
+        } else {
             fprintf(F, "    Fails, error: %d.\n", ret);
         }
     }
@@ -118,39 +112,30 @@ static int do_one_test(size_t i, FILE * F)
     return ret;
 }
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
     int ret = 0;
     int arg_err = 0;
     int nb_test_tried = 0;
     int nb_test_failed = 0;
 
-    if (argc <= 1)
-    {
-        for (size_t i = 0; i < nb_tests; i++)
-        {
+    if (argc <= 1) {
+        for (size_t i = 0; i < nb_tests; i++) {
             nb_test_tried++;
-            if (do_one_test(i, stdout) != 0)
-            {
+            if (do_one_test(i, stdout) != 0) {
                 nb_test_failed++;
                 ret = -1;
             }
         }
-    }
-    else
-    {
-        for (int arg_num = 1; arg_num < argc; arg_num++)
-        {
+    } else {
+        for (int arg_num = 1; arg_num < argc; arg_num++) {
             int tried = 0;
 
-            for (size_t i = 0; i < nb_tests; i++)
-            {
-                if (strcmp(argv[arg_num], test_table[i].test_name) == 0)
-                {
+            for (size_t i = 0; i < nb_tests; i++) {
+                if (strcmp(argv[arg_num], test_table[i].test_name) == 0) {
                     tried = 1;
                     nb_test_tried++;
-                    if (do_one_test(i, stdout) != 0)
-                    {
+                    if (do_one_test(i, stdout) != 0) {
                         nb_test_failed++;
                         ret = -1;
                     }
@@ -158,8 +143,7 @@ int main(int argc, char ** argv)
                 }
             }
 
-            if (tried == 0)
-            {
+            if (tried == 0) {
                 fprintf(stderr, "Incorrect test name: %s\n", argv[arg_num]);
                 arg_err++;
                 ret = -1;
@@ -168,22 +152,18 @@ int main(int argc, char ** argv)
         }
     }
 
-    if (nb_test_tried > 1)
-    {
+    if (nb_test_tried > 1) {
         fprintf(stdout, "Tried %d tests, %d fail%s.\n", nb_test_tried,
             nb_test_failed, (nb_test_failed > 1) ? "" : "s");
     }
 
-    if (arg_err != 0)
-    {
+    if (arg_err != 0) {
         fprintf(stderr, "\nUsage: %s [test1 [test2 ..[testN]]]\n\n", argv[0]);
         fprintf(stderr, "Valid test names are: \n");
-        for (size_t x = 0; x < nb_tests; x++)
-        {
+        for (size_t x = 0; x < nb_tests; x++) {
             fprintf(stderr, "    ");
 
-            for (int j = 0; j < 4 && x < nb_tests; j++, x++)
-            {
+            for (int j = 0; j < 4 && x < nb_tests; j++, x++) {
                 fprintf(stderr, "%s, ", test_table[x].test_name);
             }
             fprintf(stderr, "\n");

--- a/picoquicfirst/getopt.c
+++ b/picoquicfirst/getopt.c
@@ -33,74 +33,71 @@
 * SUCH DAMAGE.
 */
 
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
-int     opterr = 1,             /* if error message should be printed */
-        optind = 1,             /* index into parent argv vector */
-        optopt,                 /* character checked for validity */
-        optreset;               /* reset getopt */
-const char *optarg;                /* argument associated with option */
+int opterr = 1, /* if error message should be printed */
+    optind = 1, /* index into parent argv vector */
+    optopt, /* character checked for validity */
+    optreset; /* reset getopt */
+const char* optarg; /* argument associated with option */
 
-#define BADCH   (int)'?'
-#define BADARG  (int)':'
-#define EMSG    ""
+#define BADCH (int)'?'
+#define BADARG (int)':'
+#define EMSG ""
 
 /*
  * getopt --
  *      Parse argc/argv argument vector.
  */
-int getopt(int nargc, char * const nargv[], const char *ostr)
+int getopt(int nargc, char* const nargv[], const char* ostr)
 {
-  static const char *place = EMSG;        /* option letter processing */
-  const        char *oli;                 /* option letter list index */
+    static const char* place = EMSG; /* option letter processing */
+    const char* oli; /* option letter list index */
 
-  if (optreset || !*place) {              /* update scanning pointer */
-    optreset = 0;
-    if (optind >= nargc || *(place = nargv[optind]) != '-') {
-      place = EMSG;
-      return (-1);
-    }
-    if (place[1] && *++place == '-') {      /* found "--" */
-      ++optind;
-      place = EMSG;
-      return (-1);
-    }
-  }                                       /* option letter okay? */
-  if ((optopt = (int)*place++) == (int)':' ||
-    !(oli = strchr(ostr, optopt))) {
-      /*
+    if (optreset || !*place) { /* update scanning pointer */
+        optreset = 0;
+        if (optind >= nargc || *(place = nargv[optind]) != '-') {
+            place = EMSG;
+            return (-1);
+        }
+        if (place[1] && *++place == '-') { /* found "--" */
+            ++optind;
+            place = EMSG;
+            return (-1);
+        }
+    } /* option letter okay? */
+    if ((optopt = (int)*place++) == (int)':' || !(oli = strchr(ostr, optopt))) {
+        /*
       * if the user didn't specify '-' as an option,
       * assume it means -1.
       */
-      if (optopt == (int)'-')
-        return (-1);
-      if (!*place)
-        ++optind;
-      if (opterr && *ostr != ':')
-        (void)printf("illegal option -- %c\n", optopt);
-      return (BADCH);
-  }
-  if (*++oli != ':') {                    /* don't need argument */
-    optarg = NULL;
-    if (!*place)
-      ++optind;
-  }
-  else {                                  /* need an argument */
-    if (*place)                     /* no white space */
-      optarg = place;
-    else if (nargc <= ++optind) {   /* no arg */
-      place = EMSG;
-      if (*ostr == ':')
-        return (BADARG);
-      if (opterr)
-        (void)printf("option requires an argument -- %c\n", optopt);
-      return (BADCH);
+        if (optopt == (int)'-')
+            return (-1);
+        if (!*place)
+            ++optind;
+        if (opterr && *ostr != ':')
+            (void)printf("illegal option -- %c\n", optopt);
+        return (BADCH);
     }
-    else                            /* white space */
-      optarg = nargv[optind];
-    place = EMSG;
-    ++optind;
-  }
-  return (optopt);                        /* dump back option letter */
+    if (*++oli != ':') { /* don't need argument */
+        optarg = NULL;
+        if (!*place)
+            ++optind;
+    } else { /* need an argument */
+        if (*place) /* no white space */
+            optarg = place;
+        else if (nargc <= ++optind) { /* no arg */
+            place = EMSG;
+            if (*ostr == ':')
+                return (BADARG);
+            if (opterr)
+                (void)printf("option requires an argument -- %c\n", optopt);
+            return (BADCH);
+        } else /* white space */
+            optarg = nargv[optind];
+        place = EMSG;
+        ++optind;
+    }
+    return (optopt); /* dump back option letter */
 }

--- a/picoquicfirst/getopt.h
+++ b/picoquicfirst/getopt.h
@@ -7,13 +7,13 @@
 #define _GETOPT_H
 #endif
 
-extern int opterr;    /* if error message should be printed */
-extern int optind;    /* index into parent argv vector */
-extern int optopt;    /* character checked for validity */
-extern int optreset;  /* reset getopt  */
-extern const char *optarg;  /* argument associated with option */
+extern int opterr; /* if error message should be printed */
+extern int optind; /* index into parent argv vector */
+extern int optopt; /* character checked for validity */
+extern int optreset; /* reset getopt  */
+extern const char* optarg; /* argument associated with option */
 
-int getopt(int nargc, char * const nargv[], const char *ostr);
+int getopt(int nargc, char* const nargv[], const char* ostr);
 
 #endif
 #endif

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -21,17 +21,17 @@
 
 #ifdef _WINDOWS
 #define WIN32_LEAN_AND_MEAN
+#include "getopt.h"
+#include <WinSock2.h>
 #include <Windows.h>
 #include <assert.h>
-#include <stdint.h>
-#include <stdlib.h>
-#include <stdio.h>
-#include <WinSock2.h>
 #include <iphlpapi.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <ws2tcpip.h>
-#include "getopt.h"
 
-#ifndef SOCKET_TYPE 
+#ifndef SOCKET_TYPE
 #define SOCKET_TYPE SOCKET
 #endif
 #ifndef SOCKET_CLOSE
@@ -44,30 +44,30 @@
 #define WSA_START(x, y) WSAStartup((x), (y))
 #endif
 #ifndef WSA_LAST_ERROR
-#define WSA_LAST_ERROR(x)  WSAGetLastError()
+#define WSA_LAST_ERROR(x) WSAGetLastError()
 #endif
 #ifndef socklen_t
 #define socklen_t int
-#endif 
-
-#ifdef _WINDOWS64
-static const char *default_server_cert_file = "..\\..\\certs\\cert.pem";
-static const char *default_server_key_file  = "..\\..\\certs\\key.pem";
-#else
-static const char *default_server_cert_file = "..\\certs\\cert.pem";
-static const char *default_server_key_file = "..\\certs\\key.pem";
 #endif
 
-#else  /* Linux */
+#ifdef _WINDOWS64
+static const char* default_server_cert_file = "..\\..\\certs\\cert.pem";
+static const char* default_server_key_file = "..\\..\\certs\\key.pem";
+#else
+static const char* default_server_cert_file = "..\\certs\\cert.pem";
+static const char* default_server_key_file = "..\\certs\\key.pem";
+#endif
 
-#include <stdint.h>
-#include <stdlib.h>
+#else /* Linux */
+
 #include <alloca.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 
 #ifndef __USE_XOPEN2K
 #define __USE_XOPEN2K
@@ -75,16 +75,16 @@ static const char *default_server_key_file = "..\\certs\\key.pem";
 #ifndef __USE_POSIX
 #define __USE_POSIX
 #endif
+#include <arpa/inet.h>
+#include <errno.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <arpa/inet.h>
 #include <sys/select.h>
-#include <errno.h>
 
-#ifndef SOCKET_TYPE 
+#ifndef SOCKET_TYPE
 #define SOCKET_TYPE int
 #endif
-#ifndef INVALID_SOCKET 
+#ifndef INVALID_SOCKET
 #define INVALID_SOCKET -1
 #endif
 #ifndef SOCKET_CLOSE
@@ -94,70 +94,58 @@ static const char *default_server_key_file = "..\\certs\\key.pem";
 #define WSA_LAST_ERROR(x) ((long)(x))
 #endif
 
-static const char *default_server_cert_file = "certs/cert.pem";
-static const char *default_server_key_file  = "certs/key.pem";
+static const char* default_server_cert_file = "certs/cert.pem";
+static const char* default_server_key_file = "certs/key.pem";
 
 #endif
 
-static const int   default_server_port = 4443;
-static const char *default_server_name = "::";
-static const char *ticket_store_filename = "demo_ticket_store.bin";
+static const int default_server_port = 4443;
+static const char* default_server_name = "::";
+static const char* ticket_store_filename = "demo_ticket_store.bin";
 
 #include "../picoquic/picoquic.h"
 #include "../picoquic/picoquic_internal.h"
-#include "../picoquic/util.h"
 #include "../picoquic/picosocks.h"
+#include "../picoquic/util.h"
 
+void picoquic_log_error_packet(FILE* F, uint8_t* bytes, size_t bytes_max, int ret);
 
-void picoquic_log_error_packet(FILE * F, uint8_t * bytes, size_t bytes_max, int ret);
-
-void picoquic_log_packet(FILE* F, picoquic_quic_t * quic, picoquic_cnx_t * cnx,
-	struct sockaddr * addr_peer, int receiving,
-	uint8_t * bytes, size_t length, uint64_t current_time);
-void picoquic_log_processing(FILE* F, picoquic_cnx_t * cnx, size_t length, int ret);
-void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t * cnx, int log_cnxid);
-void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t * cnx, uint64_t current_time);
+void picoquic_log_packet(FILE* F, picoquic_quic_t* quic, picoquic_cnx_t* cnx,
+    struct sockaddr* addr_peer, int receiving,
+    uint8_t* bytes, size_t length, uint64_t current_time);
+void picoquic_log_processing(FILE* F, picoquic_cnx_t* cnx, size_t length, int ret);
+void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int log_cnxid);
+void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time);
 void picoquic_log_picotls_ticket(FILE* F, uint64_t cnx_id,
-    uint8_t * ticket, uint16_t ticket_length);
+    uint8_t* ticket, uint16_t ticket_length);
 
-void print_address(struct sockaddr * address, char * label, uint64_t cnx_id)
+void print_address(struct sockaddr* address, char* label, uint64_t cnx_id)
 {
     char hostname[256];
 
-    const char * x = inet_ntop(address->sa_family, 
-        (address->sa_family == AF_INET)?
-        (void *)&(((struct sockaddr_in *)address)->sin_addr):
-        (void *)&(((struct sockaddr_in6 *)address)->sin6_addr),
+    const char* x = inet_ntop(address->sa_family,
+        (address->sa_family == AF_INET) ? (void*)&(((struct sockaddr_in*)address)->sin_addr) : (void*)&(((struct sockaddr_in6*)address)->sin6_addr),
         hostname, sizeof(hostname));
 
     printf("%" PRIx64 ": ", cnx_id);
 
-    if (x != NULL)
-    {
+    if (x != NULL) {
         printf("%s %s, port %d\n", label, x,
-            (address->sa_family == AF_INET) ?
-            ((struct sockaddr_in *) address)->sin_port :
-            ((struct sockaddr_in6 *) address)->sin6_port);
-    }
-    else
-    {
+            (address->sa_family == AF_INET) ? ((struct sockaddr_in*)address)->sin_port : ((struct sockaddr_in6*)address)->sin6_port);
+    } else {
         printf("%s: inet_ntop failed with error # %ld\n", label, WSA_LAST_ERROR(errno));
     }
 }
 
-static char * strip_endofline(char * buf, size_t bufmax, char const * line)
+static char* strip_endofline(char* buf, size_t bufmax, char const* line)
 {
-    for (size_t i = 0; i < bufmax; i++)
-    {
+    for (size_t i = 0; i < bufmax; i++) {
         int c = line[i];
 
-        if (c == 0 || c == '\r' || c == '\n')
-        {
+        if (c == 0 || c == '\r' || c == '\n') {
             buf[i] = 0;
             break;
-        }
-        else
-        {
+        } else {
             buf[i] = c;
         }
     }
@@ -167,17 +155,16 @@ static char * strip_endofline(char * buf, size_t bufmax, char const * line)
 }
 
 #define PICOQUIC_FIRST_COMMAND_MAX 128
-#define PICOQUIC_FIRST_RESPONSE_MAX (1<<20)
+#define PICOQUIC_FIRST_RESPONSE_MAX (1 << 20)
 
-typedef enum
-{
+typedef enum {
     picoquic_first_server_stream_status_none = 0,
     picoquic_first_server_stream_status_receiving,
     picoquic_first_server_stream_status_finished
 } picoquic_first_server_stream_status_t;
 
 typedef struct st_picoquic_first_server_stream_ctx_t {
-    struct st_picoquic_first_server_stream_ctx_t * next_stream;
+    struct st_picoquic_first_server_stream_ctx_t* next_stream;
     picoquic_first_server_stream_status_t status;
     uint64_t stream_id;
     size_t command_length;
@@ -186,28 +173,23 @@ typedef struct st_picoquic_first_server_stream_ctx_t {
 } picoquic_first_server_stream_ctx_t;
 
 typedef struct st_picoquic_first_server_callback_ctx_t {
-    picoquic_first_server_stream_ctx_t * first_stream;
+    picoquic_first_server_stream_ctx_t* first_stream;
     size_t buffer_max;
-    uint8_t * buffer;
+    uint8_t* buffer;
 } picoquic_first_server_callback_ctx_t;
 
-static picoquic_first_server_callback_ctx_t * first_server_callback_create_context()
+static picoquic_first_server_callback_ctx_t* first_server_callback_create_context()
 {
-    picoquic_first_server_callback_ctx_t * ctx =
-        (picoquic_first_server_callback_ctx_t*)
+    picoquic_first_server_callback_ctx_t* ctx = (picoquic_first_server_callback_ctx_t*)
         malloc(sizeof(picoquic_first_server_callback_ctx_t));
 
-    if (ctx != NULL)
-    {
+    if (ctx != NULL) {
         ctx->first_stream = NULL;
-        ctx->buffer = (uint8_t *)malloc(PICOQUIC_FIRST_RESPONSE_MAX);
-        if (ctx->buffer == NULL)
-        {
+        ctx->buffer = (uint8_t*)malloc(PICOQUIC_FIRST_RESPONSE_MAX);
+        if (ctx->buffer == NULL) {
             free(ctx);
             ctx = NULL;
-        }
-        else
-        {
+        } else {
             ctx->buffer_max = PICOQUIC_FIRST_RESPONSE_MAX;
         }
     }
@@ -215,12 +197,11 @@ static picoquic_first_server_callback_ctx_t * first_server_callback_create_conte
     return ctx;
 }
 
-static void first_server_callback_delete_context(picoquic_first_server_callback_ctx_t * ctx)
+static void first_server_callback_delete_context(picoquic_first_server_callback_ctx_t* ctx)
 {
-    picoquic_first_server_stream_ctx_t * stream_ctx;
+    picoquic_first_server_stream_ctx_t* stream_ctx;
 
-    while ((stream_ctx = ctx->first_stream) != NULL)
-    {
+    while ((stream_ctx = ctx->first_stream) != NULL) {
         ctx->first_stream = stream_ctx->next_stream;
         free(stream_ctx);
     }
@@ -228,25 +209,21 @@ static void first_server_callback_delete_context(picoquic_first_server_callback_
     free(ctx);
 }
 
-static void first_server_callback(picoquic_cnx_t * cnx,
-    uint64_t stream_id, uint8_t * bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void * callback_ctx)
+static void first_server_callback(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
 {
-    picoquic_first_server_callback_ctx_t * ctx =
-        (picoquic_first_server_callback_ctx_t*)callback_ctx;
-    picoquic_first_server_stream_ctx_t * stream_ctx = NULL;
+    picoquic_first_server_callback_ctx_t* ctx = (picoquic_first_server_callback_ctx_t*)callback_ctx;
+    picoquic_first_server_stream_ctx_t* stream_ctx = NULL;
 
     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
     printf("Server CB, Stream: %" PRIu64 ", %" PRIst " bytes, fin=%d\n",
         stream_id, length, fin_or_event);
 
-    if (fin_or_event == picoquic_callback_close ||
-        fin_or_event == picoquic_callback_application_close)
-    {
+    if (fin_or_event == picoquic_callback_close || fin_or_event == picoquic_callback_application_close) {
         printf("%" PRIx64 ": %s\n", picoquic_get_initial_cnxid(cnx),
-            (fin_or_event == picoquic_callback_close)?"Connection closed":"Application closed");
-        if (ctx != NULL)
-        {
+            (fin_or_event == picoquic_callback_close) ? "Connection closed" : "Application closed");
+        if (ctx != NULL) {
             first_server_callback_delete_context(ctx);
             picoquic_set_callback(cnx, first_server_callback, NULL);
         }
@@ -254,18 +231,13 @@ static void first_server_callback(picoquic_cnx_t * cnx,
         return;
     }
 
-    if (ctx == NULL)
-    {
-        picoquic_first_server_callback_ctx_t * new_ctx =
-            first_server_callback_create_context();
-        if (new_ctx == NULL)
-        {
+    if (ctx == NULL) {
+        picoquic_first_server_callback_ctx_t* new_ctx = first_server_callback_create_context();
+        if (new_ctx == NULL) {
             /* cannot handle the connection */
             picoquic_close(cnx, PICOQUIC_ERROR_MEMORY);
             return;
-        }
-        else
-        {
+        } else {
             picoquic_set_callback(cnx, first_server_callback, new_ctx);
             ctx = new_ctx;
         }
@@ -274,23 +246,18 @@ static void first_server_callback(picoquic_cnx_t * cnx,
     stream_ctx = ctx->first_stream;
 
     /* if stream is already present, check its state. New bytes? */
-    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id)
-    {
+    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id) {
         stream_ctx = stream_ctx->next_stream;
     }
 
-    if (stream_ctx == NULL)
-    {
-        stream_ctx = (picoquic_first_server_stream_ctx_t *)
+    if (stream_ctx == NULL) {
+        stream_ctx = (picoquic_first_server_stream_ctx_t*)
             malloc(sizeof(picoquic_first_server_stream_ctx_t));
-        if (stream_ctx == NULL)
-        {
+        if (stream_ctx == NULL) {
             /* Could not handle this stream */
             picoquic_reset_stream(cnx, stream_id, 0);
             return;
-        }
-        else
-        {
+        } else {
             memset(stream_ctx, 0, sizeof(picoquic_first_server_stream_ctx_t));
             stream_ctx->next_stream = ctx->first_stream;
             ctx->first_stream = stream_ctx;
@@ -299,41 +266,30 @@ static void first_server_callback(picoquic_cnx_t * cnx,
     }
 
     /* verify state and copy data to the stream buffer */
-    if (fin_or_event == picoquic_callback_stop_sending)
-    {
+    if (fin_or_event == picoquic_callback_stop_sending) {
         stream_ctx->status = picoquic_first_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, 0);
         return;
-    }
-    else if (fin_or_event == picoquic_callback_stream_reset)
-    {
+    } else if (fin_or_event == picoquic_callback_stream_reset) {
         stream_ctx->status = picoquic_first_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, 0);
         return;
-    }
-    else if (stream_ctx->status == picoquic_first_server_stream_status_finished ||
-        stream_ctx->command_length + length > (PICOQUIC_FIRST_COMMAND_MAX-1))
-    {
+    } else if (stream_ctx->status == picoquic_first_server_stream_status_finished || stream_ctx->command_length + length > (PICOQUIC_FIRST_COMMAND_MAX - 1)) {
         /* send after fin, or too many bytes => reset! */
         picoquic_reset_stream(cnx, stream_id, 0);
         printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
         printf("Server CB, Stream: %" PRIu64 ", RESET, too long or after FIN\n",
             stream_id);
         return;
-    }
-    else
-    {
+    } else {
         int crlf_present = 0;
 
-        if (length > 0)
-        {
+        if (length > 0) {
             memcpy(&stream_ctx->command[stream_ctx->command_length],
                 bytes, length);
             stream_ctx->command_length += length;
-            for (size_t i = 0; i < length; i++)
-            {
-                if (bytes[i] == '\r' || bytes[i] == '\n')
-                {
+            for (size_t i = 0; i < length; i++) {
+                if (bytes[i] == '\r' || bytes[i] == '\n') {
                     crlf_present = 1;
                     break;
                 }
@@ -341,55 +297,49 @@ static void first_server_callback(picoquic_cnx_t * cnx,
         }
 
         /* if FIN present, process request through http 0.9 */
-        if ((fin_or_event == picoquic_callback_stream_fin ||
-            crlf_present != 0) && stream_ctx->response_length == 0)
-        {
+        if ((fin_or_event == picoquic_callback_stream_fin || crlf_present != 0) && stream_ctx->response_length == 0) {
             char buf[256];
 
             stream_ctx->command[stream_ctx->command_length] = 0;
             /* if data generated, just send it. Otherwise, just FIN the stream. */
             stream_ctx->status = picoquic_first_server_stream_status_finished;
             if (http0dot9_get(stream_ctx->command, stream_ctx->command_length,
-                ctx->buffer, ctx->buffer_max, &stream_ctx->response_length) != 0)
-            {
+                    ctx->buffer, ctx->buffer_max, &stream_ctx->response_length)
+                != 0) {
                 printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 printf("Server CB, Stream: %" PRIu64 ", Resetting after command: %s\n",
-                    stream_id, strip_endofline(buf, sizeof(buf), (char *)&stream_ctx->command));
+                    stream_id, strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command));
                 picoquic_reset_stream(cnx, stream_id, 0);
-            }
-            else
-            {
+            } else {
                 printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
                 printf("Server CB, Stream: %" PRIu64 ", Processing command: %s\n",
-                    stream_id, strip_endofline(buf, sizeof(buf), (char *)&stream_ctx->command));
+                    stream_id, strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command));
                 picoquic_add_to_stream(cnx, stream_id, ctx->buffer,
                     stream_ctx->response_length, 1);
             }
-        }
-        else if (stream_ctx->response_length == 0)
-        {
+        } else if (stream_ctx->response_length == 0) {
             char buf[256];
 
             printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx));
             stream_ctx->command[stream_ctx->command_length] = 0;
             printf("Server CB, Stream: %" PRIu64 ", Partial command: %s\n",
-                stream_id, strip_endofline(buf, sizeof(buf), (char *)&stream_ctx->command));
+                stream_id, strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command));
         }
     }
 
     /* that's it */
 }
 
-int quic_server(const char * server_name, int server_port,
-    const char * pem_cert, const char * pem_key,
+int quic_server(const char* server_name, int server_port,
+    const char* pem_cert, const char* pem_key,
     int just_once, int do_hrr, cnx_id_cb_fn cnx_id_callback,
-    void * cnx_id_callback_ctx, uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE])
+    void* cnx_id_callback_ctx, uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE])
 {
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
-    picoquic_quic_t *qserver = NULL;
-    picoquic_cnx_t *cnx_server = NULL;
-    picoquic_cnx_t *cnx_next = NULL;
+    picoquic_quic_t* qserver = NULL;
+    picoquic_cnx_t* cnx_server = NULL;
+    picoquic_cnx_t* cnx_next = NULL;
     picoquic_server_sockets_t server_sockets;
     struct sockaddr_storage addr_from;
     struct sockaddr_storage addr_to;
@@ -402,45 +352,38 @@ int quic_server(const char * server_name, int server_port,
     uint8_t send_buffer[1536];
     size_t send_length = 0;
     int bytes_recv;
-    picoquic_packet * p = NULL;
+    picoquic_packet* p = NULL;
     uint64_t current_time = 0;
-    picoquic_stateless_packet_t * sp;
+    picoquic_stateless_packet_t* sp;
     int64_t delay_max = 10000000;
 
     /* Open a UDP socket */
     ret = picoquic_open_server_sockets(&server_sockets, server_port);
 
     /* Wait for packets and process them */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         current_time = picoquic_current_time();
         /* Create QUIC context */
         qserver = picoquic_create(8, pem_cert, pem_key, NULL, first_server_callback, NULL,
             cnx_id_callback, cnx_id_callback_ctx, reset_seed, current_time, NULL, NULL, NULL, 0);
 
-        if (qserver == NULL)
-        {
+        if (qserver == NULL) {
             printf("Could not create server context\n");
             ret = -1;
-        }
-        else if (do_hrr != 0)
-        {
+        } else if (do_hrr != 0) {
             picoquic_set_cookie_mode(qserver, 1);
         }
     }
 
     /* Wait for packets */
-    while (ret == 0 && (just_once == 0 || cnx_server == NULL ||
-        picoquic_get_cnx_state(cnx_server) != picoquic_state_disconnected))
-    {
+    while (ret == 0 && (just_once == 0 || cnx_server == NULL || picoquic_get_cnx_state(cnx_server) != picoquic_state_disconnected)) {
         int64_t delta_t = picoquic_get_next_wake_delay(qserver, current_time, delay_max);
         uint64_t time_before = current_time;
 
         from_length = to_length = sizeof(struct sockaddr_storage);
         if_index_to = 0;
 
-        if (just_once != 0 && delta_t > 10000 && cnx_server != NULL)
-        {
+        if (just_once != 0 && delta_t > 10000 && cnx_server != NULL) {
             picoquic_log_congestion_state(stdout, cnx_server, current_time);
         }
 
@@ -450,49 +393,37 @@ int quic_server(const char * server_name, int server_port,
             buffer, sizeof(buffer),
             delta_t, &current_time);
 
-        if (just_once != 0)
-        {
-            if (bytes_recv != 0)
-            {
+        if (just_once != 0) {
+            if (bytes_recv != 0) {
                 printf("Select returns %d, from length %d after %d us (wait for %d us)\n",
                     bytes_recv, from_length, (int)(current_time - time_before), (int)delta_t);
-                print_address((struct sockaddr *)&addr_from, "recv from:", 0);
-            }
-            else
-            {
+                print_address((struct sockaddr*)&addr_from, "recv from:", 0);
+            } else {
                 printf("Select return %d, after %d us (wait for %d us)\n", bytes_recv,
                     (int)(current_time - time_before), (int)delta_t);
             }
         }
 
-        if (bytes_recv < 0)
-        {
+        if (bytes_recv < 0) {
             ret = -1;
-        }
-        else
-        {
-            if (bytes_recv > 0)
-            {
-                if (cnx_server != NULL && just_once != 0)
-                {
-                    picoquic_log_packet(stdout, qserver, cnx_server, (struct sockaddr *) &addr_from,
+        } else {
+            if (bytes_recv > 0) {
+                if (cnx_server != NULL && just_once != 0) {
+                    picoquic_log_packet(stdout, qserver, cnx_server, (struct sockaddr*)&addr_from,
                         1, buffer, bytes_recv, current_time);
                 }
 
                 /* Submit the packet to the server */
                 ret = picoquic_incoming_packet(qserver, buffer,
-                    (size_t)bytes_recv, (struct sockaddr *) &addr_from,
-                    (struct sockaddr *) &addr_to, if_index_to,
+                    (size_t)bytes_recv, (struct sockaddr*)&addr_from,
+                    (struct sockaddr*)&addr_to, if_index_to,
                     current_time);
 
-                if (ret != 0)
-                {
+                if (ret != 0) {
                     ret = 0;
                 }
 
-                if (cnx_server != picoquic_get_first_cnx(qserver) &&
-                    picoquic_get_first_cnx(qserver) != NULL)
-                {
+                if (cnx_server != picoquic_get_first_cnx(qserver) && picoquic_get_first_cnx(qserver) != NULL) {
                     cnx_server = picoquic_get_first_cnx(qserver);
                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx_server));
                     printf("Connection established, state = %d, from length: %d\n",
@@ -506,17 +437,15 @@ int quic_server(const char * server_name, int server_port,
                     picoquic_log_transport_extension(stdout, cnx_server, 1);
                 }
             }
-            if (ret == 0)
-            {
-                while ((sp = picoquic_dequeue_stateless_packet(qserver)) != NULL)
-                {
+            if (ret == 0) {
+                while ((sp = picoquic_dequeue_stateless_packet(qserver)) != NULL) {
                     int sent = picoquic_send_through_server_sockets(&server_sockets,
-                        (struct sockaddr *) &sp->addr_to,
+                        (struct sockaddr*)&sp->addr_to,
                         (sp->addr_to.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6),
-                        (struct sockaddr *) &sp->addr_local,
+                        (struct sockaddr*)&sp->addr_local,
                         (sp->addr_local.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6),
                         sp->if_index_local,
-                        (const char *)sp->bytes, (int)sp->length);
+                        (const char*)sp->bytes, (int)sp->length);
 
                     printf("Sending stateless packet, %d bytes\n", sent);
                     picoquic_delete_stateless_packet(sp);
@@ -524,21 +453,16 @@ int quic_server(const char * server_name, int server_port,
 
                 cnx_next = picoquic_get_first_cnx(qserver);
 
-                while (ret == 0 && cnx_next != NULL)
-                {
+                while (ret == 0 && cnx_next != NULL) {
                     p = picoquic_create_packet();
 
-                    if (p == NULL)
-                    {
+                    if (p == NULL) {
                         ret = -1;
-                    }
-                    else
-                    {
+                    } else {
                         ret = picoquic_prepare_packet(cnx_next, p, current_time,
                             send_buffer, sizeof(send_buffer), &send_length);
 
-                        if (ret == PICOQUIC_ERROR_DISCONNECTED)
-                        {
+                        if (ret == PICOQUIC_ERROR_DISCONNECTED) {
                             ret = 0;
                             free(p);
 
@@ -547,8 +471,7 @@ int quic_server(const char * server_name, int server_port,
                                 (int)cnx_next->nb_retransmission_total, (int)cnx_next->nb_spurious,
                                 (int)cnx_next->max_reorder_gap, (int)cnx_next->max_spurious_rtt);
 
-                            if (cnx_next == cnx_server)
-                            {
+                            if (cnx_next == cnx_server) {
                                 cnx_server = NULL;
                             }
 
@@ -557,18 +480,14 @@ int quic_server(const char * server_name, int server_port,
                             fflush(stdout);
 
                             break;
-                        }
-                        else if (ret == 0)
-                        {
+                        } else if (ret == 0) {
                             int peer_addr_len = 0;
-                            struct sockaddr * peer_addr;
+                            struct sockaddr* peer_addr;
                             int local_addr_len = 0;
-                            struct sockaddr * local_addr;
+                            struct sockaddr* local_addr;
 
-                            if (p->length > 0)
-                            {
-                                if (just_once != 0)
-                                {
+                            if (p->length > 0) {
+                                if (just_once != 0) {
                                     printf("%" PRIx64 ": ", picoquic_get_initial_cnxid(cnx_next));
                                     printf("Connection state = %d\n",
                                         picoquic_get_cnx_state(cnx_next));
@@ -577,26 +496,22 @@ int quic_server(const char * server_name, int server_port,
                                 picoquic_get_peer_addr(cnx_next, &peer_addr, &peer_addr_len);
                                 picoquic_get_local_addr(cnx_next, &local_addr, &local_addr_len);
 
-                                (void) picoquic_send_through_server_sockets(&server_sockets,
+                                (void)picoquic_send_through_server_sockets(&server_sockets,
                                     peer_addr, peer_addr_len, local_addr, local_addr_len,
                                     picoquic_get_local_if_index(cnx_next),
-                                    (const char *)send_buffer, (int)send_length);
+                                    (const char*)send_buffer, (int)send_length);
 
-                                if (cnx_server != NULL && just_once != 0 && cnx_next == cnx_server)
-                                {
-                                    picoquic_log_packet(stdout, qserver, cnx_server, (struct sockaddr *) peer_addr,
+                                if (cnx_server != NULL && just_once != 0 && cnx_next == cnx_server) {
+                                    picoquic_log_packet(stdout, qserver, cnx_server, (struct sockaddr*)peer_addr,
                                         0, send_buffer, send_length, current_time);
                                 }
-                            }
-                            else
-                            {
+                            } else {
                                 free(p);
                                 p = NULL;
                             }
                         }
 
-                        else
-                        {
+                        else {
                             break;
                         }
 
@@ -607,10 +522,8 @@ int quic_server(const char * server_name, int server_port,
         }
     }
 
-
     /* Clean up */
-    if (qserver != NULL)
-    {
+    if (qserver != NULL) {
         picoquic_free(qserver);
     }
 
@@ -619,28 +532,27 @@ int quic_server(const char * server_name, int server_port,
     return ret;
 }
 
-
 typedef struct st_demo_stream_desc_t {
     uint32_t stream_id;
     uint32_t previous_stream_id;
-    char const * doc_name;
-    char const * f_name;
+    char const* doc_name;
+    char const* f_name;
     int is_binary;
 } demo_stream_desc_t;
 
 static const demo_stream_desc_t test_scenario[] = {
 #ifdef PICOQUIC_TEST_AGAINST_ATS
-    { 4, 0, "", "slash.html",0 },
+    { 4, 0, "", "slash.html", 0 },
     { 8, 4, "en/latest/", "slash_en_slash_latest.html", 0 }
 #else
 #ifdef PICOQUIC_TEST_AGAINST_QUICKLY
-{ 4, 0, "123.txt", "123.txt", 0 }
+    { 4, 0, "123.txt", "123.txt", 0 }
 #else
-    { 4, 0, "index.html", "index.html",0 },
+    { 4, 0, "index.html", "index.html", 0 },
     { 8, 4, "test.html", "test.html", 0 },
     { 12, 4, "doc-123456.html", "doc-123456.html", 0 },
-    { 16, 4, "main.jpg", "main.jpg",1},
-    { 20, 4, "war-and-peace.txt", "war-and-peace.txt", 0},
+    { 16, 4, "main.jpg", "main.jpg", 1 },
+    { 20, 4, "war-and-peace.txt", "war-and-peace.txt", 0 },
     { 24, 4, "en/latest/", "slash_en_slash_latest.html", 0 }
 #endif
 #endif
@@ -656,43 +568,39 @@ static const uint8_t test_ping[] = { picoquic_frame_type_ping, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 typedef struct st_picoquic_first_client_stream_ctx_t {
-    struct st_picoquic_first_client_stream_ctx_t * next_stream;
+    struct st_picoquic_first_client_stream_ctx_t* next_stream;
     uint32_t stream_id;
-    uint8_t command[PICOQUIC_FIRST_COMMAND_MAX+1]; /* starts with "GET " */
+    uint8_t command[PICOQUIC_FIRST_COMMAND_MAX + 1]; /* starts with "GET " */
     size_t received_length;
     FILE* F; /* NULL if stream is closed. */
 } picoquic_first_client_stream_ctx_t;
 
 typedef struct st_picoquic_first_client_callback_ctx_t {
-    demo_stream_desc_t const * demo_stream;
+    demo_stream_desc_t const* demo_stream;
     size_t nb_demo_streams;
 
-    struct st_picoquic_first_client_stream_ctx_t * first_stream;
+    struct st_picoquic_first_client_stream_ctx_t* first_stream;
     int nb_open_streams;
     uint32_t nb_client_streams;
     uint64_t last_interaction_time;
     int progress_observed;
 } picoquic_first_client_callback_ctx_t;
 
-static void demo_client_open_stream(picoquic_cnx_t * cnx,
-    picoquic_first_client_callback_ctx_t * ctx, 
-    uint32_t stream_id, char const * text, size_t text_len, char const * fname, int is_binary)
+static void demo_client_open_stream(picoquic_cnx_t* cnx,
+    picoquic_first_client_callback_ctx_t* ctx,
+    uint32_t stream_id, char const* text, size_t text_len, char const* fname, int is_binary)
 {
     int ret = 0;
 
-    picoquic_first_client_stream_ctx_t *stream_ctx = 
-        (picoquic_first_client_stream_ctx_t *)
+    picoquic_first_client_stream_ctx_t* stream_ctx = (picoquic_first_client_stream_ctx_t*)
         malloc(sizeof(picoquic_first_client_stream_ctx_t));
 
-    if (stream_ctx == NULL)
-    {
+    if (stream_ctx == NULL) {
         fprintf(stdout, "Memory error!\n");
-    }
-    else
-    {
+    } else {
         fprintf(stdout, "Opening stream %d to GET /%s\n", stream_id, text);
 
         memset(stream_ctx, 0, sizeof(picoquic_first_client_stream_ctx_t));
@@ -701,8 +609,7 @@ static void demo_client_open_stream(picoquic_cnx_t * cnx,
         stream_ctx->command[2] = 'T';
         stream_ctx->command[3] = ' ';
         stream_ctx->command[4] = '/';
-        if (text_len > 0)
-        {
+        if (text_len > 0) {
             memcpy(&stream_ctx->command[5], text, text_len);
         }
         stream_ctx->command[text_len + 5] = '\r';
@@ -714,7 +621,7 @@ static void demo_client_open_stream(picoquic_cnx_t * cnx,
         ctx->first_stream = stream_ctx;
 
 #ifdef _WINDOWS
-        if (fopen_s(&stream_ctx->F, fname, (is_binary == 0)?"w":"wb") != 0) {
+        if (fopen_s(&stream_ctx->F, fname, (is_binary == 0) ? "w" : "wb") != 0) {
             ret = -1;
         }
 #else
@@ -723,19 +630,14 @@ static void demo_client_open_stream(picoquic_cnx_t * cnx,
             ret = -1;
         }
 #endif
-        if (ret != 0)
-        {
+        if (ret != 0) {
             fprintf(stdout, "Cannot create file: %s\n", fname);
-        }
-        else
-        {
+        } else {
             ctx->nb_open_streams++;
             ctx->nb_client_streams++;
         }
 
-        
-        if (stream_ctx->stream_id == 1)
-        {
+        if (stream_ctx->stream_id == 1) {
             /* Horrible hack to test sending in three blocks */
             (void)picoquic_add_to_stream(cnx, stream_ctx->stream_id, stream_ctx->command,
                 5, 0);
@@ -743,67 +645,53 @@ static void demo_client_open_stream(picoquic_cnx_t * cnx,
                 text_len, 0);
             (void)picoquic_add_to_stream(cnx, stream_ctx->stream_id, &stream_ctx->command[5 + text_len],
                 2, 1);
-        }
-        else
-        {
+        } else {
             (void)picoquic_add_to_stream(cnx, stream_ctx->stream_id, stream_ctx->command,
                 text_len + 7, 1);
         }
     }
 }
 
-static void demo_client_start_streams(picoquic_cnx_t * cnx,
-    picoquic_first_client_callback_ctx_t * ctx, uint64_t fin_stream_id)
+static void demo_client_start_streams(picoquic_cnx_t* cnx,
+    picoquic_first_client_callback_ctx_t* ctx, uint64_t fin_stream_id)
 {
-    for (size_t i = 0; i < ctx->nb_demo_streams; i++)
-    {
-        if (ctx->demo_stream[i].previous_stream_id == fin_stream_id)
-        {
+    for (size_t i = 0; i < ctx->nb_demo_streams; i++) {
+        if (ctx->demo_stream[i].previous_stream_id == fin_stream_id) {
             demo_client_open_stream(cnx, ctx, ctx->demo_stream[i].stream_id,
                 ctx->demo_stream[i].doc_name, strlen(ctx->demo_stream[i].doc_name),
                 ctx->demo_stream[i].f_name,
                 ctx->demo_stream[i].is_binary);
         }
     }
-
 }
 
-static void first_client_callback(picoquic_cnx_t * cnx,
-    uint64_t stream_id, uint8_t * bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void * callback_ctx)
+static void first_client_callback(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
 {
     uint64_t fin_stream_id = 0;
 
-    picoquic_first_client_callback_ctx_t * ctx =
-        (picoquic_first_client_callback_ctx_t*)callback_ctx;
-    picoquic_first_client_stream_ctx_t * stream_ctx = ctx->first_stream;
+    picoquic_first_client_callback_ctx_t* ctx = (picoquic_first_client_callback_ctx_t*)callback_ctx;
+    picoquic_first_client_stream_ctx_t* stream_ctx = ctx->first_stream;
 
     ctx->last_interaction_time = picoquic_current_time();
     ctx->progress_observed = 1;
 
-    if (fin_or_event == picoquic_callback_close ||
-        fin_or_event == picoquic_callback_application_close)
-    {
-        if (fin_or_event == picoquic_callback_application_close)
-        {
+    if (fin_or_event == picoquic_callback_close || fin_or_event == picoquic_callback_application_close) {
+        if (fin_or_event == picoquic_callback_application_close) {
             fprintf(stdout, "Received a request to close the application.\n");
-        }
-        else
-        {
+        } else {
             fprintf(stdout, "Received a request to close the connection.\n");
         }
 
-        while (stream_ctx != NULL)
-        {
-            if (stream_ctx->F != NULL)
-            {
+        while (stream_ctx != NULL) {
+            if (stream_ctx->F != NULL) {
                 fclose(stream_ctx->F);
                 stream_ctx->F = NULL;
                 ctx->nb_open_streams--;
 
                 fprintf(stdout, "On stream %d, command: %s stopped after %d bytes\n",
                     stream_ctx->stream_id, stream_ctx->command, (int)stream_ctx->received_length);
-
             }
             stream_ctx = stream_ctx->next_stream;
         }
@@ -812,23 +700,18 @@ static void first_client_callback(picoquic_cnx_t * cnx,
     }
 
     /* if stream is already present, check its state. New bytes? */
-    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id)
-    {
+    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id) {
         stream_ctx = stream_ctx->next_stream;
     }
 
-    if (stream_ctx == NULL || stream_ctx->F == NULL)
-    {
+    if (stream_ctx == NULL || stream_ctx->F == NULL) {
         /* Unexpected stream. */
         picoquic_reset_stream(cnx, stream_id, 0);
         return;
-    }
-    else if (fin_or_event == picoquic_callback_stream_reset)
-    {
+    } else if (fin_or_event == picoquic_callback_stream_reset) {
         picoquic_reset_stream(cnx, stream_id, 0);
 
-        if (stream_ctx->F != NULL)
-        {
+        if (stream_ctx->F != NULL) {
             char buf[256];
 
             fclose(stream_ctx->F);
@@ -837,33 +720,27 @@ static void first_client_callback(picoquic_cnx_t * cnx,
             fin_stream_id = stream_id;
 
             fprintf(stdout, "Reset received on stream %d, command: %s, after %d bytes\n",
-                stream_ctx->stream_id, 
-                strip_endofline(buf, sizeof(buf), (char *)&stream_ctx->command), 
+                stream_ctx->stream_id,
+                strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command),
                 (int)stream_ctx->received_length);
         }
         return;
-    }
-    else if (fin_or_event == picoquic_callback_stop_sending)
-    {
+    } else if (fin_or_event == picoquic_callback_stop_sending) {
         char buf[256];
         picoquic_reset_stream(cnx, stream_id, 0);
 
         fprintf(stdout, "Stop sending received on stream %d, command: %s\n",
             stream_ctx->stream_id,
-            strip_endofline(buf, sizeof(buf), (char *)&stream_ctx->command));
+            strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command));
         return;
-    }
-    else
-    {
-        if (length > 0)
-        {
+    } else {
+        if (length > 0) {
             (void)fwrite(bytes, 1, length, stream_ctx->F);
             stream_ctx->received_length += length;
         }
 
         /* if FIN present, process request through http 0.9 */
-        if (fin_or_event == picoquic_callback_stream_fin)
-        {
+        if (fin_or_event == picoquic_callback_stream_fin) {
             char buf[256];
             /* if data generated, just send it. Otherwise, just FIN the stream. */
             fclose(stream_ctx->F);
@@ -872,21 +749,20 @@ static void first_client_callback(picoquic_cnx_t * cnx,
             fin_stream_id = stream_id;
 
             fprintf(stdout, "Received file %s, after %d bytes, closing stream %d\n",
-                strip_endofline(buf, sizeof(buf), (char *) &stream_ctx->command[4]),
+                strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->command[4]),
                 (int)stream_ctx->received_length, stream_ctx->stream_id);
         }
     }
 
-    if (fin_stream_id != 0)
-    {
+    if (fin_stream_id != 0) {
         demo_client_start_streams(cnx, ctx, fin_stream_id);
     }
 
     /* that's it */
 }
 
-void quic_client_launch_scenario(picoquic_cnx_t *cnx_client,
-    picoquic_first_client_callback_ctx_t *callback_ctx)
+void quic_client_launch_scenario(picoquic_cnx_t* cnx_client,
+    picoquic_first_client_callback_ctx_t* callback_ctx)
 {
     /* Start the download scenario */
     callback_ctx->demo_stream = test_scenario;
@@ -895,12 +771,12 @@ void quic_client_launch_scenario(picoquic_cnx_t *cnx_client,
     demo_client_start_streams(cnx_client, callback_ctx, 0);
 }
 
-int quic_client(const char * ip_address_text, int server_port, uint32_t proposed_version, FILE * F_log)
+int quic_client(const char* ip_address_text, int server_port, uint32_t proposed_version, FILE* F_log)
 {
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
-    picoquic_quic_t *qclient = NULL;
-    picoquic_cnx_t *cnx_client = NULL;
+    picoquic_quic_t* qclient = NULL;
+    picoquic_cnx_t* cnx_client = NULL;
     picoquic_first_client_callback_ctx_t callback_ctx;
     SOCKET_TYPE fd = INVALID_SOCKET;
     struct sockaddr_storage server_address;
@@ -915,89 +791,74 @@ int quic_client(const char * ip_address_text, int server_port, uint32_t proposed
     size_t send_length = 0;
     int bytes_recv;
     int bytes_sent;
-    picoquic_packet * p = NULL;
+    picoquic_packet* p = NULL;
     uint64_t current_time = 0;
     int client_ready_loop = 0;
     int established = 0;
     int is_name = 0;
-    const char * sni = NULL;
+    const char* sni = NULL;
     int64_t delay_max = 10000000;
     int64_t delta_t = 0;
     int notified_ready = 0;
-    const char * alpn = "hq-08";
+    const char* alpn = "hq-08";
 
     memset(&callback_ctx, 0, sizeof(picoquic_first_client_callback_ctx_t));
 
     ret = picoquic_get_server_address(ip_address_text, server_port, &server_address, &server_addr_length, &is_name);
-    if (is_name != 0)
-    {
+    if (is_name != 0) {
         sni = ip_address_text;
     }
 
     /* Open a UDP socket */
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         fd = socket(server_address.ss_family, SOCK_DGRAM, IPPROTO_UDP);
-        if (fd == INVALID_SOCKET)
-        {
+        if (fd == INVALID_SOCKET) {
             ret = -1;
         }
-
     }
 
     /* Create QUIC context */
     current_time = picoquic_current_time();
     callback_ctx.last_interaction_time = current_time;
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         qclient = picoquic_create(8, NULL, NULL, alpn, NULL, NULL, NULL, NULL, NULL, current_time, NULL, ticket_store_filename, NULL, 0);
 
-        if (qclient == NULL)
-        {
+        if (qclient == NULL) {
             ret = -1;
         }
     }
 
     /* Create the client connection */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         /* Create a client connection */
 
         cnx_client = picoquic_create_cnx(qclient, 0,
-            (struct sockaddr *)&server_address, current_time,
+            (struct sockaddr*)&server_address, current_time,
             proposed_version, sni, alpn, 1);
 
-        if (cnx_client == NULL)
-        {
+        if (cnx_client == NULL) {
             ret = -1;
-        }
-		else
-		{
+        } else {
             picoquic_set_callback(cnx_client, first_client_callback, &callback_ctx);
 
-			p = picoquic_create_packet();
+            p = picoquic_create_packet();
 
-			if (p == NULL)
-			{
-				ret = -1;
-			}
-			else
-			{
-				ret = picoquic_prepare_packet(cnx_client, p, current_time,
-					send_buffer, sizeof(send_buffer), &send_length);
+            if (p == NULL) {
+                ret = -1;
+            } else {
+                ret = picoquic_prepare_packet(cnx_client, p, current_time,
+                    send_buffer, sizeof(send_buffer), &send_length);
 
-				if (ret == 0 && send_length > 0)
-				{
-					bytes_sent = sendto(fd, send_buffer, (int)send_length, 0,
-						(struct sockaddr *) &server_address, server_addr_length);
+                if (ret == 0 && send_length > 0) {
+                    bytes_sent = sendto(fd, send_buffer, (int)send_length, 0,
+                        (struct sockaddr*)&server_address, server_addr_length);
 
-					picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr *) &server_address,
-						0, send_buffer, bytes_sent, current_time);
+                    picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr*)&server_address,
+                        0, send_buffer, bytes_sent, current_time);
 #if 1
-                    if (picoquic_is_0rtt_available(cnx_client))
-                    {
+                    if (picoquic_is_0rtt_available(cnx_client)) {
                         /* Queue a simple frame to perform 0-RTT test */
                         picoquic_queue_misc_frame(cnx_client, test_ping, sizeof(test_ping));
                     }
@@ -1010,85 +871,64 @@ int quic_client(const char * ip_address_text, int server_port, uint32_t proposed
                     callback_ctx.nb_demo_streams = test_scenario_nb;
                     demo_client_start_streams(cnx_client, &callback_ctx, 0);
 #endif
-				}
-				else
-				{
-					free(p);
-				}
-			}
-		}
+                } else {
+                    free(p);
+                }
+            }
+        }
     }
 
     /* Wait for packets */
-    while (ret == 0 &&
-        picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected)
-    {
-        if (picoquic_is_cnx_backlog_empty(cnx_client) &&
-            callback_ctx.nb_open_streams == 0)
-        {
+    while (ret == 0 && picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected) {
+        if (picoquic_is_cnx_backlog_empty(cnx_client) && callback_ctx.nb_open_streams == 0) {
             delay_max = 10000;
-        }
-        else
-        {
+        } else {
             delay_max = 10000000;
         }
 
         from_length = to_length = sizeof(struct sockaddr_storage);
 
-        bytes_recv = picoquic_select(&fd, 1, &packet_from, &from_length, 
+        bytes_recv = picoquic_select(&fd, 1, &packet_from, &from_length,
             &packet_to, &to_length, &if_index_to,
-            buffer, sizeof(buffer), 
+            buffer, sizeof(buffer),
             delta_t,
             &current_time);
 
-        if (bytes_recv != 0)
-        {
+        if (bytes_recv != 0) {
             fprintf(F_log, "Select returns %d, from length %d\n", bytes_recv, from_length);
 
-			picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr *) &packet_from,
-				1, buffer, bytes_recv, current_time);
+            picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr*)&packet_from,
+                1, buffer, bytes_recv, current_time);
         }
 
-        if (bytes_recv < 0)
-        {
+        if (bytes_recv < 0) {
             ret = -1;
-        }
-        else
-        {
-            if (bytes_recv > 0)
-            {
+        } else {
+            if (bytes_recv > 0) {
                 /* Submit the packet to the client */
                 ret = picoquic_incoming_packet(qclient, buffer,
-                    (size_t)bytes_recv, (struct sockaddr *) &packet_from,
-                    (struct sockaddr *) &packet_to, if_index_to,
+                    (size_t)bytes_recv, (struct sockaddr*)&packet_from,
+                    (struct sockaddr*)&packet_to, if_index_to,
                     current_time);
 
                 picoquic_log_processing(F_log, cnx_client, bytes_recv, ret);
 
-                if (picoquic_get_cnx_state(cnx_client) == picoquic_state_client_almost_ready &&
-                    notified_ready == 0)
-                {
-                    if (picoquic_tls_is_psk_handshake(cnx_client))
-                    {
+                if (picoquic_get_cnx_state(cnx_client) == picoquic_state_client_almost_ready && notified_ready == 0) {
+                    if (picoquic_tls_is_psk_handshake(cnx_client)) {
                         fprintf(stdout, "The session was properly resumed!\n");
                     }
                     fprintf(stdout, "Almost ready!\n\n");
                     notified_ready = 1;
                 }
 
-                if (ret != 0)
-                {
+                if (ret != 0) {
                     picoquic_log_error_packet(F_log, buffer, (size_t)bytes_recv, ret);
                 }
 
                 delta_t = 0;
-            }
-            else
-            {
-                if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_client_ready)
-                {
-                    if (established == 0)
-                    {
+            } else {
+                if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_client_ready) {
+                    if (established == 0) {
                         picoquic_log_transport_extension(F_log, cnx_client, 0);
                         printf("Connection established.\n");
                         established = 1;
@@ -1103,55 +943,40 @@ int quic_client(const char * ip_address_text, int server_port, uint32_t proposed
 
                     client_ready_loop++;
 
-                    if ((bytes_recv == 0 || client_ready_loop > 4) &&
-                        picoquic_is_cnx_backlog_empty(cnx_client))
-                    {
-                        if (callback_ctx.nb_open_streams == 0)
-                        {
-                            if (cnx_client->nb_zero_rtt_sent != 0)
-                            {
+                    if ((bytes_recv == 0 || client_ready_loop > 4) && picoquic_is_cnx_backlog_empty(cnx_client)) {
+                        if (callback_ctx.nb_open_streams == 0) {
+                            if (cnx_client->nb_zero_rtt_sent != 0) {
                                 fprintf(stdout, "Out of %d zero RTT packets, %d were acked by the server.\n",
                                     cnx_client->nb_zero_rtt_sent, cnx_client->nb_zero_rtt_acked);
                             }
                             fprintf(stdout, "All done, Closing the connection.\n");
                             ret = picoquic_close(cnx_client, 0);
-                        }
-                        else if (
-                            current_time > callback_ctx.last_interaction_time &&
-                            current_time - callback_ctx.last_interaction_time >
-                            10000000ull)
-                        {
+                        } else if (
+                            current_time > callback_ctx.last_interaction_time && current_time - callback_ctx.last_interaction_time > 10000000ull) {
                             fprintf(stdout, "No progress for 10 seconds. Closing. \n");
                             ret = picoquic_close(cnx_client, 0);
                         }
                     }
                 }
 
-                if (ret == 0)
-                {
+                if (ret == 0) {
                     p = picoquic_create_packet();
 
-                    if (p == NULL)
-                    {
+                    if (p == NULL) {
                         ret = -1;
-                    }
-                    else
-                    {
+                    } else {
                         send_length = 1000000;
 
                         ret = picoquic_prepare_packet(cnx_client, p, current_time,
                             send_buffer, sizeof(send_buffer), &send_length);
 
-                        if (ret == 0 && send_length > 0)
-                        {
+                        if (ret == 0 && send_length > 0) {
                             bytes_sent = sendto(fd, send_buffer, (int)send_length, 0,
-                                (struct sockaddr *) &server_address, server_addr_length);
-                            picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr *)  &server_address,
+                                (struct sockaddr*)&server_address, server_addr_length);
+                            picoquic_log_packet(F_log, qclient, cnx_client, (struct sockaddr*)&server_address,
                                 0, send_buffer, send_length, current_time);
 
-                        }
-                        else
-                        {
+                        } else {
                             free(p);
                         }
                     }
@@ -1163,59 +988,46 @@ int quic_client(const char * ip_address_text, int server_port, uint32_t proposed
     }
 
     /* Clean up */
-    if (qclient != NULL)
-    {
-        uint8_t *ticket;
+    if (qclient != NULL) {
+        uint8_t* ticket;
         uint16_t ticket_length;
 
-        if (sni != NULL && 0 == picoquic_get_ticket(qclient->p_first_ticket, current_time,
-            sni, (uint16_t)strlen(sni), alpn, (uint16_t)strlen(alpn), &ticket, &ticket_length))
-        {
+        if (sni != NULL && 0 == picoquic_get_ticket(qclient->p_first_ticket, current_time, sni, (uint16_t)strlen(sni), alpn, (uint16_t)strlen(alpn), &ticket, &ticket_length)) {
             fprintf(F_log, "Received ticket from %s:\n", sni);
             picoquic_log_picotls_ticket(F_log, 0, ticket, ticket_length);
         }
 
-        if (picoquic_save_tickets(qclient->p_first_ticket, current_time, ticket_store_filename) != 0)
-        {
+        if (picoquic_save_tickets(qclient->p_first_ticket, current_time, ticket_store_filename) != 0) {
             fprintf(stderr, "Could not store the saved session tickets.\n");
         }
         picoquic_free(qclient);
     }
 
-    if (fd != INVALID_SOCKET)
-    {
+    if (fd != INVALID_SOCKET) {
         SOCKET_CLOSE(fd);
     }
 
     return ret;
 }
 
-uint32_t parse_target_version(char const * v_arg)
+uint32_t parse_target_version(char const* v_arg)
 {
     /* Expect the version to be encoded in base 16 */
     uint32_t v = 0;
-    char const * x = v_arg;
+    char const* x = v_arg;
 
-    while (*x != 0)
-    {
+    while (*x != 0) {
         int c = *x;
 
-        if (c >= '0' && c <= '9')
-        {
+        if (c >= '0' && c <= '9') {
             c -= '0';
-        }
-        else if (c >= 'a' && c <= 'f')
-        {
+        } else if (c >= 'a' && c <= 'f') {
             c -= 'a';
             c += 10;
-        }
-        else if (c >= 'A' && c <= 'F')
-        {
+        } else if (c >= 'A' && c <= 'F') {
             c -= 'A';
             c += 10;
-        }
-        else
-        {
+        } else {
             v = 0;
             break;
         }
@@ -1229,66 +1041,67 @@ uint32_t parse_target_version(char const * v_arg)
 
 void usage()
 {
-	fprintf(stderr, "PicoQUIC demo client and server\n");
-	fprintf(stderr, "Usage: picoquicdemo [server_name [port]] <options>\n");
-	fprintf(stderr, "  For the client mode, specify sever_name and port.\n");
-	fprintf(stderr, "  For the server mode, use -p to specify the port.\n");
-	fprintf(stderr, "Options:\n");
-	fprintf(stderr, "  -c file               cert file (default: %s)\n", default_server_cert_file);
-	fprintf(stderr, "  -k file               key file (default: %s)\n", default_server_key_file);
-	fprintf(stderr, "  -p port               server port (default: %d)\n", default_server_port);
-	fprintf(stderr, "  -1                    Once\n");
-	fprintf(stderr, "  -r                    Do Reset Request\n");
-	fprintf(stderr, "  -s <64b 64b>        Reset seed\n");
-	fprintf(stderr, "  -i <src mask value>   Connection ID modification: (src & ~mask) || val\n");
-	fprintf(stderr, "                        Implies unconditional server cnx_id xmit\n");
-	fprintf(stderr, "                          where <src> is int:\n");
-	fprintf(stderr, "                            0: picoquic_cnx_id_random\n");
-	fprintf(stderr, "                            1: picoquic_cnx_id_remote (client)\n");
-	fprintf(stderr, "  -v version            Version proposed by client, e.g. -v ff000008\n");
+    fprintf(stderr, "PicoQUIC demo client and server\n");
+    fprintf(stderr, "Usage: picoquicdemo [server_name [port]] <options>\n");
+    fprintf(stderr, "  For the client mode, specify sever_name and port.\n");
+    fprintf(stderr, "  For the server mode, use -p to specify the port.\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  -c file               cert file (default: %s)\n", default_server_cert_file);
+    fprintf(stderr, "  -k file               key file (default: %s)\n", default_server_key_file);
+    fprintf(stderr, "  -p port               server port (default: %d)\n", default_server_port);
+    fprintf(stderr, "  -1                    Once\n");
+    fprintf(stderr, "  -r                    Do Reset Request\n");
+    fprintf(stderr, "  -s <64b 64b>        Reset seed\n");
+    fprintf(stderr, "  -i <src mask value>   Connection ID modification: (src & ~mask) || val\n");
+    fprintf(stderr, "                        Implies unconditional server cnx_id xmit\n");
+    fprintf(stderr, "                          where <src> is int:\n");
+    fprintf(stderr, "                            0: picoquic_cnx_id_random\n");
+    fprintf(stderr, "                            1: picoquic_cnx_id_remote (client)\n");
+    fprintf(stderr, "  -v version            Version proposed by client, e.g. -v ff000008\n");
     fprintf(stderr, "  -l file               Log file\n");
-	fprintf(stderr, "  -h                    This help message\n");
-	exit(1);
+    fprintf(stderr, "  -h                    This help message\n");
+    exit(1);
 }
 
 enum picoquic_cnx_id_select {
-	picoquic_cnx_id_random = 0,
-	picoquic_cnx_id_remote = 1
+    picoquic_cnx_id_random = 0,
+    picoquic_cnx_id_remote = 1
 };
 
 typedef struct {
-	enum picoquic_cnx_id_select cnx_id_select;
-	uint64_t cnx_id_mask;
-	uint64_t cnx_id_val;
+    enum picoquic_cnx_id_select cnx_id_select;
+    uint64_t cnx_id_mask;
+    uint64_t cnx_id_val;
 } cnx_id_callback_ctx_t;
 
-static uint64_t cnx_id_callback(uint64_t cnx_id_local, uint64_t cnx_id_remote, void *cnx_id_callback_ctx) {
-	cnx_id_callback_ctx_t *ctx = (cnx_id_callback_ctx_t *) cnx_id_callback_ctx;
+static uint64_t cnx_id_callback(uint64_t cnx_id_local, uint64_t cnx_id_remote, void* cnx_id_callback_ctx)
+{
+    cnx_id_callback_ctx_t* ctx = (cnx_id_callback_ctx_t*)cnx_id_callback_ctx;
 
-	if (ctx->cnx_id_select == picoquic_cnx_id_remote)
-		cnx_id_local = cnx_id_remote;
+    if (ctx->cnx_id_select == picoquic_cnx_id_remote)
+        cnx_id_local = cnx_id_remote;
 
-	return (cnx_id_local & ctx->cnx_id_mask) | ctx->cnx_id_val;
+    return (cnx_id_local & ctx->cnx_id_mask) | ctx->cnx_id_val;
 }
 
-int main(int argc, char ** argv)
+int main(int argc, char** argv)
 {
-    const char * server_name      = default_server_name;
-    const char * server_cert_file = default_server_cert_file;
-    const char * server_key_file  = default_server_key_file;
-    const char * log_file = NULL;
-    int server_port               = default_server_port;
+    const char* server_name = default_server_name;
+    const char* server_cert_file = default_server_cert_file;
+    const char* server_key_file = default_server_key_file;
+    const char* log_file = NULL;
+    int server_port = default_server_port;
     uint32_t proposed_version = 0xFF000008;
     int is_client = 0;
     int just_once = 0;
     int do_hrr = 0;
     cnx_id_callback_ctx_t cnx_id_cbdata = {
-    		.cnx_id_select = 0,
-    		.cnx_id_mask = UINT64_MAX,
-			.cnx_id_val = 0
+        .cnx_id_select = 0,
+        .cnx_id_mask = UINT64_MAX,
+        .cnx_id_val = 0
     };
 
-    uint64_t *reset_seed = NULL;
+    uint64_t* reset_seed = NULL;
     uint64_t reset_seed_x[2];
 
 #ifdef _WINDOWS
@@ -1299,94 +1112,85 @@ int main(int argc, char ** argv)
     /* HTTP09 test */
 
     /* Get the parameters */
-	int opt;
-	while( (opt = getopt(argc, argv, "c:k:p:v:1rhi:s:l:")) != -1 )
-	{
-		switch (opt)
-		{
-			case 'c':
-				server_cert_file = optarg;
-				break;
-			case 'k':
-				server_key_file = optarg;
-				break;
-			case 'p':
-				if ((server_port = atoi(optarg)) <= 0)
-				{
-					fprintf(stderr, "Invalid port: %s\n", optarg);
-					usage();
-				}
-				break;
-            case 'v':
-                if (optind + 1 > argc) {
-                    fprintf(stderr, "option requires more arguments -- s\n");
-                    usage();
-                }
-                if ((proposed_version = parse_target_version(optarg)) <= 0)
-                {
-                    fprintf(stderr, "Invalid version: %s\n", optarg);
-                    usage();
-                }
-                break;
-			case '1':
-				just_once = 1;
-				break;
-			case 'r':
-				do_hrr = 1;
-				break;
-			case 's':
-				if (optind + 1 > argc) {
-					fprintf(stderr, "option requires more arguments -- s\n");
-					usage();
-				}
-				reset_seed = reset_seed_x; /* replacing the original alloca, which is not supported in Windows */
-				reset_seed[1] = strtoul(argv[optind], NULL, 0);
-				reset_seed[0] = strtoul(argv[optind++], NULL, 0);
-				break;
-			case 'i':
-				if (optind + 2 > argc) {
-					fprintf(stderr, "option requires more arguments -- i\n");
-					usage();
-				}
+    int opt;
+    while ((opt = getopt(argc, argv, "c:k:p:v:1rhi:s:l:")) != -1) {
+        switch (opt) {
+        case 'c':
+            server_cert_file = optarg;
+            break;
+        case 'k':
+            server_key_file = optarg;
+            break;
+        case 'p':
+            if ((server_port = atoi(optarg)) <= 0) {
+                fprintf(stderr, "Invalid port: %s\n", optarg);
+                usage();
+            }
+            break;
+        case 'v':
+            if (optind + 1 > argc) {
+                fprintf(stderr, "option requires more arguments -- s\n");
+                usage();
+            }
+            if ((proposed_version = parse_target_version(optarg)) <= 0) {
+                fprintf(stderr, "Invalid version: %s\n", optarg);
+                usage();
+            }
+            break;
+        case '1':
+            just_once = 1;
+            break;
+        case 'r':
+            do_hrr = 1;
+            break;
+        case 's':
+            if (optind + 1 > argc) {
+                fprintf(stderr, "option requires more arguments -- s\n");
+                usage();
+            }
+            reset_seed = reset_seed_x; /* replacing the original alloca, which is not supported in Windows */
+            reset_seed[1] = strtoul(argv[optind], NULL, 0);
+            reset_seed[0] = strtoul(argv[optind++], NULL, 0);
+            break;
+        case 'i':
+            if (optind + 2 > argc) {
+                fprintf(stderr, "option requires more arguments -- i\n");
+                usage();
+            }
 
-				cnx_id_cbdata.cnx_id_select = atoi(optarg);
-				cnx_id_cbdata.cnx_id_mask = ~strtoul(argv[optind++], NULL, 0);
-				cnx_id_cbdata.cnx_id_val = strtoul(argv[optind++], NULL, 0);
-				break;
-            case 'l':
-                if (optind + 1 > argc) {
-                    fprintf(stderr, "option requires more arguments -- s\n");
-                    usage();
-                }
-                log_file = optarg;
-                break;
-			case 'h':
-				usage();
-				break;
-		}
+            cnx_id_cbdata.cnx_id_select = atoi(optarg);
+            cnx_id_cbdata.cnx_id_mask = ~strtoul(argv[optind++], NULL, 0);
+            cnx_id_cbdata.cnx_id_val = strtoul(argv[optind++], NULL, 0);
+            break;
+        case 'l':
+            if (optind + 1 > argc) {
+                fprintf(stderr, "option requires more arguments -- s\n");
+                usage();
+            }
+            log_file = optarg;
+            break;
+        case 'h':
+            usage();
+            break;
+        }
     }
 
-	/* Simplified style params */
-	if (optind < argc)
-	{
-		server_name = argv[optind++];
-		is_client = 1;
-	}
+    /* Simplified style params */
+    if (optind < argc) {
+        server_name = argv[optind++];
+        is_client = 1;
+    }
 
-	if (optind < argc)
-	{
-		if ((server_port = atoi(argv[optind++])) <= 0)
-		{
-			fprintf(stderr, "Invalid port: %s\n", optarg);
-			usage();
-		}
-	}
-	
-	
+    if (optind < argc) {
+        if ((server_port = atoi(argv[optind++])) <= 0) {
+            fprintf(stderr, "Invalid port: %s\n", optarg);
+            usage();
+        }
+    }
+
 #ifdef _WINDOWS
     // Init WSA.
-    if (ret == 0)
-    {
+    if (ret == 0) {
         if (WSA_START(MAKEWORD(2, 2), &wsaData)) {
             fprintf(stderr, "Cannot init WSA\n");
             ret = -1;
@@ -1394,24 +1198,20 @@ int main(int argc, char ** argv)
     }
 #endif
 
-    if (is_client == 0)
-    {
+    if (is_client == 0) {
         /* Run as server */
-        printf("Starting PicoQUIC server on port %d, server name = %s, just_once = %d, hrr= %d\n", 
+        printf("Starting PicoQUIC server on port %d, server name = %s, just_once = %d, hrr= %d\n",
             server_port, server_name, just_once, do_hrr);
         ret = quic_server(server_name, server_port,
             server_cert_file, server_key_file, just_once, do_hrr,
             (cnx_id_cbdata.cnx_id_mask == UINT64_MAX) ? NULL : cnx_id_callback,
-            (cnx_id_cbdata.cnx_id_mask == UINT64_MAX) ? NULL : (void *)&cnx_id_cbdata,
-            (uint8_t *)reset_seed);
+            (cnx_id_cbdata.cnx_id_mask == UINT64_MAX) ? NULL : (void*)&cnx_id_cbdata,
+            (uint8_t*)reset_seed);
         printf("Server exit with code = %d\n", ret);
-    }
-    else
-    {
-        FILE * F_log = NULL;
+    } else {
+        FILE* F_log = NULL;
 
-        if (log_file != NULL)
-        {
+        if (log_file != NULL) {
 #ifdef _WINDOWS
             if (fopen_s(&F_log, log_file, "w") != 0) {
                 F_log = NULL;
@@ -1419,14 +1219,12 @@ int main(int argc, char ** argv)
 #else
             F_log = fopen(log_file, "w");
 #endif
-            if (F_log == NULL)
-            {
+            if (F_log == NULL) {
                 fprintf(stderr, "Could not open the log file <%s>\n", log_file);
             }
         }
 
-        if (F_log == NULL)
-        {
+        if (F_log == NULL) {
             F_log = stdout;
         }
 
@@ -1436,8 +1234,7 @@ int main(int argc, char ** argv)
 
         printf("Client exit with code = %d\n", ret);
 
-        if (F_log != NULL && F_log != stdout)
-        {
+        if (F_log != NULL && F_log != stdout) {
             fclose(F_log);
         }
     }

--- a/picoquictest/cnx_creation_test.c
+++ b/picoquictest/cnx_creation_test.c
@@ -47,34 +47,32 @@
 int cnxcreation_test()
 {
     int ret = 0;
-    picoquic_quic_t * quic = NULL;
-    picoquic_cnx_t * test_cnx[5] = { NULL,  NULL, NULL, NULL, NULL };
+    picoquic_quic_t* quic = NULL;
+    picoquic_cnx_t* test_cnx[5] = { NULL, NULL, NULL, NULL, NULL };
     struct sockaddr_in test4[4];
     struct sockaddr_in6 test6[2];
     const uint8_t test_ipv4[4] = { 192, 0, 2, 0 };
-    const uint8_t test_ipv6[16] = { 0x20, 0x01,0x0D, 0xB8, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0x01 };
+    const uint8_t test_ipv6[16] = { 0x20, 0x01, 0x0D, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01 };
     const uint64_t test_cnx_id[5] = { 0, 1, 2, 3, 4 };
-    struct sockaddr * test_cnx_addr[5] = { 
-        (struct sockaddr *) &test4[0],
-        (struct sockaddr *) &test4[1], 
-        (struct sockaddr *) &test4[2], 
-        (struct sockaddr *) &test6[0], 
-        (struct sockaddr *) &test6[1] };
-
+    struct sockaddr* test_cnx_addr[5] = {
+        (struct sockaddr*)&test4[0],
+        (struct sockaddr*)&test4[1],
+        (struct sockaddr*)&test4[2],
+        (struct sockaddr*)&test6[0],
+        (struct sockaddr*)&test6[1]
+    };
 
     /* Create QUIC context */
     quic = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (quic == NULL)
-    {
+    if (quic == NULL) {
         ret = -1;
     }
 
     /*
      * Initialize the sockaddr values
      */
-    for (int i = 0; i < 4; i++)
-    {
-        uint8_t * addr = (uint8_t*)&test4[i].sin_addr;
+    for (int i = 0; i < 4; i++) {
+        uint8_t* addr = (uint8_t*)&test4[i].sin_addr;
         memset(&test4[i], 0, sizeof(test4[i]));
         test4[i].sin_family = AF_INET;
         addr[0] = test_ipv4[0];
@@ -84,13 +82,11 @@ int cnxcreation_test()
         test4[i].sin_port = 1000 + i;
     }
 
-    for (int i = 0; i < 2; i++)
-    {
-        uint8_t * addr = (uint8_t*)&test6[i].sin6_addr;
+    for (int i = 0; i < 2; i++) {
+        uint8_t* addr = (uint8_t*)&test6[i].sin6_addr;
         memset(&test6[i], 0, sizeof(test6[i]));
         test6[i].sin6_family = AF_INET6;
-        for (int j = 0; j < 15; j++)
-        {
+        for (int j = 0; j < 15; j++) {
             addr[j] = test_ipv6[j];
         }
         addr[15] = i + 1;
@@ -104,31 +100,26 @@ int cnxcreation_test()
     * -either no connection ID or a connection ID.
     */
 
-    for (int i = 0; ret == 0 && i < 5; i++)
-    {
+    for (int i = 0; ret == 0 && i < 5; i++) {
         test_cnx[i] = picoquic_create_cnx(quic, test_cnx_id[i], test_cnx_addr[i], 0, 0, NULL, NULL, 1);
-        if (test_cnx[i] == NULL)
-        {
+        if (test_cnx[i] == NULL) {
             ret = -1;
         }
     }
-
 
     /*
      *  -Verify that all these connections can be retrieved using their
      *    registered attributes.
      */
-    for (int i = 0; ret == 0 && i < 5; i++)
-    {
-        picoquic_cnx_t * cnx = picoquic_cnx_by_net(quic, test_cnx_addr[i]);
+    for (int i = 0; ret == 0 && i < 5; i++) {
+        picoquic_cnx_t* cnx = picoquic_cnx_by_net(quic, test_cnx_addr[i]);
 
-        if (cnx == NULL)
-        {
+        if (cnx == NULL) {
             ret = -1;
         }
     }
 
-    /* TODO: cannot retrieve connections by initial ID yet, should work on it */
+/* TODO: cannot retrieve connections by initial ID yet, should work on it */
 
 #if 0
     for (int i = 0; ret == 0 && i < 5; i++)
@@ -145,36 +136,31 @@ int cnxcreation_test()
         }
     }
 #endif
-     /*
+    /*
       *  -Verify that a non registered connection cannot be retrieved.
       */
 
-    if (ret == 0)
-    {
-        picoquic_cnx_t * cnx = picoquic_cnx_by_id(quic, 123456789);
-        if (cnx != NULL)
-        {
+    if (ret == 0) {
+        picoquic_cnx_t* cnx = picoquic_cnx_by_id(quic, 123456789);
+        if (cnx != NULL) {
             ret = -1;
         }
     }
 
-    if (ret == 0)
-    {
-        picoquic_cnx_t * cnx = picoquic_cnx_by_net(quic, (struct sockaddr*) &test4[3]);
-        if (cnx != NULL)
-        {
+    if (ret == 0) {
+        picoquic_cnx_t* cnx = picoquic_cnx_by_net(quic, (struct sockaddr*)&test4[3]);
+        if (cnx != NULL) {
             ret = -1;
         }
     }
 
     /* Delete connections first - middle - last. */
-    for (int i = 0; ret == 0 && i < 5; i += 2)
-    {
+    for (int i = 0; ret == 0 && i < 5; i += 2) {
         picoquic_delete_cnx(test_cnx[i]);
         test_cnx[i] = NULL;
     }
 
-    /* Verify that deleted connections cannot be retrieved, and the others can. */
+/* Verify that deleted connections cannot be retrieved, and the others can. */
 #if 0
     for (int i = 0; ret == 0 && i < 5; i++)
     {
@@ -194,23 +180,18 @@ int cnxcreation_test()
     }
 #endif
 
-    for (int i = 0; ret == 0 && i < 5; i++)
-    {
-        picoquic_cnx_t * cnx = picoquic_cnx_by_net(quic, test_cnx_addr[i]);
+    for (int i = 0; ret == 0 && i < 5; i++) {
+        picoquic_cnx_t* cnx = picoquic_cnx_by_net(quic, test_cnx_addr[i]);
 
-        if (cnx != NULL && (i & 1) == 0)
-        {
+        if (cnx != NULL && (i & 1) == 0) {
             ret = -1;
-        }
-        else if (cnx == NULL && (i & 1) != 0)
-        {
+        } else if (cnx == NULL && (i & 1) != 0) {
             ret = -1;
         }
     }
 
     /* delete QUIC context. */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         picoquic_free(quic);
     }
 

--- a/picoquictest/float16test.c
+++ b/picoquictest/float16test.c
@@ -44,10 +44,10 @@ struct _float16test_st {
 };
 
 static struct _float16test_st float16_test_case[] = {
-    { 0, 0, 0},
-    { 1, 1, 1},
-    { 0x7FF, 0x7FF, 0x7FF},
-    { 0x800, 0x800, 0x800},
+    { 0, 0, 0 },
+    { 1, 1, 1 },
+    { 0x7FF, 0x7FF, 0x7FF },
+    { 0x800, 0x800, 0x800 },
     { 0x801, 0x801, 0x801 },
     { 0xFFF, 0xFFF, 0xFFF },
     { 0x1000, 0x1000, 0x1000 },
@@ -67,17 +67,13 @@ int float16test()
 {
     int ret = 0;
 
-    for (size_t i = 0; ret == 0 && i < nb_float16_test_case; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_float16_test_case; i++) {
         uint16_t encoded = picoquic_deltat_to_float16(float16_test_case[i].n64);
         uint64_t decoded = picoquic_float16_to_deltat(float16_test_case[i].f16);
 
-        if (encoded != float16_test_case[i].f16)
-        {
+        if (encoded != float16_test_case[i].f16) {
             ret = -1;
-        }
-        else if (decoded != float16_test_case[i].n64_decoded)
-        {
+        } else if (decoded != float16_test_case[i].n64_decoded) {
             ret = -1;
         }
     }

--- a/picoquictest/fnv1atest.c
+++ b/picoquictest/fnv1atest.c
@@ -19,9 +19,9 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <stdlib.h>
-#include <stdint.h>
 #include "../picoquic/fnv1a.h"
+#include <stdint.h>
+#include <stdlib.h>
 
 int fnv1atest()
 {
@@ -31,53 +31,40 @@ int fnv1atest()
     size_t coded_length;
     size_t decoded_length;
 
-
-
     /* try some test length at various alignments */
-    for (test_length = 496; ret==0 && test_length < 504; test_length++)
-    {
+    for (test_length = 496; ret == 0 && test_length < 504; test_length++) {
         /* initialize bytes to some value */
-        for (size_t i = 0; i < sizeof(bytes); i++)
-        {
+        for (size_t i = 0; i < sizeof(bytes); i++) {
             bytes[i] = (uint8_t)(i + 'A');
         }
 
         /* try some invalid max length */
-        for (size_t x = 0; ret == 0 && x < 8; x++)
-        {
+        for (size_t x = 0; ret == 0 && x < 8; x++) {
             coded_length = fnv1a_protect(bytes, test_length, test_length + x);
 
-            if (coded_length != 0)
-            {
+            if (coded_length != 0) {
                 ret = -1;
             }
         }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             /* try with valid max length */
             coded_length = fnv1a_protect(bytes, test_length, sizeof(bytes));
 
-            if (coded_length == 0)
-            {
+            if (coded_length == 0) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 decoded_length = fnv1a_check(bytes, coded_length);
 
-                if (decoded_length != test_length)
-                {
+                if (decoded_length != test_length) {
                     ret = -1;
                 }
             }
         }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             /* try  content errors */
-            for (size_t j = 0; j < test_length; j+=7)
-            {
+            for (size_t j = 0; j < test_length; j += 7) {
                 uint8_t old_byte = bytes[j];
 
                 bytes[j] ^= 1;
@@ -86,11 +73,10 @@ int fnv1atest()
 
                 bytes[j] = old_byte;
 
-                if (decoded_length != 0)
-                {
+                if (decoded_length != 0) {
                     ret = -1;
                 }
-            } 
+            }
         }
     }
 

--- a/picoquictest/hashtest.c
+++ b/picoquictest/hashtest.c
@@ -25,32 +25,30 @@
 #endif
 #include "../picoquic/picohash.h"
 
-struct hashtestkey
-{
+struct hashtestkey {
     uint64_t x;
 };
 
-static uint64_t hashtest_hash(void * v)
+static uint64_t hashtest_hash(void* v)
 {
-    struct hashtestkey * k = (struct hashtestkey *) v;
+    struct hashtestkey* k = (struct hashtestkey*)v;
     uint64_t hash = (k->x + 0xDEADBEEFull);
     return hash;
 }
 
-static int hashtest_compare(void * v1, void *v2)
+static int hashtest_compare(void* v1, void* v2)
 {
-    struct hashtestkey * k1 = (struct hashtestkey *) v1;
-    struct hashtestkey * k2 = (struct hashtestkey *) v2;
+    struct hashtestkey* k1 = (struct hashtestkey*)v1;
+    struct hashtestkey* k2 = (struct hashtestkey*)v2;
 
     return (k1->x == k2->x) ? 0 : -1;
 }
 
-static struct hashtestkey * hashtest_item(uint64_t x)
+static struct hashtestkey* hashtest_item(uint64_t x)
 {
-    struct hashtestkey * p = (struct hashtestkey *) malloc(sizeof(struct hashtestkey));
+    struct hashtestkey* p = (struct hashtestkey*)malloc(sizeof(struct hashtestkey));
 
-    if (p != NULL)
-    {
+    if (p != NULL) {
         p->x = x;
     }
 
@@ -61,89 +59,72 @@ int picohash_test()
 {
     /* Create a hash table */
     int ret = 0;
-    picohash_table * t = picohash_create(32, hashtest_hash, hashtest_compare);
+    picohash_table* t = picohash_create(32, hashtest_hash, hashtest_compare);
 
-    if (t == NULL)
-    {
+    if (t == NULL) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         struct hashtestkey hk;
 
         /* Enter a bunch of values, all different */
-        for (uint64_t i = 1; ret == 0 && i < 10; i += 2)
-        {
+        for (uint64_t i = 1; ret == 0 && i < 10; i += 2) {
             ret = picohash_insert(t, hashtest_item(i));
         }
 
         /* Test whether each value can be retrieved */
-        for (uint64_t i = 1; ret == 0 && i < 10; i += 2)
-        {
+        for (uint64_t i = 1; ret == 0 && i < 10; i += 2) {
             hk.x = i;
-            picohash_item * pi = picohash_retrieve(t, &hk);
+            picohash_item* pi = picohash_retrieve(t, &hk);
 
-            if (pi == NULL)
-            {
+            if (pi == NULL) {
                 ret = -1;
             }
         }
 
         /* Create a bunch of collisions */
-        for (uint64_t k = 1; ret == 0 && k < 6; k += 4)
-        {
-            for (uint64_t j = 1; ret == 0 && j <= k; j++)
-            {
+        for (uint64_t k = 1; ret == 0 && k < 6; k += 4) {
+            for (uint64_t j = 1; ret == 0 && j <= k; j++) {
                 ret = picohash_insert(t, hashtest_item(k + 32 * j));
             }
         }
 
         /* Check that the collisions can be retrieved */
-        for (uint64_t k = 1; ret == 0 && k < 6; k += 4)
-        {
-            for (uint64_t j = 1; ret == 0 && j <= k; j++)
-            {
+        for (uint64_t k = 1; ret == 0 && k < 6; k += 4) {
+            for (uint64_t j = 1; ret == 0 && j <= k; j++) {
                 hk.x = k + 32 * j;
-                picohash_item * pi = picohash_retrieve(t, &hk);
+                picohash_item* pi = picohash_retrieve(t, &hk);
 
                 ret = (pi != NULL) ? 0 : -1;
             }
         }
 
         /* Test whether different values cannot be retrieved */
-        for (uint64_t i = 0; ret == 0 && i <= 10; i += 2)
-        {
+        for (uint64_t i = 0; ret == 0 && i <= 10; i += 2) {
             hk.x = i;
-            picohash_item * pi = picohash_retrieve(t, &hk);
+            picohash_item* pi = picohash_retrieve(t, &hk);
 
-            ret = (pi == NULL)?0:-1;
+            ret = (pi == NULL) ? 0 : -1;
         }
 
         /* Delete first, last and middle */
-        for (uint64_t i = 1; ret == 0 && i < 10; i += 4)
-        {
+        for (uint64_t i = 1; ret == 0 && i < 10; i += 4) {
             hk.x = i;
-            picohash_item * pi = picohash_retrieve(t, &hk);
+            picohash_item* pi = picohash_retrieve(t, &hk);
 
-            if (pi == NULL)
-            {
+            if (pi == NULL) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 picohash_item_delete(t, pi, 1);
             }
         }
 
         /* Check that the deleted are gone */
 
-        for (uint64_t i = 1; ret == 0 && i < 10; i += 4)
-        {
+        for (uint64_t i = 1; ret == 0 && i < 10; i += 4) {
             hk.x = i;
-            picohash_item * pi = picohash_retrieve(t, &hk);
+            picohash_item* pi = picohash_retrieve(t, &hk);
 
-            if (pi != NULL)
-            {
+            if (pi != NULL) {
                 ret = -1;
             }
         }

--- a/picoquictest/http0dot9test.c
+++ b/picoquictest/http0dot9test.c
@@ -3,35 +3,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+int http0dot9_get(uint8_t* command, size_t command_length,
+    uint8_t* response, size_t response_max, size_t* response_length);
 
-int http0dot9_get(uint8_t * command, size_t command_length,
-    uint8_t * response, size_t response_max, size_t *response_length);
-
-
-int http0dot9_test_one(char const * command, int expected_ret, size_t expected_length,
-    char const * fileName)
+int http0dot9_test_one(char const* command, int expected_ret, size_t expected_length,
+    char const* fileName)
 {
     int ret = 0;
     int c_ret = 0;
     const size_t big_size = 1 << 20;
-    uint8_t * big_buffer = (uint8_t *)malloc(big_size);
+    uint8_t* big_buffer = (uint8_t*)malloc(big_size);
     size_t content_length = 0;
 
-    if (big_buffer == NULL)
-    {
+    if (big_buffer == NULL) {
         ret = -1;
-    }
-    else
-    {
-        c_ret = http0dot9_get((uint8_t *)command, strlen(command), big_buffer, big_size, &content_length);
+    } else {
+        c_ret = http0dot9_get((uint8_t*)command, strlen(command), big_buffer, big_size, &content_length);
 
-        if (c_ret != expected_ret || content_length != expected_length)
-        {
+        if (c_ret != expected_ret || content_length != expected_length) {
             ret = -1;
-        }
-        else if (c_ret == 0 && fileName != 0)
-        {
-            FILE * F = NULL;
+        } else if (c_ret == 0 && fileName != 0) {
+            FILE* F = NULL;
 #ifdef _WINDOWS
             errno_t err = fopen_s(&F, fileName, "w");
             if (err != 0) {
@@ -44,8 +36,7 @@ int http0dot9_test_one(char const * command, int expected_ret, size_t expected_l
             }
 #endif
 
-            if (ret == 0)
-            {
+            if (ret == 0) {
                 (void)fwrite(big_buffer, 1, content_length, F);
 
                 fclose(F);
@@ -62,48 +53,39 @@ int http0dot9_test()
     int ret = 0;
     const size_t index_html_size = 558;
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get /", 0, index_html_size, "http09_index.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get /\r\n", 0, index_html_size, "http09_index2.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get / HTTP/0.9", 0, index_html_size, "http09_index.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get / HTTP/0.9\r\n", 0, index_html_size, "http09_index.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get index.html", 0, index_html_size, "http09_index3.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get doc-12345.html", 0, 12345, "http09_12345.html");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get doc-1234.txt", 0, 1234, "http09_1234.txt");
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("post 12345.html", -1, 0, NULL);
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = http0dot9_test_one("get nosuch.html", -1, 0, NULL);
     }
 

--- a/picoquictest/intformattest.c
+++ b/picoquictest/intformattest.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <string.h>
 #include "../picoquic/picoquic_internal.h"
+#include <string.h>
 
 static const uint64_t test_number[] = {
     0,
@@ -32,12 +32,11 @@ static const uint64_t test_number[] = {
 
 static size_t nb_test_numbers = sizeof(test_number) / sizeof(const uint64_t);
 
-static uint64_t decode_number(uint8_t * bytes, size_t length)
+static uint64_t decode_number(uint8_t* bytes, size_t length)
 {
     uint64_t n = 0;
 
-    for (size_t i = 0; i < length; i++)
-    {
+    for (size_t i = 0; i < length; i++) {
         n <<= 8;
 
         n += bytes[i];
@@ -58,60 +57,45 @@ int intformattest()
     uint64_t test64;
 
     /* First test with 16 bits macros */
-    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++) {
         test16 = (uint16_t)test_number[i];
         picoformat_16(bytes, test16);
         decoded = decode_number(bytes, 2);
-        if (decoded != test16)
-        {
+        if (decoded != test16) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             parsed = PICOPARSE_16(bytes);
-            if (parsed != test16)
-            {
+            if (parsed != test16) {
                 ret = -1;
             }
         }
     }
 
     /* Next test with 32 bits macros */
-    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++) {
         test32 = (uint32_t)test_number[i];
         picoformat_32(bytes, test32);
         decoded = decode_number(bytes, 4);
-        if (decoded != test32)
-        {
+        if (decoded != test32) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             parsed = PICOPARSE_32(bytes);
-            if (parsed != test32)
-            {
+            if (parsed != test32) {
                 ret = -1;
             }
         }
     }
 
     /* Final test with 64 bits macros */
-    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_numbers; i++) {
         test64 = test_number[i];
         picoformat_64(bytes, test64);
         decoded = decode_number(bytes, 8);
-        if (decoded != test64)
-        {
+        if (decoded != test64) {
             ret = -1;
-        }
-        else
-        {
+        } else {
             parsed = PICOPARSE_64(bytes);
-            if (parsed != test64)
-            {
+            if (parsed != test64) {
                 ret = -1;
             }
         }
@@ -128,60 +112,42 @@ typedef struct st_picoquic_varintformat_test_t {
 } picoquic_varintformat_test_t;
 
 static picoquic_varintformat_test_t varint_test_cases[] = {
-    {
-        {0, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
+    { { 0, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
         1,
         0,
-        1
-    },
-    {
-        { 1, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 1, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
         1,
         1,
-        1
-    },
-    {
-        { 63, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 63, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
         1,
         63,
-        1
-    },
-    {
-        { 0x40, 64, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 0x40, 64, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
         2,
         64,
-        1
-    },
-    {
-        { 0x7F, 0xFF, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 0x7F, 0xFF, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC, 0xCC },
         2,
         0x3FFF,
-        1
-    },
-    {
-        { 0x80, 0, 0x40, 0, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 0x80, 0, 0x40, 0, 0xCC, 0xCC, 0xCC, 0xCC },
         4,
         0x4000,
-        1
-    },
-    {
-        { 0xBF, 0xFF, 0xFF, 0xFF, 0xCC, 0xCC, 0xCC, 0xCC },
+        1 },
+    { { 0xBF, 0xFF, 0xFF, 0xFF, 0xCC, 0xCC, 0xCC, 0xCC },
         4,
         0x3FFFFFFF,
-        1
-    },
-    {
-        { 0xC0, 0, 0, 0, 0x40, 0, 0, 0 },
+        1 },
+    { { 0xC0, 0, 0, 0, 0x40, 0, 0, 0 },
         8,
         0x40000000,
-        1
-    },
-    {
-        { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+        1 },
+    { { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
         8,
         0x3FFFFFFFFFFFFFFFull,
-        1
-    },
+        1 },
     /* For example, the eight octet sequence c2 19 7c 5e ff 14 e8 8c (in hexadecimal) 
      * decodes to the decimal value 151288809941952652; 
      * the four octet sequence 9d 7f 3e 7d decodes to 494878333; 
@@ -191,50 +157,35 @@ static picoquic_varintformat_test_t varint_test_cases[] = {
         { 0xc2, 0x19, 0x7c, 0x5e, 0xff, 0x14, 0xe8, 0x8c },
         8,
         151288809941952652ull,
-        1
-    },
-    {
-        { 0x9d, 0x7f, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
+        1 },
+    { { 0x9d, 0x7f, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
         4,
         494878333,
-        1
-    },
-    {
-        { 0xC0, 0, 0, 0, 0x1d, 0x7f, 0x3e, 0x7d },
+        1 },
+    { { 0xC0, 0, 0, 0, 0x1d, 0x7f, 0x3e, 0x7d },
         8,
         494878333,
-        0
-    },
-    {
-        { 0x7b, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
+        0 },
+    { { 0x7b, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
         2,
         15293,
-        1
-    },
-    {
-        { 0x80, 0, 0x3b, 0xbd, 0x3e, 0x7d, 0xff, 0x14 },
+        1 },
+    { { 0x80, 0, 0x3b, 0xbd, 0x3e, 0x7d, 0xff, 0x14 },
         4,
         15293,
-        0
-    },
-    {
-        { 0xC0, 0, 0, 0, 0, 0, 0x3b, 0xbd },
+        0 },
+    { { 0xC0, 0, 0, 0, 0, 0, 0x3b, 0xbd },
         8,
         15293,
-        0
-    },
-    {
-        { 0x25, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
+        0 },
+    { { 0x25, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8, 0x8c },
         1,
         37,
-        1
-    },
-    {
-        { 0x40, 0x25, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8 },
+        1 },
+    { { 0x40, 0x25, 0xbd, 0x3e, 0x7d, 0xff, 0x14, 0xe8 },
         2,
         37,
-        0
-    }
+        0 }
 };
 
 static size_t nb_varint_test_cases = sizeof(varint_test_cases) / sizeof(picoquic_varintformat_test_t);
@@ -243,36 +194,28 @@ int varint_test()
 {
     int ret = 0;
 
-    for (size_t i = 0; i < nb_varint_test_cases; i++)
-    {
+    for (size_t i = 0; i < nb_varint_test_cases; i++) {
         uint64_t n64;
         size_t length = picoquic_varint_decode(
             varint_test_cases[i].encoding, 8, &n64);
 
-        if (length != varint_test_cases[i].length)
-        {
+        if (length != varint_test_cases[i].length) {
             ret = -1;
-        }
-        else if (n64 != varint_test_cases[i].decoded)
-        {
+        } else if (n64 != varint_test_cases[i].decoded) {
             ret = -1;
-        }
-        else if (varint_test_cases[i].is_canonical != 0)
-        {
+        } else if (varint_test_cases[i].is_canonical != 0) {
             uint8_t encoding[8];
             size_t coded_length = picoquic_varint_encode(
                 encoding,
                 varint_test_cases[i].length,
                 n64);
 
-            if (coded_length != varint_test_cases[i].length)
-            {
+            if (coded_length != varint_test_cases[i].length) {
                 ret = -1;
-            }
-            else if (memcmp(encoding,
-                varint_test_cases[i].encoding,
-                coded_length) != 0)
-            {
+            } else if (memcmp(encoding,
+                           varint_test_cases[i].encoding,
+                           coded_length)
+                != 0) {
                 ret = -1;
             }
         }

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -19,24 +19,24 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "../picoquic/picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
-#include "../picoquic/picoquic_internal.h"
 
 /* test vectors and corresponding structure */
 
-#define TEST_CNXID_INI_BYTES  0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 
-#define TEST_CNXID_INI_VAL    0x0001020304050607ull
+#define TEST_CNXID_INI_BYTES 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07
+#define TEST_CNXID_INI_VAL 0x0001020304050607ull
 
-#define TEST_CNXID_07_BYTES  0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
-#define TEST_CNXID_07_VAL    0x0102030405060708ull
+#define TEST_CNXID_07_BYTES 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+#define TEST_CNXID_07_VAL 0x0102030405060708ull
 
 /*
  * New definitions
  */
 
-#define TEST_CNXID_08_BYTES  0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09
-#define TEST_CNXID_08_VAL    0x0203040506070809ull
+#define TEST_CNXID_08_BYTES 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09
+#define TEST_CNXID_08_VAL 0x0203040506070809ull
 
 static uint8_t pinitial08[] = {
     0xFF,
@@ -129,7 +129,6 @@ static picoquic_packet_header hphi1_c_8_08 = {
     0, 0
 };
 
-
 static uint8_t packet_short_phi0_noc_16_08[] = {
     0x5E,
     0xBE, 0xEF,
@@ -161,17 +160,17 @@ static picoquic_packet_header hphi0_noc_8_08 = {
 };
 
 struct _test_entry {
-    uint8_t * packet;
+    uint8_t* packet;
     size_t length;
-    picoquic_packet_header * ph;
+    picoquic_packet_header* ph;
 };
 
 static struct _test_entry test_entries[] = {
-    { pinitial08 , sizeof(pinitial08), &hinitial08 },
-    { pvnego08, sizeof(pvnego08), &hvnego08},
+    { pinitial08, sizeof(pinitial08), &hinitial08 },
+    { pvnego08, sizeof(pvnego08), &hvnego08 },
     { pvnegobis08, sizeof(pvnegobis08), &hvnego08 },
     { packet_short_phi0_c_32_08, sizeof(packet_short_phi0_c_32_08), &hphi0_c_32_08 },
-    { packet_short_phi1_c_16_08 , sizeof(packet_short_phi1_c_16_08), &hphi1_c_16_08 },
+    { packet_short_phi1_c_16_08, sizeof(packet_short_phi1_c_16_08), &hphi1_c_16_08 },
     { packet_short_phi1_c_8_08, sizeof(packet_short_phi1_c_8_08), &hphi1_c_8_08 },
     { packet_short_phi0_noc_16_08, sizeof(packet_short_phi0_noc_16_08), &hphi0_noc_16_08 },
     { packet_short_phi0_noc_8_08, sizeof(packet_short_phi0_noc_8_08), &hphi0_noc_8_08 }
@@ -183,11 +182,10 @@ int parseheadertest()
 {
     int ret = 0;
     picoquic_packet_header ph;
-    picoquic_quic_t * quic = NULL;
-    picoquic_cnx_t * cnx_08 = NULL;
+    picoquic_quic_t* quic = NULL;
+    picoquic_cnx_t* cnx_08 = NULL;
     struct sockaddr_in addr_08;
-    picoquic_cnx_t * pcnx;
-
+    picoquic_cnx_t* pcnx;
 
     /* Initialize the quic context and the connection contexts */
     memset(&addr_08, 0, sizeof(struct sockaddr_in));
@@ -202,38 +200,27 @@ int parseheadertest()
 
     quic = picoquic_create(8, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (quic == NULL)
-    {
+    if (quic == NULL) {
         ret = -1;
-    }
-    else
-    {
-        cnx_08 = picoquic_create_cnx(quic, TEST_CNXID_08_VAL, (struct sockaddr *) &addr_08,
+    } else {
+        cnx_08 = picoquic_create_cnx(quic, TEST_CNXID_08_VAL, (struct sockaddr*)&addr_08,
             0, PICOQUIC_INTERNAL_TEST_VERSION_1, NULL, NULL, 1);
 
-        if (cnx_08 == NULL)
-        {
+        if (cnx_08 == NULL) {
             ret = -1;
         }
     }
 
-    for (size_t i = 0; ret == 0 && i < nb_test_entries; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_entries; i++) {
         pcnx = NULL;
 
         if (picoquic_parse_packet_header(quic, test_entries[i].packet, (uint32_t)test_entries[i].length,
-            (struct sockaddr *)&addr_08, &ph, &pcnx) != 0)
-        {
+                (struct sockaddr*)&addr_08, &ph, &pcnx)
+            != 0) {
             ret = -1;
         }
 
-        if (ph.cnx_id != test_entries[i].ph->cnx_id ||
-            ph.pn != test_entries[i].ph->pn ||
-            ph.vn != test_entries[i].ph->vn ||
-            ph.offset != test_entries[i].ph->offset ||
-            ph.ptype != test_entries[i].ph->ptype ||
-            ph.pnmask != test_entries[i].ph->pnmask)
-        {
+        if (ph.cnx_id != test_entries[i].ph->cnx_id || ph.pn != test_entries[i].ph->pn || ph.vn != test_entries[i].ph->vn || ph.offset != test_entries[i].ph->offset || ph.ptype != test_entries[i].ph->ptype || ph.pnmask != test_entries[i].ph->pnmask) {
             ret = -1;
         }
     }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -22,66 +22,66 @@
 #ifndef PICOQUICTEST_H
 #define PICOQUICTEST_H
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
-    int picohash_test();
-    int cnxcreation_test();
-    int parseheadertest();
-    int pn2pn64test();
-    int intformattest();
-    int fnv1atest();
-    int sacktest();
-    int float16test();
-    int StreamZeroFrameTest();
-	int sendacktest();
-    int tls_api_test();
-    int tls_api_silence_test();
-	int tls_api_loss_test(uint64_t mask);
-    int tls_api_client_first_loss_test();
-    int tls_api_client_second_loss_test();
-	int tls_api_many_losses();
-	int tls_api_version_negotiation_test();
-	int transport_param_test();
-	int tls_api_sni_test();
-	int tls_api_alpn_test();
-	int tls_api_wrong_alpn_test();
-	int tls_api_oneway_stream_test();
-	int tls_api_q_and_r_stream_test();
-	int tls_api_q2_and_r2_stream_test();
-	int tls_api_server_reset_test();
-	int tls_api_bad_server_reset_test();
-	int sim_link_test();
-	int tls_api_very_long_stream_test();
-	int tls_api_very_long_max_test();
-	int tls_api_very_long_with_err_test();
-	int tls_api_very_long_congestion_test();
-    int http0dot9_test();
-    int tls_api_hrr_test();
-    int ackrange_test();
-    int ack_of_ack_test();
-    int tls_api_two_connections_test();
-    int cleartext_aead_test();
-    int tls_api_multiple_versions_test();
-    int varint_test();
-    int tls_api_client_losses_test();
-    int tls_api_server_losses_test();
-    int skip_frame_test();
-    int ping_pong_test();
-    int logger_test();
-    int transport_parameter_client_error_test();
-    int socket_test();
-    int ticket_store_test();
-    int session_resume_test();
-    int zero_rtt_test();
-    int stop_sending_test();
-    int unidir_test();
-    int mtu_discovery_test();
-    int spurious_retransmit_test();
-    int wrong_keyshare_test();
+int picohash_test();
+int cnxcreation_test();
+int parseheadertest();
+int pn2pn64test();
+int intformattest();
+int fnv1atest();
+int sacktest();
+int float16test();
+int StreamZeroFrameTest();
+int sendacktest();
+int tls_api_test();
+int tls_api_silence_test();
+int tls_api_loss_test(uint64_t mask);
+int tls_api_client_first_loss_test();
+int tls_api_client_second_loss_test();
+int tls_api_many_losses();
+int tls_api_version_negotiation_test();
+int transport_param_test();
+int tls_api_sni_test();
+int tls_api_alpn_test();
+int tls_api_wrong_alpn_test();
+int tls_api_oneway_stream_test();
+int tls_api_q_and_r_stream_test();
+int tls_api_q2_and_r2_stream_test();
+int tls_api_server_reset_test();
+int tls_api_bad_server_reset_test();
+int sim_link_test();
+int tls_api_very_long_stream_test();
+int tls_api_very_long_max_test();
+int tls_api_very_long_with_err_test();
+int tls_api_very_long_congestion_test();
+int http0dot9_test();
+int tls_api_hrr_test();
+int ackrange_test();
+int ack_of_ack_test();
+int tls_api_two_connections_test();
+int cleartext_aead_test();
+int tls_api_multiple_versions_test();
+int varint_test();
+int tls_api_client_losses_test();
+int tls_api_server_losses_test();
+int skip_frame_test();
+int ping_pong_test();
+int logger_test();
+int transport_parameter_client_error_test();
+int socket_test();
+int ticket_store_test();
+int session_resume_test();
+int zero_rtt_test();
+int stop_sending_test();
+int unidir_test();
+int mtu_discovery_test();
+int spurious_retransmit_test();
+int wrong_keyshare_test();
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -24,12 +24,11 @@
 
 #include "../picoquic/picoquic_internal.h"
 
-#ifdef  __cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
-
-	/*
+/*
 	 * Really basic network simulator, only simulates a simple link using a
 	 * packet structure.
 	 * Init: link creation. Returns a link structure with defined bandwidth,
@@ -39,42 +38,42 @@ extern "C" {
 	 * Get packet out of link at time T + L + Queue.
 	 */
 
-	typedef struct st_picoquictest_sim_packet_t {
-		struct st_picoquictest_sim_packet_t * next_packet;
-		uint64_t sent_time;
-		uint64_t arrival_time;
-		size_t length;
-		uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
-	} picoquictest_sim_packet_t;
+typedef struct st_picoquictest_sim_packet_t {
+    struct st_picoquictest_sim_packet_t* next_packet;
+    uint64_t sent_time;
+    uint64_t arrival_time;
+    size_t length;
+    uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
+} picoquictest_sim_packet_t;
 
-	typedef struct st_picoquictest_sim_link_t {
-		uint64_t next_send_time;
-		uint64_t queue_time;
-		uint64_t queue_delay_max;
-		uint64_t picosec_per_byte;
-		uint64_t microsec_latency;
-		uint64_t *loss_mask;
-		uint64_t packets_dropped;
-		uint64_t packets_sent;
-		picoquictest_sim_packet_t * first_packet;
-		picoquictest_sim_packet_t * last_packet;
-	} picoquictest_sim_link_t;
+typedef struct st_picoquictest_sim_link_t {
+    uint64_t next_send_time;
+    uint64_t queue_time;
+    uint64_t queue_delay_max;
+    uint64_t picosec_per_byte;
+    uint64_t microsec_latency;
+    uint64_t* loss_mask;
+    uint64_t packets_dropped;
+    uint64_t packets_sent;
+    picoquictest_sim_packet_t* first_packet;
+    picoquictest_sim_packet_t* last_packet;
+} picoquictest_sim_link_t;
 
-	picoquictest_sim_link_t * picoquictest_sim_link_create(double data_rate_in_gps,
-		uint64_t microsec_latency, uint64_t * loss_mask, uint64_t queue_delay_max, uint64_t current_time);
+picoquictest_sim_link_t* picoquictest_sim_link_create(double data_rate_in_gps,
+    uint64_t microsec_latency, uint64_t* loss_mask, uint64_t queue_delay_max, uint64_t current_time);
 
-	void picoquictest_sim_link_delete(picoquictest_sim_link_t * link);
+void picoquictest_sim_link_delete(picoquictest_sim_link_t* link);
 
-	picoquictest_sim_packet_t * picoquictest_sim_link_create_packet();
+picoquictest_sim_packet_t* picoquictest_sim_link_create_packet();
 
-	uint64_t picoquictest_sim_link_next_arrival(picoquictest_sim_link_t * link, uint64_t current_time);
+uint64_t picoquictest_sim_link_next_arrival(picoquictest_sim_link_t* link, uint64_t current_time);
 
-	picoquictest_sim_packet_t * picoquictest_sim_link_dequeue(picoquictest_sim_link_t * link,
-		uint64_t current_time);
+picoquictest_sim_packet_t* picoquictest_sim_link_dequeue(picoquictest_sim_link_t* link,
+    uint64_t current_time);
 
-	void picoquictest_sim_link_submit(picoquictest_sim_link_t * link, picoquictest_sim_packet_t * packet,
-		uint64_t current_time);
-#ifdef  __cplusplus
+void picoquictest_sim_link_submit(picoquictest_sim_link_t* link, picoquictest_sim_packet_t* packet,
+    uint64_t current_time);
+#ifdef __cplusplus
 }
 #endif
 

--- a/picoquictest/pn2pn64test.c
+++ b/picoquictest/pn2pn64test.c
@@ -22,8 +22,7 @@
 #include "../picoquic/picoquic_internal.h"
 #include <stdlib.h>
 
-struct _pn2pn64test_entry
-{
+struct _pn2pn64test_entry {
     uint64_t highest;
     uint64_t mask;
     uint32_t pn;
@@ -31,7 +30,7 @@ struct _pn2pn64test_entry
 };
 
 static struct _pn2pn64test_entry test_entries[] = {
-    { 0x10000, 0xFFFFFFFFFFFF0000ull, 0x8000, 0x18000},
+    { 0x10000, 0xFFFFFFFFFFFF0000ull, 0x8000, 0x18000 },
     { 0xFFFE, 0xFFFFFFFFFFFF0000ull, 0x8000, 0x8000 },
     { 0xFFFF, 0xFFFFFFFFFFFF0000ull, 0x8000, 0x8000 },
     { 0xDEADBEEF, 0xFFFFFFFF00000000ull, 0xDEADBEF0, 0xDEADBEF0 },
@@ -67,15 +66,13 @@ int pn2pn64test()
 {
     int ret = 0;
 
-    for (size_t i = 0; i < nb_test_entries; i++)
-    {
+    for (size_t i = 0; i < nb_test_entries; i++) {
         uint64_t pn64 = picoquic_get_packet_number64(
             test_entries[i].highest,
             test_entries[i].mask,
             test_entries[i].pn);
 
-        if (pn64 != test_entries[i].expected)
-        {
+        if (pn64 != test_entries[i].expected) {
             ret = -1;
         }
     }

--- a/picoquictest/sacktest.c
+++ b/picoquictest/sacktest.c
@@ -19,10 +19,9 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "../picoquic/picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
-#include <stdlib.h>
-#include "../picoquic/picoquic_internal.h"
 
 /*
  * Test of the SACK functionality
@@ -34,33 +33,31 @@ static const uint64_t test_pn64[] = {
 
 static const size_t nb_test_pn64 = sizeof(test_pn64) / sizeof(uint64_t);
 
-struct expected_ack_t
-{
+struct expected_ack_t {
     uint64_t highest_received;
     uint64_t last_range;
     uint8_t num_blocks;
 };
 
-static struct expected_ack_t expected_ack[] =
-{
-    {3, 0, 0},
-    {4, 1, 0},
-    {4, 2, 0},
-    {7, 0, 1},
-    {8, 1, 1},
-    {11, 0, 2},
+static struct expected_ack_t expected_ack[] = {
+    { 3, 0, 0 },
+    { 4, 1, 0 },
+    { 4, 2, 0 },
+    { 7, 0, 1 },
+    { 8, 1, 1 },
+    { 11, 0, 2 },
     { 12, 1, 2 },
     { 13, 2, 2 },
     { 17, 0, 3 },
-    {19, 0, 4},
-    {21, 0, 5},
-    {21, 0, 4},
-    {21, 0, 4},
-    {21, 5, 3},
-    {21, 5, 3},
+    { 19, 0, 4 },
+    { 21, 0, 5 },
+    { 21, 0, 4 },
+    { 21, 0, 4 },
     { 21, 5, 3 },
-    {21, 5, 2},
-    {21, 5, 1},
+    { 21, 5, 3 },
+    { 21, 5, 3 },
+    { 21, 5, 2 },
+    { 21, 5, 1 },
     { 21, 5, 1 },
     { 21, 5, 1 },
     { 21, 20, 0 }
@@ -76,50 +73,37 @@ int sacktest()
 
     memset(&cnx, 0, sizeof(cnx));
 
-    for (size_t i = 0; ret == 0 && i < nb_test_pn64; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_pn64; i++) {
         current_time = i * 100;
 
-        if (test_pn64[i] > highest_seen)
-        {
+        if (test_pn64[i] > highest_seen) {
             highest_seen = test_pn64[i];
             highest_seen_time = current_time;
         }
 
-        if (picoquic_record_pn_received(&cnx, test_pn64[i], current_time) != 0)
-        {
+        if (picoquic_record_pn_received(&cnx, test_pn64[i], current_time) != 0) {
             ret = -1;
         }
 
-        for (size_t j = 0; ret == 0 && j <= i; j++)
-        {
-            if (picoquic_is_pn_already_received(&cnx, test_pn64[j]) == 0)
-            {
+        for (size_t j = 0; ret == 0 && j <= i; j++) {
+            if (picoquic_is_pn_already_received(&cnx, test_pn64[j]) == 0) {
                 ret = -1;
             }
 
-            if (picoquic_record_pn_received(&cnx, test_pn64[j], current_time) != 1)
-            {
+            if (picoquic_record_pn_received(&cnx, test_pn64[j], current_time) != 1) {
                 ret = -1;
             }
         }
 
-        for (size_t j = i+1; ret == 0 && j < nb_test_pn64; j++)
-        {
-            if (picoquic_is_pn_already_received(&cnx, test_pn64[j]) != 0)
-            {
+        for (size_t j = i + 1; ret == 0 && j < nb_test_pn64; j++) {
+            if (picoquic_is_pn_already_received(&cnx, test_pn64[j]) != 0) {
                 ret = -1;
             }
         }
     }
 
-    if (ret == 0)
-    {
-        if (cnx.first_sack_item.end_of_sack_range != 21 ||
-            cnx.first_sack_item.start_of_sack_range != 1 ||
-            cnx.time_stamp_largest_received != highest_seen_time ||
-            cnx.first_sack_item.next_sack != NULL)
-        {
+    if (ret == 0) {
+        if (cnx.first_sack_item.end_of_sack_range != 21 || cnx.first_sack_item.start_of_sack_range != 1 || cnx.time_stamp_largest_received != highest_seen_time || cnx.first_sack_item.next_sack != NULL) {
             ret = -1;
         }
     }
@@ -127,17 +111,16 @@ int sacktest()
     return ret;
 }
 
-static void ack_range_mask(uint64_t * mask, uint64_t highest, uint64_t range)
+static void ack_range_mask(uint64_t* mask, uint64_t highest, uint64_t range)
 {
-    for (uint64_t i = 0; i < range; i++)
-    {
+    for (uint64_t i = 0; i < range; i++) {
         *mask |= 1ull << (highest & 63);
         highest--;
     }
 }
 
-static int basic_ack_parse(uint8_t * bytes, size_t bytes_max,
-    struct expected_ack_t * expected_ack, uint64_t expected_mask,
+static int basic_ack_parse(uint8_t* bytes, size_t bytes_max,
+    struct expected_ack_t* expected_ack, uint64_t expected_mask,
     uint32_t version_flags)
 {
     int ret = 0;
@@ -154,124 +137,92 @@ static int basic_ack_parse(uint8_t * bytes, size_t bytes_max,
     size_t l_num_block = 0;
     size_t l_last_range = 0;
 
-    if (first_byte != picoquic_frame_type_ack)
-    {
+    if (first_byte != picoquic_frame_type_ack) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         /* Largest */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             l_largest = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &largest);
             byte_index += l_largest;
         }
 
         /* ACK delay */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             l_delay = picoquic_varint_skip(bytes + byte_index);
             byte_index += l_delay;
         }
 
         /* Num blocks */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             l_num_block = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &num_block);
             byte_index += l_num_block;
         }
 
         /* last range */
-        if (byte_index < bytes_max)
-        {
+        if (byte_index < bytes_max) {
             l_last_range = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &last_range);
             byte_index += l_last_range;
         }
 
-        if (l_largest == 0 || l_delay == 0 || l_num_block == 0 || l_last_range == 0 || byte_index > bytes_max)
-        {
+        if (l_largest == 0 || l_delay == 0 || l_num_block == 0 || l_last_range == 0 || byte_index > bytes_max) {
             ret = -1;
-        }
-        else
-        {
-            if (last_range < largest)
-            {
+        } else {
+            if (last_range < largest) {
                 ack_range_mask(&acked_mask, largest, last_range + 1);
                 gap_begin = largest - last_range - 1;
-            }
-            else
-            {
+            } else {
                 ret = -1;
             }
 
-            for (int i = 0; ret == 0 && i < num_block; i++)
-            {
+            for (int i = 0; ret == 0 && i < num_block; i++) {
                 size_t l_gap = 0;
                 size_t l_range = 0;
                 uint64_t gap;
 
                 /* Decode the gap */
-                if (byte_index < bytes_max)
-                {
+                if (byte_index < bytes_max) {
                     l_gap = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &gap);
                     byte_index += l_gap;
                 }
                 /* decode the range */
-                if (byte_index < bytes_max)
-                {
+                if (byte_index < bytes_max) {
                     l_range = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &ack_range);
                     byte_index += l_range;
                 }
-                if (l_gap == 0 || l_range == 0)
-                {
+                if (l_gap == 0 || l_range == 0) {
                     ret = -1;
-                }
-                else if (gap > gap_begin)
-                {
+                } else if (gap > gap_begin) {
                     ret = -1;
-                }
-                else
-                {
+                } else {
                     gap_begin -= gap;
 
-                    if (gap_begin >= ack_range)
-                    {
+                    if (gap_begin >= ack_range) {
                         /* mark the range as received */
                         ack_range_mask(&acked_mask, gap_begin, ack_range);
 
                         /* start of next gap */
                         gap_begin -= ack_range;
-                    }
-                    else
-                    {
+                    } else {
                         ret = -1;
                     }
                 }
             }
         }
 
-        if (ret == 0)
-        {
-            if (byte_index != bytes_max)
-            {
+        if (ret == 0) {
+            if (byte_index != bytes_max) {
                 ret = -1;
             }
         }
 
-        if (ret == 0)
-        {
-            if (largest != expected_ack->highest_received ||
-                last_range != expected_ack->last_range ||
-                num_block != expected_ack->num_blocks)
-            {
+        if (ret == 0) {
+            if (largest != expected_ack->highest_received || last_range != expected_ack->last_range || num_block != expected_ack->num_blocks) {
                 ret = -1;
             }
         }
 
-        if (ret == 0)
-        {
-            if (acked_mask != expected_mask)
-            {
+        if (ret == 0) {
+            if (acked_mask != expected_mask) {
                 ret = -1;
             }
         }
@@ -291,25 +242,21 @@ int sendacktest()
 
     memset(&cnx, 0, sizeof(cnx));
 
-    for (size_t i = 0; ret == 0 && i < nb_test_pn64; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < nb_test_pn64; i++) {
         current_time = i * 100;
 
-        if (picoquic_record_pn_received(&cnx, test_pn64[i], current_time) != 0)
-        {
+        if (picoquic_record_pn_received(&cnx, test_pn64[i], current_time) != 0) {
             ret = -1;
         }
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             consumed = 0;
             ret = picoquic_prepare_ack_frame(&cnx, 0, bytes, sizeof(bytes), &consumed);
 
             received_mask |= 1ull << (test_pn64[i] & 63);
 
-            if (ret == 0)
-            {
-            	ret = basic_ack_parse(bytes, consumed, &expected_ack[i], received_mask,
+            if (ret == 0) {
+                ret = basic_ack_parse(bytes, consumed, &expected_ack[i], received_mask,
                     picoquic_supported_versions[cnx.version_index].version_flags);
             }
         }
@@ -318,21 +265,20 @@ int sendacktest()
     return ret;
 }
 
-typedef struct st_test_ack_range_t
-{
+typedef struct st_test_ack_range_t {
     uint64_t range_min;
     uint64_t range_max;
 } test_ack_range_t;
 
 static const test_ack_range_t ack_range[] = {
     { 0, 1000 },
-    { 3001, 4000},
-    { 4001, 5000},
-    { 6001, 7000},
-    { 5001, 6000},
-    { 1501, 2500},
-    { 501, 1500},
-    { 501, 7500}
+    { 3001, 4000 },
+    { 4001, 5000 },
+    { 6001, 7000 },
+    { 5001, 6000 },
+    { 1501, 2500 },
+    { 501, 1500 },
+    { 501, 7500 }
 };
 
 static const size_t nb_ack_range = sizeof(ack_range) / sizeof(test_ack_range_t);
@@ -345,50 +291,42 @@ int ackrange_test()
 
     memset(&sack0, 0, sizeof(picoquic_sack_item_t));
 
-    for (size_t i = 0; i < nb_ack_range; i++)
-    {
+    for (size_t i = 0; i < nb_ack_range; i++) {
         ret = picoquic_check_sack_list(&sack0,
             ack_range[i].range_min, ack_range[i].range_max);
 
-        if (ret == 0)
-        {
+        if (ret == 0) {
             ret = picoquic_update_sack_list(&sack0,
                 ack_range[i].range_min, ack_range[i].range_max, &blockmax);
         }
 
-        for (size_t j = 0; j < i; j++)
-        {
+        for (size_t j = 0; j < i; j++) {
             if (picoquic_check_sack_list(&sack0,
-                ack_range[j].range_min, ack_range[j].range_max) == 0)
-            {
+                    ack_range[j].range_min, ack_range[j].range_max)
+                == 0) {
                 ret = -1;
                 break;
             }
         }
 
-        if (ret != 0)
-        {
+        if (ret != 0) {
             break;
         }
     }
 
-    if (ret == 0 && blockmax != 7500)
-    {
+    if (ret == 0 && blockmax != 7500) {
         ret = -1;
     }
 
-    if (ret == 0 && sack0.start_of_sack_range != 0)
-    {
+    if (ret == 0 && sack0.start_of_sack_range != 0) {
         ret = -1;
     }
 
-    if (ret == 0 && sack0.end_of_sack_range != 7500)
-    {
+    if (ret == 0 && sack0.end_of_sack_range != 7500) {
         ret = -1;
     }
 
-    if (ret == 0 && sack0.next_sack != NULL)
-    {
+    if (ret == 0 && sack0.next_sack != NULL) {
         ret = -1;
     }
 

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -25,7 +25,6 @@
  * Testing Arrival of Frame for Stream Zero
  */
 
-
 /*
  * New definitions, using variable int coding.
  */
@@ -33,21 +32,21 @@
 static uint8_t v0_1[] = {
     0x10, /* Start Byte: F=0, Len=0, Off=0 */
     0, /* One byte stream ID */
-    1 , 2, 3, 4, 5, 6, 7, 8, 9, 10 /* Some random data */
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10 /* Some random data */
 };
 
 static uint8_t v0_2[] = {
     0x14, /* Start Byte: F=0, Len=0, Off=4 */
     0, /* One byte stream ID */
     10, /* One byte offset */
-    11 , 12, 13, 14, 15, 16, 17, 18, 19, 20 /* Some random data */
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20 /* Some random data */
 };
 
 static uint8_t v0_3[] = {
     0x14, /* Start Byte: F=0, Len=0, Off=4 */
     0x40, 0, /* Two  byte stream ID, still 0 */
     0x40, 20, /* Two byte offset */
-    21 , 22, 23, 24, 25, 26, 27, 28, 29, 30 /* Some random data */
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30 /* Some random data */
 };
 
 static uint8_t v0_4[] = {
@@ -55,7 +54,7 @@ static uint8_t v0_4[] = {
     0x40, 0, /* Two  byte stream ID */
     0x80, 0, 0, 30, /* Four byte offset */
     0x40, 10, /* two byte length */
-    31 , 32, 33, 34, 35, 36, 37, 38, 39, 40 /* Some random data */
+    31, 32, 33, 34, 35, 36, 37, 38, 39, 40 /* Some random data */
 };
 
 static uint8_t v0_5[] = {
@@ -63,7 +62,7 @@ static uint8_t v0_5[] = {
     0x80, 0, 0, 0, /* Four  byte stream ID */
     0xC0, 0, 0, 0, 0, 0, 0, 40, /* Eight byte offset */
     0x40, 10, /* Two byte length */
-    41 , 42, 43, 44, 45, 46, 47, 48, 49, 50, /* Some random data */
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50, /* Some random data */
     0, 0, 0, 0, 0 /* Some random padding */
 };
 
@@ -72,12 +71,11 @@ static uint8_t v0_45_overlap[] = {
     0, /* One  byte stream ID */
     0x40, 35, /* Two byte offset */
     0x40, 10, /* Two byte length */
-    0xFF , 0xFF ,0xFF , 0xFF , 0xFF , 0xFF ,0xFF ,0xFF, 0xFF, 0xFF /* Some random data */
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF /* Some random data */
 };
 
-struct packet
-{
-    uint8_t * packet;
+struct packet {
+    uint8_t* packet;
     size_t packet_length;
     size_t offset;
     size_t data_length;
@@ -91,7 +89,6 @@ static struct packet list_v1[] = {
     { v0_4, sizeof(v0_4), 30, 10, 0 },
     { v0_5, sizeof(v0_5), 40, 10, 0 }
 };
-
 
 static struct packet list_v2[] = {
     { v0_2, sizeof(v0_2), 10, 10, 0 },
@@ -113,12 +110,9 @@ static struct packet list_v3[] = {
     { v0_45_overlap, sizeof(v0_45_overlap), 35, 10, 0 }
 };
 
-
-
-struct test_case_st
-{
-    const char *name;
-    struct packet * list;
+struct test_case_st {
+    const char* name;
+    struct packet* list;
     size_t list_size;
     size_t expected_length;
 };
@@ -133,7 +127,7 @@ static size_t const nb_test_cases = sizeof(test_case) / sizeof(struct test_case_
 
 #define FAIL(test, fmt, ...) DBG_PRINTF("Test %s failed: " fmt, (test)->name, __VA_ARGS__)
 
-static int StreamZeroFrameOneTest(struct test_case_st * test)
+static int StreamZeroFrameOneTest(struct test_case_st* test)
 {
     int ret = 0;
 
@@ -141,34 +135,28 @@ static int StreamZeroFrameOneTest(struct test_case_st * test)
     size_t consumed = 0;
     uint64_t current_time = 0;
 
-    for (size_t i = 0; ret == 0 && i < test->list_size; i++)
-    {
+    for (size_t i = 0; ret == 0 && i < test->list_size; i++) {
         if (0 != picoquic_decode_stream_frame(&cnx, test->list[i].packet,
-            test->list[i].packet_length, 1, &consumed, current_time))
-        {
+                     test->list[i].packet_length, 1, &consumed, current_time)) {
             FAIL(test, "packet %" PRIst, i);
             ret = -1;
         }
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         /* Check the content of all the data in the context */
-        picoquic_stream_data * data = cnx.first_stream.stream_data;
+        picoquic_stream_data* data = cnx.first_stream.stream_data;
         size_t data_rank = 0;
 
-        while (data != NULL)
-        {
-            if (data->bytes == NULL)
-            {
+        while (data != NULL) {
+            if (data->bytes == NULL) {
                 FAIL(test, "%s", "No data bytes");
                 ret = -1;
             }
 
             for (size_t i = 0; ret == 0 && i < data->length; i++) {
                 data_rank++;
-                if (data->bytes[i] != data_rank)
-                {
+                if (data->bytes[i] != data_rank) {
                     FAIL(test, "byte %" PRIst " is %u instead of %" PRIst, i, data->bytes[i], data_rank);
                     ret = -1;
                 }
@@ -177,8 +165,7 @@ static int StreamZeroFrameOneTest(struct test_case_st * test)
             data = data->next_stream_data;
         }
 
-        if (ret == 0 && data_rank != test->expected_length)
-        {
+        if (ret == 0 && data_rank != test->expected_length) {
             FAIL(test, "total byte %" PRIst " bytes instead of %" PRIst, data_rank, test->expected_length);
             ret = -1;
         }
@@ -191,10 +178,9 @@ int StreamZeroFrameTest()
 {
     int ret = 0;
 
-    for (size_t i = 0; ret == 0 && i < nb_test_cases; i++)
-        {
-            ret = StreamZeroFrameOneTest(&test_case[i]);
-        }
+    for (size_t i = 0; ret == 0 && i < nb_test_cases; i++) {
+        ret = StreamZeroFrameOneTest(&test_case[i]);
+    }
 
     return ret;
 }

--- a/picoquictest/ticket_store_test.c
+++ b/picoquictest/ticket_store_test.c
@@ -19,31 +19,28 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <string.h>
-#include <stdlib.h>
 #include "../picoquic/picoquic_internal.h"
+#include <stdlib.h>
+#include <string.h>
 
-static char const * test_file_name = "ticket_store_test.bin";
-static char const * test_sni[] = { "example.com", "example.net", "test.example.com" };
-static char const * test_alpn[] = { "hq05", "hq07", "hq09" };
-static const size_t nb_test_sni = sizeof(test_sni) / sizeof(char const *);
-static const size_t nb_test_alpn = sizeof(test_alpn) / sizeof(char const *);
+static char const* test_file_name = "ticket_store_test.bin";
+static char const* test_sni[] = { "example.com", "example.net", "test.example.com" };
+static char const* test_alpn[] = { "hq05", "hq07", "hq09" };
+static const size_t nb_test_sni = sizeof(test_sni) / sizeof(char const*);
+static const size_t nb_test_alpn = sizeof(test_alpn) / sizeof(char const*);
 
-static int create_test_ticket(uint64_t current_time, uint32_t ttl, uint8_t * buf, uint16_t len)
+static int create_test_ticket(uint64_t current_time, uint32_t ttl, uint8_t* buf, uint16_t len)
 {
     int ret = 0;
-    if (len < 35)
-    {
+    if (len < 35) {
         ret = -1;
-    }
-    else
-    {
+    } else {
         uint16_t t_length = len - 31;
         picoformat_64(buf, current_time);
         buf[8] = 0;
         buf[9] = 1;
         buf[10] = 0;
-        buf[11] = (uint8_t)(t_length >>8);
+        buf[11] = (uint8_t)(t_length >> 8);
         buf[12] = (uint8_t)(t_length & 0xFF);
         picoformat_32(buf + 13, ttl);
         memset(buf + 17, 0xcc, len - 17);
@@ -54,40 +51,26 @@ static int create_test_ticket(uint64_t current_time, uint32_t ttl, uint8_t * buf
     return ret;
 }
 
-static int ticket_store_compare(picoquic_stored_ticket_t * s1, picoquic_stored_ticket_t *s2)
+static int ticket_store_compare(picoquic_stored_ticket_t* s1, picoquic_stored_ticket_t* s2)
 {
     int ret = 0;
-    picoquic_stored_ticket_t * c1 = s1;
-    picoquic_stored_ticket_t * c2 = s2;
+    picoquic_stored_ticket_t* c1 = s1;
+    picoquic_stored_ticket_t* c2 = s2;
 
-    while (ret == 0 && c1 != 0)
-    {
-        if (c2 == 0)
-        {
+    while (ret == 0 && c1 != 0) {
+        if (c2 == 0) {
             ret = -1;
-        }
-        else
-        {
-            if (c1->time_valid_until != c2->time_valid_until ||
-                c1->sni_length != c2->sni_length ||
-                c1->alpn_length != c2->alpn_length ||
-                c1->ticket_length != c2->ticket_length ||
-                memcmp(c1->sni, c2->sni, c1->sni_length) != 0 ||
-                memcmp(c1->alpn, c2->alpn, c1->alpn_length) != 0 ||
-                memcmp(c1->ticket, c2->ticket, c1->ticket_length) != 0)
-            {
+        } else {
+            if (c1->time_valid_until != c2->time_valid_until || c1->sni_length != c2->sni_length || c1->alpn_length != c2->alpn_length || c1->ticket_length != c2->ticket_length || memcmp(c1->sni, c2->sni, c1->sni_length) != 0 || memcmp(c1->alpn, c2->alpn, c1->alpn_length) != 0 || memcmp(c1->ticket, c2->ticket, c1->ticket_length) != 0) {
                 ret = -1;
-            }
-            else
-            {
+            } else {
                 c1 = c1->next_ticket;
                 c2 = c2->next_ticket;
             }
         }
     }
 
-    if (ret == 0 && c1 == NULL && c2 != NULL)
-    {
+    if (ret == 0 && c1 == NULL && c2 != NULL) {
         ret = -1;
     }
 
@@ -97,10 +80,10 @@ static int ticket_store_compare(picoquic_stored_ticket_t * s1, picoquic_stored_t
 int ticket_store_test()
 {
     int ret = 0;
-    picoquic_stored_ticket_t * p_first_ticket = NULL;
-    picoquic_stored_ticket_t * p_first_ticket_bis = NULL;
-    picoquic_stored_ticket_t * p_first_ticket_ter = NULL;
-    
+    picoquic_stored_ticket_t* p_first_ticket = NULL;
+    picoquic_stored_ticket_t* p_first_ticket_bis = NULL;
+    picoquic_stored_ticket_t* p_first_ticket_ter = NULL;
+
     uint64_t ticket_time = 40000000000ull;
     uint64_t current_time = 50000000000ull;
     uint64_t retrieve_time = 60000000000ull;
@@ -109,74 +92,61 @@ int ticket_store_test()
     uint8_t ticket[128];
 
     /* Generate a set of tickets */
-    for (size_t i = 0; ret == 0 && i < nb_test_sni; i++)
-    {
-        for (size_t j = 0;  ret == 0 && j < nb_test_alpn; j++)
-        {
-            uint16_t ticket_length = (uint16_t)(64 + j*nb_test_sni + i);
-            ret = create_test_ticket((ticket_time/1000) + 1000*((i*nb_test_alpn) + j), ttl, ticket, ticket_length);
-            if (ret != 0)
-            {
+    for (size_t i = 0; ret == 0 && i < nb_test_sni; i++) {
+        for (size_t j = 0; ret == 0 && j < nb_test_alpn; j++) {
+            uint16_t ticket_length = (uint16_t)(64 + j * nb_test_sni + i);
+            ret = create_test_ticket((ticket_time / 1000) + 1000 * ((i * nb_test_alpn) + j), ttl, ticket, ticket_length);
+            if (ret != 0) {
                 break;
             }
-            ret = picoquic_store_ticket(&p_first_ticket, current_time, 
-                test_sni[i], (uint16_t) strlen(test_sni[i]),
-                test_alpn[j], (uint16_t) strlen(test_alpn[j]),
+            ret = picoquic_store_ticket(&p_first_ticket, current_time,
+                test_sni[i], (uint16_t)strlen(test_sni[i]),
+                test_alpn[j], (uint16_t)strlen(test_alpn[j]),
                 ticket, ticket_length);
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 break;
             }
         }
     }
 
     /* Verify that they can be retrieved */
-    for (size_t i = 0; ret == 0 && i < nb_test_sni; i++)
-    {
-        for (size_t j = 0; ret == 0 && j < nb_test_alpn; j++)
-        {
+    for (size_t i = 0; ret == 0 && i < nb_test_sni; i++) {
+        for (size_t j = 0; ret == 0 && j < nb_test_alpn; j++) {
             uint16_t ticket_length = 0;
-            uint16_t expected_length = (uint16_t)(64 + j*nb_test_sni + i);
-            uint8_t * ticket = NULL;
+            uint16_t expected_length = (uint16_t)(64 + j * nb_test_sni + i);
+            uint8_t* ticket = NULL;
             ret = picoquic_get_ticket(p_first_ticket, current_time,
-                test_sni[i], (uint16_t) strlen(test_sni[i]),
-                test_alpn[j], (uint16_t) strlen(test_alpn[j]),
+                test_sni[i], (uint16_t)strlen(test_sni[i]),
+                test_alpn[j], (uint16_t)strlen(test_alpn[j]),
                 &ticket, &ticket_length);
-            if (ret != 0)
-            {
+            if (ret != 0) {
                 break;
             }
-            if (ticket_length != expected_length)
-            {
+            if (ticket_length != expected_length) {
                 ret = -1;
                 break;
             }
         }
     }
     /* Store them on a file */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = picoquic_save_tickets(p_first_ticket, current_time, test_file_name);
     }
     /* Load the file again */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = picoquic_load_tickets(&p_first_ticket_bis, retrieve_time, test_file_name);
     }
 
     /* Verify that the two contents match */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = ticket_store_compare(p_first_ticket, p_first_ticket_bis);
     }
 
     /* Reload after a long time */
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = picoquic_load_tickets(&p_first_ticket_ter, too_late_time, test_file_name);
 
-        if (ret == 0 && p_first_ticket_ter != NULL)
-        {
+        if (ret == 0 && p_first_ticket_ter != NULL) {
             ret = -1;
         }
     }

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -19,10 +19,10 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include "../picoquic/picoquic_internal.h"
+#include "../picoquic/util.h"
 #include <stdlib.h>
 #include <string.h>
-#include "../picoquic/util.h"
-#include "../picoquic/picoquic_internal.h"
 
 /* Start with a series of test vectors to test that 
  * encoding and decoding are OK. 
@@ -30,49 +30,56 @@
  */
 
 static picoquic_transport_parameters transport_param_test1 = {
-	65535, 0x400000, 65533, 0, 30, 0, 1480, 3 };
+    65535, 0x400000, 65533, 0, 30, 0, 1480, 3
+};
 
-static picoquic_transport_parameters transport_param_test2 = { 
-	0x1000000, 0x1000000, 0x1000001, 0, 255, 1, 1480, 3 };
+static picoquic_transport_parameters transport_param_test2 = {
+    0x1000000, 0x1000000, 0x1000001, 0, 255, 1, 1480, 3
+};
 
 static picoquic_transport_parameters transport_param_test3 = {
-    0x1000000, 0x1000000, 0x1000001, 0, 255, 1, 0, 3 };
+    0x1000000, 0x1000000, 0x1000001, 0, 255, 1, 0, 3
+};
 
 static picoquic_transport_parameters transport_param_test4 = {
-    65535, 0x400000, 65532, 0, 30, 0, 1480, 3 };
+    65535, 0x400000, 65532, 0, 30, 0, 1480, 3
+};
 
 static picoquic_transport_parameters transport_param_test5 = {
-    0x1000000, 0x1000000, 0x1000000, 0, 255, 1, 1480, 3 };
+    0x1000000, 0x1000000, 0x1000000, 0, 255, 1, 1480, 3
+};
 
 static picoquic_transport_parameters transport_param_test6 = {
-    0x10000, 0xffffffff, 0, 0, 30, 1, 1480, 3 };
+    0x10000, 0xffffffff, 0, 0, 30, 1, 1480, 3
+};
 
 static picoquic_transport_parameters transport_param_test7 = {
-    8192, 16384, 5, 0, 10, 1, 1472, 3 };
+    8192, 16384, 5, 0, 10, 1, 1472, 3
+};
 
 static uint8_t transport_param_reset_secret[PICOQUIC_RESET_SECRET_SIZE] = {
-	1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 };
 
 uint8_t client_param1[] = {
     'P', 'C', 'Q', '0',
-	0, 0x24,
-	0, 0, 0, 4, 0, 0, 0xFF, 0xFF,
-	0, 1, 0, 4, 0, 0x40, 0, 0,
-	0, 2, 0, 4, 0, 0, 0xFF, 0xFD,
-	0, 3, 0, 2, 0, 0x1E,
-	0, 5, 0, 2, 0x05, 0xC8,
+    0, 0x24,
+    0, 0, 0, 4, 0, 0, 0xFF, 0xFF,
+    0, 1, 0, 4, 0, 0x40, 0, 0,
+    0, 2, 0, 4, 0, 0, 0xFF, 0xFD,
+    0, 3, 0, 2, 0, 0x1E,
+    0, 5, 0, 2, 0x05, 0xC8,
 };
 
 uint8_t client_param2[] = {
-	0x0A, 0x1A, 0x0A, 0x1A,
-	0, 0x28,
-	0, 0, 0, 4, 0x01, 0, 0, 0,
-	0, 1, 0, 4, 0x01, 0, 0, 0,
-	0, 2, 0, 4, 0x01, 0, 0, 1,
-	0, 3, 0, 2, 0, 0xFF,
-	0, 4, 0, 0,
-	0, 5, 0, 2, 0x05, 0xC8
+    0x0A, 0x1A, 0x0A, 0x1A,
+    0, 0x28,
+    0, 0, 0, 4, 0x01, 0, 0, 0,
+    0, 1, 0, 4, 0x01, 0, 0, 0,
+    0, 2, 0, 4, 0x01, 0, 0, 1,
+    0, 3, 0, 2, 0, 0xFF,
+    0, 4, 0, 0,
+    0, 5, 0, 2, 0x05, 0xC8
 };
 
 uint8_t client_param3[] = {
@@ -88,7 +95,7 @@ uint8_t client_param3[] = {
 uint8_t client_param4[] = {
     0x0A, 0x1A, 0x0A, 0x1A,
     0, 0x20,
-    0, 0, 0, 4,  0, 0x01, 0, 0,
+    0, 0, 0, 4, 0, 0x01, 0, 0,
     0, 1, 0, 4, 0xFF, 0xFF, 0xFF, 0xFF,
     0, 3, 0, 2, 0, 0x1E,
     0, 4, 0, 0,
@@ -107,19 +114,18 @@ uint8_t client_param5[] = {
     0, 0x07, 0, 0x01, 0x03
 };
 
-
 uint8_t server_param1[] = {
     'P', 'C', 'Q', '0',
-	0x08,
+    0x08,
     'P', 'C', 'Q', '0',
     0xFF, 0x00, 0x00, 0x08,
-	0, 0x38,
-	0, 0, 0, 4, 0, 0, 0xFF, 0xFF,
-	0, 1, 0, 4, 0, 0x40, 0, 0,
-	0, 2, 0, 4, 0, 0, 0xFF, 0xFC,
-	0, 3, 0, 2, 0, 0x1E,
-	0, 5, 0, 2, 0x05, 0xC8,
-	0, 6, 0, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    0, 0x38,
+    0, 0, 0, 4, 0, 0, 0xFF, 0xFF,
+    0, 1, 0, 4, 0, 0x40, 0, 0,
+    0, 2, 0, 4, 0, 0, 0xFF, 0xFC,
+    0, 3, 0, 2, 0, 0x1E,
+    0, 5, 0, 2, 0x05, 0xC8,
+    0, 6, 0, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 };
 
 uint8_t server_param2[] = {
@@ -127,75 +133,64 @@ uint8_t server_param2[] = {
     0x08,
     'P', 'C', 'Q', '0',
     0xFF, 0x00, 0x00, 0x08,
-	0, 0x3C,
-	0, 0, 0, 4, 0x01, 0, 0, 0,
-	0, 1, 0, 4, 0x01, 0, 0, 0,
-	0, 2, 0, 4, 0x01, 0, 0, 0,
-	0, 3, 0, 2, 0, 0xFF,
-	0, 4, 0, 0,
-	0, 5, 0, 2, 0x05, 0xC8,
-	0, 6, 0, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    0, 0x3C,
+    0, 0, 0, 4, 0x01, 0, 0, 0,
+    0, 1, 0, 4, 0x01, 0, 0, 0,
+    0, 2, 0, 4, 0x01, 0, 0, 0,
+    0, 3, 0, 2, 0, 0xFF,
+    0, 4, 0, 0,
+    0, 5, 0, 2, 0x05, 0xC8,
+    0, 6, 0, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 };
 
-int transport_param_one_test(int mode, uint32_t version, uint32_t proposed_version, 
-	picoquic_transport_parameters * param, uint8_t * target, size_t target_length)
+int transport_param_one_test(int mode, uint32_t version, uint32_t proposed_version,
+    picoquic_transport_parameters* param, uint8_t* target, size_t target_length)
 {
-	int ret = 0;
+    int ret = 0;
     picoquic_quic_t quic_ctx;
-	picoquic_cnx_t test_cnx;
-	uint8_t buffer[256];
-	size_t encoded, decoded;
+    picoquic_cnx_t test_cnx;
+    uint8_t buffer[256];
+    size_t encoded, decoded;
 
     memset(&quic_ctx, 0, sizeof(quic_ctx));
-	memset(&test_cnx, 0, sizeof(picoquic_cnx_t));
+    memset(&test_cnx, 0, sizeof(picoquic_cnx_t));
     test_cnx.quic = &quic_ctx;
 
-	/* initialize the connection object to the test parameters */
-	memcpy(&test_cnx.local_parameters, param, sizeof(picoquic_transport_parameters));
-	// test_cnx.version = version;
+    /* initialize the connection object to the test parameters */
+    memcpy(&test_cnx.local_parameters, param, sizeof(picoquic_transport_parameters));
+    // test_cnx.version = version;
     test_cnx.version_index = picoquic_get_version_index(version);
-	test_cnx.proposed_version = proposed_version;
-	memcpy(test_cnx.reset_secret, transport_param_reset_secret, PICOQUIC_RESET_SECRET_SIZE);
+    test_cnx.proposed_version = proposed_version;
+    memcpy(test_cnx.reset_secret, transport_param_reset_secret, PICOQUIC_RESET_SECRET_SIZE);
 
-	ret = picoquic_prepare_transport_extensions(&test_cnx, mode, buffer, sizeof(buffer), &encoded);
+    ret = picoquic_prepare_transport_extensions(&test_cnx, mode, buffer, sizeof(buffer), &encoded);
 
-	if (ret == 0)
-	{
-		if (encoded != target_length)
-		{
-			ret = -1;
-		}
-		else if (memcmp(buffer, target, target_length) != 0)
-		{
-			for (size_t i = 0; i < target_length; i++)
-			{
-				if (buffer[i] != target[i])
-				{
-					ret = -1;
-				}
-			}
-			ret = -1;
-		}
-	}
+    if (ret == 0) {
+        if (encoded != target_length) {
+            ret = -1;
+        } else if (memcmp(buffer, target, target_length) != 0) {
+            for (size_t i = 0; i < target_length; i++) {
+                if (buffer[i] != target[i]) {
+                    ret = -1;
+                }
+            }
+            ret = -1;
+        }
+    }
 
-	if (ret == 0)
-	{
-		ret = picoquic_receive_transport_extensions(&test_cnx, mode, buffer, encoded, &decoded);
+    if (ret == 0) {
+        ret = picoquic_receive_transport_extensions(&test_cnx, mode, buffer, encoded, &decoded);
 
-		if (ret == 0 &&
-			memcmp(&test_cnx.remote_parameters, param,
-				sizeof(picoquic_transport_parameters)) != 0)
-		{
-			ret = -1;
-		}
-	}
+        if (ret == 0 && memcmp(&test_cnx.remote_parameters, param, sizeof(picoquic_transport_parameters)) != 0) {
+            ret = -1;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
-
 int transport_param_decode_test(int mode, uint32_t version, uint32_t proposed_version,
-    picoquic_transport_parameters * param, uint8_t * target, size_t target_length)
+    picoquic_transport_parameters* param, uint8_t* target, size_t target_length)
 {
     int ret = 0;
     picoquic_quic_t quic_ctx;
@@ -205,162 +200,139 @@ int transport_param_decode_test(int mode, uint32_t version, uint32_t proposed_ve
     memset(&quic_ctx, 0, sizeof(quic_ctx));
     memset(&test_cnx, 0, sizeof(picoquic_cnx_t));
     test_cnx.quic = &quic_ctx;
-    
-    ret = picoquic_receive_transport_extensions(&test_cnx, mode, 
+
+    ret = picoquic_receive_transport_extensions(&test_cnx, mode,
         target, target_length, &decoded);
 
-    if (ret == 0 && decoded != target_length)
-    {
+    if (ret == 0 && decoded != target_length) {
         ret = -1;
     }
 
-    if (ret == 0 &&
-        memcmp(&test_cnx.remote_parameters, param,
-            sizeof(picoquic_transport_parameters)) != 0)
-    {
+    if (ret == 0 && memcmp(&test_cnx.remote_parameters, param, sizeof(picoquic_transport_parameters)) != 0) {
         ret = -1;
     }
-    
+
     return ret;
 }
 
-
 int transport_param_fuzz_test(int mode, uint32_t version, uint32_t proposed_version,
-	picoquic_transport_parameters * param, uint8_t * target, size_t target_length, uint64_t * proof)
+    picoquic_transport_parameters* param, uint8_t* target, size_t target_length, uint64_t* proof)
 {
-	int ret = 0;
-	int fuzz_ret = 0;
+    int ret = 0;
+    int fuzz_ret = 0;
     picoquic_quic_t quic_ctx;
-	picoquic_cnx_t test_cnx;
-	uint8_t buffer[256];
-	size_t decoded;
-	uint8_t fuzz_byte = 1;
+    picoquic_cnx_t test_cnx;
+    uint8_t buffer[256];
+    size_t decoded;
+    uint8_t fuzz_byte = 1;
 
     memset(&quic_ctx, 0, sizeof(quic_ctx));
     memset(&test_cnx, 0, sizeof(picoquic_cnx_t));
     test_cnx.quic = &quic_ctx;
 
-	/* test for valid arguments */
-	if (target_length < 8 || target_length > sizeof(buffer))
-	{
-		return -1;
-	}
+    /* test for valid arguments */
+    if (target_length < 8 || target_length > sizeof(buffer)) {
+        return -1;
+    }
 
     debug_printf_suspend();
 
-	/* initialize the connection object to the test parameters */
-	memcpy(&test_cnx.local_parameters, param, sizeof(picoquic_transport_parameters));
-	test_cnx.version_index = picoquic_get_version_index(version);
-	test_cnx.proposed_version = proposed_version;
+    /* initialize the connection object to the test parameters */
+    memcpy(&test_cnx.local_parameters, param, sizeof(picoquic_transport_parameters));
+    test_cnx.version_index = picoquic_get_version_index(version);
+    test_cnx.proposed_version = proposed_version;
 
-	/* add computation of the proof argument to make sure the compiler 
+    /* add computation of the proof argument to make sure the compiler 
 	 * will not optimize the loop to nothing */
 
-	*proof = 0;
+    *proof = 0;
 
-	/* repeat multiple times */
-	for (size_t l = 0; l < 8; l++)
-	{
-		for (size_t i = 0; i < target_length - l; i++)
-		{
-			/* copy message to buffer */
-			memcpy(buffer, target, target_length);
+    /* repeat multiple times */
+    for (size_t l = 0; l < 8; l++) {
+        for (size_t i = 0; i < target_length - l; i++) {
+            /* copy message to buffer */
+            memcpy(buffer, target, target_length);
 
-			/* fuzz */
-			for (size_t j = 0; j < l; j++)
-			{
-				buffer[i + j] ^= fuzz_byte;
-				fuzz_byte++;
-			}
+            /* fuzz */
+            for (size_t j = 0; j < l; j++) {
+                buffer[i + j] ^= fuzz_byte;
+                fuzz_byte++;
+            }
 
-			/* decode */
-			fuzz_ret = picoquic_receive_transport_extensions(&test_cnx, mode, buffer, 
-				target_length, &decoded);
+            /* decode */
+            fuzz_ret = picoquic_receive_transport_extensions(&test_cnx, mode, buffer,
+                target_length, &decoded);
 
-			if (fuzz_ret != 0)
-			{
-				*proof += (uint64_t)fuzz_ret;
-			}
-			else
-			{
-				*proof += test_cnx.remote_parameters.initial_max_stream_data;
+            if (fuzz_ret != 0) {
+                *proof += (uint64_t)fuzz_ret;
+            } else {
+                *proof += test_cnx.remote_parameters.initial_max_stream_data;
 
-				if (decoded > target_length)
-				{
-					ret = -1;
-				}
-			}
-
-		}
-	}
+                if (decoded > target_length) {
+                    ret = -1;
+                }
+            }
+        }
+    }
 
     debug_printf_resume();
 
-	return ret;
+    return ret;
 }
 
 int transport_param_test()
 {
-	int ret = 0;
-	uint64_t proof = 0;
+    int ret = 0;
+    uint64_t proof = 0;
     uint32_t version_default = picoquic_supported_versions[0].version;
 
-	if (ret == 0)
-	{
-		ret = transport_param_one_test(0, version_default, version_default,
-			&transport_param_test1, client_param1, sizeof(client_param1));
-	}
+    if (ret == 0) {
+        ret = transport_param_one_test(0, version_default, version_default,
+            &transport_param_test1, client_param1, sizeof(client_param1));
+    }
 
-	if (ret == 0)
-	{
-		ret = transport_param_one_test(0, version_default, 0x0A1A0A1A,
-			&transport_param_test2, client_param2, sizeof(client_param2));
-	}
+    if (ret == 0) {
+        ret = transport_param_one_test(0, version_default, 0x0A1A0A1A,
+            &transport_param_test2, client_param2, sizeof(client_param2));
+    }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = transport_param_decode_test(0, version_default, 0x0A1A0A1A,
             &transport_param_test3, client_param3, sizeof(client_param3));
     }
 
-	if (ret == 0)
-	{
-		ret = transport_param_one_test(1, version_default, version_default,
-			&transport_param_test4, server_param1, sizeof(server_param1));
-	}
+    if (ret == 0) {
+        ret = transport_param_one_test(1, version_default, version_default,
+            &transport_param_test4, server_param1, sizeof(server_param1));
+    }
 
-	if (ret == 0)
-	{
-		ret = transport_param_one_test(1, version_default, 0x0A1A0A1A,
-			&transport_param_test5, server_param2, sizeof(server_param2));
-	}
+    if (ret == 0) {
+        ret = transport_param_one_test(1, version_default, 0x0A1A0A1A,
+            &transport_param_test5, server_param2, sizeof(server_param2));
+    }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = transport_param_decode_test(0, version_default, 0x0A1A0A1A,
             &transport_param_test6, client_param4, sizeof(client_param4));
     }
 
-    if (ret == 0)
-    {
+    if (ret == 0) {
         ret = transport_param_decode_test(0, version_default, 0xBABABABA,
             &transport_param_test7, client_param5, sizeof(client_param5));
     }
 
     DBG_PRINTF("%s", "Starting transport parameters fuzz test.\n");
 
-	if (ret == 0)
-	{
-		ret = transport_param_fuzz_test(0, version_default, 0x0A1A0A1A,
-			&transport_param_test2, client_param2, sizeof(client_param2), &proof);
-	}
+    if (ret == 0) {
+        ret = transport_param_fuzz_test(0, version_default, 0x0A1A0A1A,
+            &transport_param_test2, client_param2, sizeof(client_param2), &proof);
+    }
 
-	if (ret == 0)
-	{
-		ret = transport_param_fuzz_test(1, version_default, 0x0A1A0A1A,
-			&transport_param_test2, server_param2, sizeof(server_param2), &proof);
-	}
+    if (ret == 0) {
+        ret = transport_param_fuzz_test(1, version_default, 0x0A1A0A1A,
+            &transport_param_test2, server_param2, sizeof(server_param2), &proof);
+    }
 
     DBG_PRINTF("%s", "End of transport parameters fuzz test.\n");
-	return ret;
+    return ret;
 }


### PR DESCRIPTION
Run `make clangformat` to format all the source code again.

I used the "Webkit" style to format the source code, because it seems to fit best the current formatting. I can also change that, if you want. The following styles are supported: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options

If none of these styles is okay for you, we could also create a custom one.