### PR TITLE
Reset `next_wake_time` to `0`, if data is added to a stream

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -130,6 +130,8 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
                 *pprevious = stream_data;
             }
         }
+
+        picoquic_cnx_set_next_wake_time(cnx, 0);
     }
 
     return ret;


### PR DESCRIPTION
This ensures that the connection is scheduled to be woken up in the next call to `picoquic_get_earliest_cnx_to_wake`.