### PR TITLE
0rtt spurious

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -547,10 +547,17 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
-
+        
         TEST_METHOD(zero_rtt_spurious)
         {
             int ret = zero_rtt_spurious_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
+        TEST_METHOD(zero_rtt_retry)
+        {
+            int ret = zero_rtt_retry_test();
 
             Assert::AreEqual(ret, 0);
         }

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -548,5 +548,11 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(zero_rtt_spurious)
+        {
+            int ret = zero_rtt_spurious_test();
+
+            Assert::AreEqual(ret, 0);
+        }
     };
 }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1214,18 +1214,17 @@ static picoquic_packet* picoquic_process_ack_range(
         if (p->sequence_number > highest) {
             p = p->next_packet;
         } else {
-            if (restricted) {
-                /* check that the packet was sent in clear text */
-                if (picoquic_is_packet_encrypted(p->ptype)) {
-                    /* Protocol error! */
-                    *ret = picoquic_connection_error(cnx,
-                        PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-                    p = NULL;
-                    break;
-                }
-            }
-
             if (p->sequence_number == highest) {
+                if (restricted) {
+                    /* check that the packet was sent in clear text */
+                    if (picoquic_is_packet_encrypted(p->ptype)) {
+                        /* Protocol error! */
+                        *ret = picoquic_connection_error(cnx,
+                            PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
+                        p = NULL;
+                        break;
+                    }
+                }
                 /* TODO: RTT Estimate */
                 picoquic_packet* next = p->next_packet;
                 picoquic_path_t * old_path = p->send_path;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -149,7 +149,7 @@ int picoquic_get_ticket(picoquic_stored_ticket_t* p_first_ticket,
     char const* sni, uint16_t sni_length, char const* alpn, uint16_t alpn_length,
     uint8_t** ticket, uint16_t* ticket_length);
 
-int picoquic_save_tickets(picoquic_stored_ticket_t* first_ticket,
+int picoquic_save_tickets(const picoquic_stored_ticket_t* first_ticket,
     uint64_t current_time, char const* ticket_file_name);
 int picoquic_load_tickets(picoquic_stored_ticket_t** pp_first_ticket,
     uint64_t current_time, char const* ticket_file_name);

--- a/picoquic/ticket_store.c
+++ b/picoquic/ticket_store.c
@@ -56,7 +56,7 @@ picoquic_stored_ticket_t* picoquic_format_ticket(uint64_t time_valid_until,
     return stored;
 }
 
-int picoquic_serialize_ticket(picoquic_stored_ticket_t * ticket, uint8_t * bytes, size_t bytes_max, size_t * consumed)
+int picoquic_serialize_ticket(const picoquic_stored_ticket_t * ticket, uint8_t * bytes, size_t bytes_max, size_t * consumed)
 {
     int ret = 0;
     size_t byte_index = 0;
@@ -239,13 +239,13 @@ int picoquic_get_ticket(picoquic_stored_ticket_t* p_first_ticket,
     return ret;
 }
 
-int picoquic_save_tickets(picoquic_stored_ticket_t* first_ticket,
+int picoquic_save_tickets(const picoquic_stored_ticket_t* first_ticket,
     uint64_t current_time,
     char const* ticket_file_name)
 {
     int ret = 0;
     FILE* F = NULL;
-    picoquic_stored_ticket_t* next = first_ticket;
+    const picoquic_stored_ticket_t* next = first_ticket;
 #ifdef _WINDOWS
     errno_t err = fopen_s(&F, ticket_file_name, "wb");
     if (err != 0 || F == NULL) {

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -108,7 +108,8 @@ static const picoquic_test_def_t test_table[] = {
     { "client_error", client_error_test },
     { "packet_enc_dec", packet_enc_dec_test},
     { "pn_vector", cleartext_pn_vector_test },
-    { "zero_rtt_spurious", zero_rtt_spurious_test }
+    { "zero_rtt_spurious", zero_rtt_spurious_test },
+    { "zero_rtt_retry", zero_rtt_retry_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -107,7 +107,8 @@ static const picoquic_test_def_t test_table[] = {
     { "spin_bit", spin_bit_test},
     { "client_error", client_error_test },
     { "packet_enc_dec", packet_enc_dec_test},
-    { "pn_vector", cleartext_pn_vector_test }
+    { "pn_vector", cleartext_pn_vector_test },
+    { "zero_rtt_spurious", zero_rtt_spurious_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -103,6 +103,7 @@ int client_error_test();
 int packet_enc_dec_test();
 int cleartext_pn_vector_test();
 int zero_rtt_spurious_test();
+int zero_rtt_retry_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -102,6 +102,7 @@ int spin_bit_test();
 int client_error_test();
 int packet_enc_dec_test();
 int cleartext_pn_vector_test();
+int zero_rtt_spurious_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fixes issue #189. Two tests reproduce the scenario leading to breakage, e.g. 0-RTT packet followed by a stateless retry from the server. 