### PR TITLE
More crash/test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,9 @@ before_install:
 before_script:
   # First build external lib
   - ./ci/build_picotls.sh
+  - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script:
   # Now build picotls examples and test
   - cmake .
   - make
-  - ./picoquic_ct -x sockets -x wrong_keyshare
+  - ./picoquic_ct -x wrong_keyshare

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1209,7 +1209,7 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_pa
             byte_index += frame_length;
         } else {
             ret = picoquic_skip_frame(&p->bytes[byte_index],
-                p->length - ph.offset, &frame_length, &frame_is_pure_ack, version);
+                p->length - byte_index, &frame_length, &frame_is_pure_ack, version);
             byte_index += frame_length;
         }
     }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -71,6 +71,9 @@ int picoquic_parse_packet_header(
                 ph->offset += picoquic_parse_connection_id(bytes + ph->offset, l_dest_id, &ph->dest_cnx_id);
                 ph->offset += picoquic_parse_connection_id(bytes + ph->offset, l_srce_id, &ph->srce_cnx_id);
 
+                /* Not applicable for long packets. */
+                ph->spin = 0;
+
                 if (ph->vn == 0) {
                     /* VN = zero identifies a version negotiation packet */
                     ph->ptype = picoquic_packet_version_negotiation;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -193,7 +193,7 @@ int main(int argc, char** argv)
 
                 if (test_number < 0) {
                     fprintf(stderr, "Incorrect test name: %s\n", optarg);
-                    usage(argv[0]);
+                    ret = usage(argv[0]);
                 }
                 else {
                     is_excluded[test_number] = 1;
@@ -202,6 +202,10 @@ int main(int argc, char** argv)
             }
             case 'h':
                 usage(argv[0]);
+                exit(0);
+                break;
+            default:
+                ret = usage(argv[0]);
                 break;
             }
         }
@@ -227,7 +231,7 @@ int main(int argc, char** argv)
 
                     if (test_number < 0) {
                         fprintf(stderr, "Incorrect test name: %s\n", argv[arg_num]);
-                        usage(argv[0]);
+                        ret = usage(argv[0]);
                     }
                     else {
                         nb_test_tried++;

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -328,16 +328,14 @@ int parseheadertest()
                 (struct sockaddr*)&addr_10, &ph, &pcnx)
             != 0) {
             ret = -1;
-        }
-
-        if (picoquic_compare_connection_id(&ph.dest_cnx_id, &test_entries[i].ph->dest_cnx_id) != 0) {
+        } else if (picoquic_compare_connection_id(&ph.dest_cnx_id, &test_entries[i].ph->dest_cnx_id) != 0) {
             ret = -1;
         } else if (picoquic_compare_connection_id(&ph.srce_cnx_id, &test_entries[i].ph->srce_cnx_id) != 0) {
             ret = -1;
         } else if (ph.pn != test_entries[i].ph->pn) {
             ret = -1;
         } else if (ph.vn != test_entries[i].ph->vn) {
-                ret = -1;
+            ret = -1;
         } else if (ph.offset != test_entries[i].ph->offset) {
             ret = -1;
         } else if (ph.pn_offset != test_entries[i].ph->pn_offset) {

--- a/picoquictest/socket_test.c
+++ b/picoquictest/socket_test.c
@@ -79,6 +79,7 @@ static int socket_ping_pong(SOCKET_TYPE fd, struct sockaddr* server_addr, int se
     if (ret == 0) {
         memset(buffer, 0, sizeof(buffer));
 
+        back_length = (socklen_t)sizeof(addr_back);
         bytes_recv = picoquic_select(&fd, 1,
             &addr_back, &back_length, NULL, NULL, NULL,
             buffer, sizeof(buffer), 1000000, &current_time);


### PR DESCRIPTION
Another memory safety fix and improvements for the test suite. After this, `./picoquic_ct` runs passes tests without crashing. (There are lots of memory leaks, but I ignored those for now.)

Also figured out why #90 happened and added a workaround for it in the travis config.