### PR TITLE
Provide access to current time through context

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -463,5 +463,14 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+
+        TEST_METHOD(test_virtual_time)
+        {
+            int ret = virtual_time_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
+        
 	};
 }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -891,6 +891,8 @@ int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t 
         cnx->first_misc_frame = misc_frame;
     }
 
+    picoquic_cnx_set_next_wake_time(cnx, picoquic_get_tls_time(cnx->quic));
+
     return ret;
 }
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -131,7 +131,7 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
             }
         }
 
-        picoquic_cnx_set_next_wake_time(cnx, 0);
+        picoquic_cnx_set_next_wake_time(cnx, picoquic_get_tls_time(cnx->quic));
     }
 
     return ret;
@@ -156,6 +156,8 @@ int picoquic_reset_stream(picoquic_cnx_t* cnx,
             stream->local_error = local_stream_error;
             stream->stream_flags |= picoquic_stream_flag_reset_requested;
         }
+
+        picoquic_cnx_set_next_wake_time(cnx, picoquic_get_tls_time(cnx->quic));
     }
 
     return ret;
@@ -180,6 +182,8 @@ int picoquic_stop_sending(picoquic_cnx_t* cnx,
             stream->local_stop_error = local_stream_error;
             stream->stream_flags |= picoquic_stream_flag_stop_sending_requested;
         }
+
+        picoquic_cnx_set_next_wake_time(cnx, picoquic_get_tls_time(cnx->quic));
     }
 
     return ret;
@@ -1768,6 +1772,8 @@ int picoquic_close(picoquic_cnx_t* cnx, uint16_t reason_code)
     } else {
         ret = -1;
     }
+
+    picoquic_cnx_set_next_wake_time(cnx, picoquic_get_tls_time(cnx->quic));
 
     return ret;
 }

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -660,6 +660,14 @@ void picoquic_master_tlscontext_free(picoquic_quic_t* quic)
     }
 }
 
+uint64_t picoquic_get_tls_time(picoquic_quic_t* quic)
+{
+    ptls_context_t* ctx = (ptls_context_t*)quic->tls_master_ctx;
+    uint64_t now = ctx->get_time->cb(ctx->get_time);
+
+    return now;
+}
+
 /*
  * Creation of a TLS context.
  * This includes setting the handshake properties that will later be

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -660,10 +660,18 @@ void picoquic_master_tlscontext_free(picoquic_quic_t* quic)
     }
 }
 
+/*
+ * Get the same time simulation as used for TLS 
+ */
+
 uint64_t picoquic_get_tls_time(picoquic_quic_t* quic)
 {
-    ptls_context_t* ctx = (ptls_context_t*)quic->tls_master_ctx;
-    uint64_t now = ctx->get_time->cb(ctx->get_time);
+    uint64_t now;
+    if (quic->p_simulated_time == NULL) {
+        now = picoquic_current_time();
+    } else {
+        now = *quic->p_simulated_time;
+    }
 
     return now;
 }

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -38,6 +38,8 @@ int picoquic_tlsinput_stream_zero(picoquic_cnx_t* cnx);
 
 int picoquic_initialize_stream_zero(picoquic_cnx_t* cnx);
 
+uint64_t picoquic_get_tls_time(picoquic_quic_t* quic);
+
 void picoquic_crypto_random(picoquic_quic_t* quic, void* buf, size_t len);
 uint64_t picoquic_crypto_uniform_random(picoquic_quic_t* quic, uint64_t rnd_max);
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -95,7 +95,8 @@ static const picoquic_test_def_t test_table[] = {
     { "cleartext_aead_vector", cleartext_aead_vector_test },
     { "transport_param_log", transport_param_log_test },
     { "bad_certificate", bad_certificate_test },
-    { "set_verify_certificate_callback_test", set_verify_certificate_callback_test }
+    { "set_verify_certificate_callback_test", set_verify_certificate_callback_test },
+    { "virtual_time" , virtual_time_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -90,6 +90,7 @@ int cleartext_aead_vector_test();
 int transport_param_log_test();
 int bad_certificate_test();
 int set_verify_certificate_callback_test();
+int virtual_time_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This builds on previous work to enable "virtual time" management in the TLS stack: either a simulated time for tests, or the actual current time.