### PR TITLE
Implements verify certificate as plug-able callback

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -201,6 +201,10 @@ typedef struct st_picoquic_quic_t {
 
     void* aead_encrypt_ticket_ctx;
     void* aead_decrypt_ticket_ctx;
+
+    picoquic_verify_certificate_cb_fn verify_certificate_callback_fn;
+    picoquic_free_verify_certificate_ctx free_verify_certificate_callback_fn;
+    void* verify_certificate_ctx;
 } picoquic_quic_t;
 
 /*

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -79,4 +79,6 @@ void picoquic_provide_received_transport_extensions(picoquic_cnx_t* cnx,
 char const* picoquic_tls_get_negotiated_alpn(picoquic_cnx_t* cnx);
 char const* picoquic_tls_get_sni(picoquic_cnx_t* cnx);
 
+int picoquic_enable_custom_verify_certificate_callback(picoquic_quic_t* quic);
+
 #endif /* TLS_API_H */

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -94,7 +94,8 @@ static const picoquic_test_def_t test_table[] = {
     { "tls_zero_share", tls_zero_share_test },
     { "cleartext_aead_vector", cleartext_aead_vector_test },
     { "transport_param_log", transport_param_log_test },
-    { "bad_certificate", bad_certificate_test }
+    { "bad_certificate", bad_certificate_test },
+    { "set_verify_certificate_callback_test", set_verify_certificate_callback_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -89,6 +89,7 @@ int tls_zero_share_test();
 int cleartext_aead_vector_test();
 int transport_param_log_test();
 int bad_certificate_test();
+int set_verify_certificate_callback_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The verify certificate function is now set-able. If the callback is NULL, the
default behavior is to use the standard OpenSSL implementation of the verify
certificate function from picotls.

Requires: https://github.com/h2o/picotls/pull/123