### PR TITLE
Implement the VEC extension to the Spin Bit (0K110SVV)

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -54,6 +54,8 @@ extern "C" {
 #define PICOQUIC_CWIN_INITIAL (10 * PICOQUIC_MAX_PACKET_SIZE)
 #define PICOQUIC_CWIN_MINIMUM (2 * PICOQUIC_MAX_PACKET_SIZE)
 
+#define PICOQUIC_VEC_LATE 1000 /* microseconds */
+
 /*
  * Types of frames
  */
@@ -376,6 +378,11 @@ typedef struct st_picoquic_cnx_t {
     unsigned int ack_needed : 1;
     unsigned int current_spin : 1; /* Current value of the spin bit */             
     unsigned int client_mode : 1; /* Is this connection the client side? */
+    unsigned int prev_spin : 1;  /* previous Spin bit */
+    unsigned int VEC : 2; 
+    unsigned int Edge : 1;
+    uint64_t lastTrigger;
+
 
     /* Local and remote parameters */
     picoquic_transport_parameters local_parameters;
@@ -552,6 +559,8 @@ typedef struct _picoquic_packet_header {
     uint16_t payload_length;
     int version_index;
     unsigned int spin : 1;
+    unsigned int VEC : 2;
+    unsigned int hasspinbit : 1;
 } picoquic_packet_header;
 
 int picoquic_parse_packet_header(

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -319,10 +319,21 @@ uint32_t picoquic_create_packet_header_12(
         /* Create a short packet -- using 32 bit sequence numbers for now */
         uint8_t K = (packet_type == picoquic_packet_1rtt_protected_phi0) ? 0 : 0x40;
         const uint8_t C = 0x30;
+	uint8_t VEC = (cnx->VEC );
         uint8_t spin_bit = (uint8_t)((cnx->current_spin) << 2);
 
-        length = 0;
-        bytes[length++] = (K | C | spin_bit);
+	if (!cnx->Edge) VEC = 0;
+	else {
+		cnx->Edge = 0;
+		uint64_t dt = picoquic_get_quic_time(cnx->quic) - cnx->lastTrigger;
+		if (dt > PICOQUIC_VEC_LATE) { // DELAYED
+			VEC = 1;
+			fprintf(stderr, "Delayed Outgoing Spin=%d DT=%ld\n", cnx->current_spin, dt);
+		}
+	}
+
+	length = 0;
+        bytes[length++] = (K | C | spin_bit | VEC);
         length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, dest_cnx_id);
 
         *pn_offset = length;


### PR DESCRIPTION
Hello. This implements the Valid Edge Counter extension to the Spin Bit, as per section 4 of draft-trammell-quic-spin . To exercise it and validate the result, take a pcap and submit it to our online spibit+VEC analysis tool at http://193.252.113.227/cgi-bin/quicspin.cgi

Welcoming any comments/questions: alexandre.ferrieux@orange.com