### PR TITLE
Fix off-by-one error in encoding of ack ranges and gaps

### DIFF
--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -410,7 +410,6 @@ size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
     fprintf(F, "    ACK (nb=%u)", (int)num_block);
 
     /* decoding the acks */
-    unsigned extra_ack = 1;
 
     while (ret == 0) {
         uint64_t range;
@@ -433,7 +432,8 @@ size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
             byte_index += l_range;
         }
 
-        range += extra_ack;
+        range++;
+
         if (largest + 1 < range) {
             fprintf(F, "ack range error: largest=%" PRIx64 ", range=%" PRIx64, largest, range);
             byte_index = bytes_max;
@@ -441,12 +441,10 @@ size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
             break;
         }
 
-        if (range > 1)
-            fprintf(F, ", %" PRIx64 "-%" PRIx64, largest - (range - 1), largest);
-        else if (range == 1)
+        if (range <= 1)
             fprintf(F, ", %" PRIx64, largest);
         else
-            fprintf(F, ", _");
+            fprintf(F, ", %" PRIx64 "-%" PRIx64, largest - range + 1, largest);
 
         if (num_block-- == 0)
             break;
@@ -468,6 +466,7 @@ size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
                 break;
             } else {
                 byte_index += l_gap;
+                block_to_block += 1;
                 block_to_block += range;
             }
         }
@@ -481,7 +480,6 @@ size_t picoquic_log_ack_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
         }
 
         largest -= block_to_block;
-        extra_ack = 0;
     }
 
     fprintf(F, "\n");

--- a/picoquictest/ack_of_ack_test.c
+++ b/picoquictest/ack_of_ack_test.c
@@ -197,9 +197,9 @@ static size_t build_test_ack(test_ack_range_t const* ranges, size_t nb_ranges,
     byte_index += picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, ack_range);
     /* Encode each of the ack block items */
     for (size_t i = 1; i < nb_ranges && byte_index + 5 < bytes_max; i++) {
-        uint64_t gap = ranges[i - 1].start_of_sack_range - ranges[i].end_of_sack_range - 1;
+        uint64_t gap = ranges[i - 1].start_of_sack_range - ranges[i].end_of_sack_range - 2;
         byte_index += picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, gap);
-        ack_range = ranges[i].end_of_sack_range - ranges[i].start_of_sack_range + 1;
+        ack_range = ranges[i].end_of_sack_range - ranges[i].start_of_sack_range;
         byte_index += picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index, ack_range);
     }
     return byte_index;

--- a/picoquictest/log_test_ref.txt
+++ b/picoquictest/log_test_ref.txt
@@ -13,6 +13,6 @@
     STOP SENDING 17 (0x00000011), Error 0x4000.
     path_challenge: 0102030405060708
     path_response: 0102030405060708
-    ACK (nb=0), 102030400-102030405
+    ACK (nb=2), 102030400-102030405, 1020303fe, 1020303eb-1020303f7
     Stream 0, offset 0, length 16, fin = 0: a0a1a2a3a4a5a6a7...
     Stream 1, offset 1024, length 16, fin = 0: a0a1a2a3a4a5a6a7...

--- a/picoquictest/sacktest.c
+++ b/picoquictest/sacktest.c
@@ -183,6 +183,7 @@ static int basic_ack_parse(uint8_t* bytes, size_t bytes_max,
                 if (byte_index < bytes_max) {
                     l_gap = picoquic_varint_decode(bytes + byte_index, bytes_max - byte_index, &gap);
                     byte_index += l_gap;
+                    gap += 1;
                 }
                 /* decode the range */
                 if (byte_index < bytes_max) {
@@ -195,6 +196,7 @@ static int basic_ack_parse(uint8_t* bytes, size_t bytes_max,
                     ret = -1;
                 } else {
                     gap_begin -= gap;
+                    ack_range++;
 
                     if (gap_begin >= ack_range) {
                         /* mark the range as received */
@@ -258,6 +260,10 @@ int sendacktest()
             if (ret == 0) {
                 ret = basic_ack_parse(bytes, consumed, &expected_ack[i], received_mask,
                     picoquic_supported_versions[cnx.version_index].version_flags);
+            }
+
+            if (ret != 0) {
+                ret = -1; /* useless code, but helps with checkpointing */
             }
         }
     }

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -106,8 +106,10 @@ static uint8_t test_frame_type_ack[] = {
     picoquic_frame_type_ack,
     0xC0, 0, 0, 1, 2, 3, 4, 5,
     0x44, 0,
-    0,
-    5
+    2,
+    5,
+    0, 0,
+    5, 12
 };
 static uint8_t test_frame_type_stream_range_min[] = {
     picoquic_frame_type_stream_range_min,


### PR DESCRIPTION
Embarrassing bug. The coding changed way back, with draft-08, but we missed it, and the interop tests did not surface the issue.