### PR TITLE
Fuzz skip and log

### DIFF
--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -80,6 +80,9 @@ int test_one_pn_enc_pair(uint8_t * seqnum, size_t seqnum_len, void * pn_enc, voi
 
 int picoquic_test_compare_files(char const* fname1, char const* fname2);
 
+uint64_t picoquic_test_random(uint64_t * random_context);
+uint64_t picoquic_test_uniform_random(uint64_t * random_context, uint64_t rnd_max);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Add fuzzing to the skip_frame and logger tests, to verify that all types of frame combinations can be
properly skipped, and properly logged, without crashes