### PR TITLE
Move payload length

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -70,7 +70,6 @@ int picoquic_parse_packet_header(
                 ph->offset = 6;
                 ph->offset += picoquic_parse_connection_id(bytes + ph->offset, l_dest_id, &ph->dest_cnx_id);
                 ph->offset += picoquic_parse_connection_id(bytes + ph->offset, l_srce_id, &ph->srce_cnx_id);
-                ph->pn_offset = ph->offset;
 
                 if (ph->vn == 0) {
                     /* VN = zero identifies a version negotiation packet */
@@ -94,24 +93,28 @@ int picoquic_parse_packet_header(
                             }
                         }
                     }
-                } else {
+                }
+                else {
                     char context_by_addr = 0;
                     uint64_t payload_length;
-                    size_t var_length;
-
-                    ph->pn = PICOPARSE_32(bytes + ph->offset);
-                    ph->version_index = picoquic_get_version_index(ph->vn);
-                    ph->offset += 4;
-                    ph->pnmask = 0xFFFFFFFF00000000ull;
-                    var_length = picoquic_varint_decode(bytes + ph->offset,
+                    size_t var_length = picoquic_varint_decode(bytes + ph->offset,
                         length - ph->offset, &payload_length);
-                    if (ph->offset + var_length + payload_length > length ||
+
+                    ph->version_index = picoquic_get_version_index(ph->vn);
+
+                    if (var_length <= 0 || ph->offset + var_length + payload_length + 4 > length ||
                         ph->version_index < 0) {
                         ph->ptype = picoquic_packet_error;
-                        ph->payload_length = (uint16_t) ((length > ph->offset) ? length - ph->offset : 0);
-                    } else {
-                        ph->payload_length = (uint16_t) payload_length;
+                        ph->payload_length = (uint16_t)((length > ph->offset) ? length - ph->offset : 0);
+                    }
+                    else {
+                        ph->payload_length = (uint16_t)payload_length;
                         ph->offset += var_length;
+                        ph->pn_offset = ph->offset;
+
+                        ph->pn = PICOPARSE_32(bytes + ph->offset);
+                        ph->offset += 4;
+                        ph->pnmask = 0xFFFFFFFF00000000ull;
 
                         /* Retrieve the connection context */
                         if (*pcnx == NULL) {
@@ -561,23 +564,9 @@ void picoquic_queue_stateless_reset(picoquic_cnx_t* cnx,
         size_t header_length = 0;
         size_t pn_offset = 0;
 
-        /* Packet type set to long header, with cnxid */
-        bytes[byte_index++] = 0x80 | 0x7E;
-        /* Copy the version number */
-        picoformat_32(bytes + byte_index, ph->vn);
-        byte_index += 4;
-        /* Copy the connection ID */
-        bytes[byte_index++] = picoquic_create_packet_header_cnxid_lengths(ph->srce_cnx_id.id_len, ph->dest_cnx_id.id_len);
-        byte_index += picoquic_format_connection_id(bytes + byte_index, PICOQUIC_MAX_PACKET_SIZE - byte_index, ph->srce_cnx_id);
-        byte_index += picoquic_format_connection_id(bytes + byte_index, PICOQUIC_MAX_PACKET_SIZE - byte_index, ph->dest_cnx_id);
-        /* Copy the sequence number */
-        pn_offset = byte_index;
-        picoformat_32(bytes + byte_index, ph->pn);
-        byte_index += 4;
-        /* Reserve two bytes for payload length */
-        bytes[byte_index++] = 0;
-        bytes[byte_index++] = 0;
-
+        cnx->remote_cnxid = ph->srce_cnx_id;
+        byte_index = picoquic_create_packet_header(cnx, picoquic_packet_server_stateless,
+            ph->pn, bytes, &pn_offset);
         header_length = byte_index;
 
         /* Draft 11 requires adding an ACK frame */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -543,6 +543,13 @@ int picoquic_parse_packet_header(
     picoquic_packet_header* ph,
     picoquic_cnx_t** pcnx);
 
+size_t picoquic_create_packet_header(
+    picoquic_cnx_t* cnx,
+    picoquic_packet_type_enum packet_type,
+    uint64_t sequence_number,
+    uint8_t* bytes,
+    size_t * pn_offset);
+
 void picoquic_update_payload_length(
     uint8_t* bytes, size_t header_length, size_t packet_length);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -533,6 +533,7 @@ typedef struct _picoquic_packet_header {
     uint64_t pn64;
     uint16_t payload_length;
     int version_index;
+    unsigned int spin : 1;
 } picoquic_packet_header;
 
 int picoquic_parse_packet_header(

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -69,6 +69,7 @@ static picoquic_packet_header hinitial10 = {
     0xFFFFFFFF00000000ull,
     0, 
     0x400,
+    0,
     0
 };
 
@@ -93,6 +94,7 @@ static picoquic_packet_header hinitial10_l = {
     0xFFFFFFFF00000000ull,
     0,
     0x400,
+    0,
     0
 };
 
@@ -127,6 +129,7 @@ static picoquic_packet_header hvnego10 = {
     0,
     0,
     PICOQUIC_MAX_PACKET_SIZE - 18,
+    0,
     0
 };
 
@@ -146,8 +149,30 @@ static picoquic_packet_header hphi0_c_32 = {
     picoquic_packet_1rtt_protected_phi0,
     0xFFFFFFFF00000000ull,
     0,
-    PICOQUIC_MAX_PACKET_SIZE - 13, 
+    PICOQUIC_MAX_PACKET_SIZE - 13,
+    0,
     0
+};
+
+static uint8_t packet_short_phi0_c_32_spin[] = {
+    0x36, /* Setting the spin bit */
+    TEST_CNXID_10_BYTES,
+    0xDE, 0xAD, 0xBE, 0xEF
+};
+
+static picoquic_packet_header hphi0_c_32_spin = {
+    TEST_CNXID_10_VAL,
+    TEST_CNXID_NULL_VAL,
+    0xDEADBEEF,
+    0,
+    13,
+    9,
+    picoquic_packet_1rtt_protected_phi0,
+    0xFFFFFFFF00000000ull,
+    0,
+    PICOQUIC_MAX_PACKET_SIZE - 13, 
+    0,
+    1
 };
 
 static uint8_t packet_short_phi1_c_16[] = {
@@ -167,6 +192,7 @@ static picoquic_packet_header hphi1_c_16 = {
     0xFFFFFFFFFFFF0000ull,
     0,
     PICOQUIC_MAX_PACKET_SIZE - 11,
+    0,
     0
 };
 
@@ -187,6 +213,7 @@ static picoquic_packet_header hphi1_c_8 = {
     0xFFFFFFFFFFFFFF00ull,
     0,
     PICOQUIC_MAX_PACKET_SIZE - 10,
+    0,
     0
 };
 
@@ -206,6 +233,7 @@ static picoquic_packet_header hphi0_noc_16 = {
     0xFFFFFFFFFFFF0000ull,
     0,
     PICOQUIC_MAX_PACKET_SIZE - 3,
+    0,
     0
 };
 
@@ -225,6 +253,7 @@ static picoquic_packet_header hphi0_noc_8 = {
     0xFFFFFFFFFFFFFF00ull,
     0,
     PICOQUIC_MAX_PACKET_SIZE - 2,
+    0,
     0
 };
 
@@ -242,6 +271,7 @@ static struct _test_entry test_entries[] = {
     { pvnego10, sizeof(pvnego10), &hvnego10, 1, 8 },
     { pvnegobis10, sizeof(pvnegobis10), &hvnego10, 1, 8 },
     { packet_short_phi0_c_32, sizeof(packet_short_phi0_c_32), &hphi0_c_32, 0, 8 },
+    { packet_short_phi0_c_32_spin, sizeof(packet_short_phi0_c_32_spin), &hphi0_c_32_spin, 1, 8 },
     { packet_short_phi1_c_16, sizeof(packet_short_phi1_c_16), &hphi1_c_16, 1, 8 },
     { packet_short_phi1_c_8, sizeof(packet_short_phi1_c_8), &hphi1_c_8, 1, 8 },
     { packet_short_phi0_noc_16, sizeof(packet_short_phi0_noc_16), &hphi0_noc_16, 1, 0 },
@@ -315,6 +345,8 @@ int parseheadertest()
         } else if (ph.payload_length != test_entries[i].ph->payload_length) {
             ret = -1;
         } else if (ph.ptype != test_entries[i].ph->ptype || ph.pnmask != test_entries[i].ph->pnmask) {
+            ret = -1;
+        } else if (ph.spin != test_entries[i].ph->spin) {
             ret = -1;
         }
     }


### PR DESCRIPTION
Move payload length per latest draft-11. Also, reserve the spin bit. And improve the parse-header tests.