### PR TITLE
Big frame refactoring. Phase 1. Decoder function.

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -269,7 +269,7 @@ int picoquic_prepare_stream_reset_frame(picoquic_stream_head* stream,
 }
 
 
-static int picoquic_decode_padding_or_padding_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max,
+static int picoquic_decode_padding_or_ping_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max,
                                                     picoquic_frame_type_enum_t frame_type)
 {
     /* As an optimization, consume multiple subsequent padding in one go */
@@ -282,12 +282,12 @@ static int picoquic_decode_padding_or_padding_frame(picoquic_cnx_t* cnx, const u
 
 int picoquic_decode_padding_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max, int restricted, uint64_t current_time)
 {
-    return picoquic_decode_padding_or_padding_frame(cnx, pbytes, bytes_max, picoquic_frame_type_padding);
+    return picoquic_decode_padding_or_ping_frame(cnx, pbytes, bytes_max, picoquic_frame_type_padding);
 }
 
 int picoquic_decode_ping_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max, int restricted, uint64_t current_time)
 {
-    return picoquic_decode_padding_or_padding_frame(cnx, pbytes, bytes_max, picoquic_frame_type_ping);
+    return picoquic_decode_padding_or_ping_frame(cnx, pbytes, bytes_max, picoquic_frame_type_ping);
 }
 
 int picoquic_decode_blocked_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max, int restricted, uint64_t current_time)

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1354,11 +1354,11 @@ int picoquic_incoming_packet(
             packet_length - consumed_index, packet_length,
             &consumed, addr_from, addr_to, if_index_to, current_time);
 
-        if (ret == 0) {
-            consumed_index += consumed;
-        } else {
+        if (ret != 0) {
             break;
         }
+
+        consumed_index += consumed;
     }
 
     return ret;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -79,7 +79,8 @@ typedef enum {
     picoquic_frame_type_ack_range_min_old = 0xa0,
     picoquic_frame_type_ack_range_max_old = 0xbf,
     picoquic_frame_type_stream_range_min_old = 0xc0,
-    picoquic_frame_type_stream_range_max_old = 0xcf
+    picoquic_frame_type_stream_range_max_old = 0xcf,
+    picoquic_frame_type_expired_stream_data = 0xf0
 } picoquic_frame_type_enum_t;
 
 /*
@@ -528,7 +529,7 @@ void picoformat_64(uint8_t* bytes, uint64_t n64);
 size_t picoquic_varint_encode(uint8_t* bytes, size_t max_bytes, uint64_t n64);
 void picoquic_varint_encode_16(uint8_t* bytes, uint16_t n16);
 size_t picoquic_varint_decode(const uint8_t* bytes, size_t max_bytes, uint64_t* n64);
-size_t picoquic_varint_skip(uint8_t* bytes);
+size_t picoquic_varint_skip(const uint8_t* bytes);
 
 void picoquic_headint_encode_32(uint8_t* bytes, uint64_t sequence_number);
 size_t picoquic_headint_decode(const uint8_t* bytes, size_t max_bytes, uint64_t* n64);
@@ -657,9 +658,9 @@ void picoquic_update_stream_initial_remote(picoquic_cnx_t* cnx);
 picoquic_stream_head* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t stream_id, int create);
 picoquic_stream_head* picoquic_find_ready_stream(picoquic_cnx_t* cnx, int restricted);
 int picoquic_stream_network_input(picoquic_cnx_t* cnx, uint64_t stream_id,
-    uint64_t offset, int fin, uint8_t* bytes, size_t length, uint64_t current_time);
-int picoquic_decode_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
-    size_t bytes_max, int restricted, size_t* consumed, uint64_t current_time);
+    uint64_t offset, int fin, const uint8_t* bytes, size_t length, uint64_t current_time);
+int picoquic_decode_stream_frame(picoquic_cnx_t* cnx, const uint8_t** pbytes, const uint8_t* bytes_max,
+                                 int restricted, uint64_t current_time);
 int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* stream,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
 int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
@@ -683,7 +684,7 @@ int picoquic_prepare_misc_frame(picoquic_misc_frame_header_t* misc_frame, uint8_
 
 /* send/receive */
 
-int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
+int picoquic_decode_frames(picoquic_cnx_t* cnx, const uint8_t* bytes,
     size_t bytes_max, int restricted, uint64_t current_time);
 
 int picoquic_skip_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed, int* pure_ack);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1236,12 +1236,12 @@ int picoquic_connection_error(picoquic_cnx_t* cnx, uint32_t local_error)
         cnx->local_error = local_error;
         cnx->cnx_state = picoquic_state_disconnecting;
 
-        DBG_PRINTF("Protocol error (%x)", local_error);
+        DBG_PRINTF("Protocol error (0x%x)", local_error);
     } else if (cnx->cnx_state < picoquic_state_client_ready) {
         cnx->local_error = local_error;
         cnx->cnx_state = picoquic_state_handshake_failure;
 
-        DBG_PRINTF("Protocol error %x", local_error);
+        DBG_PRINTF("Protocol error 0x%x", local_error);
     }
 
     return PICOQUIC_ERROR_DETECTED;

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -132,12 +132,12 @@ static int StreamZeroFrameOneTest(struct test_case_st* test)
     int ret = 0;
 
     picoquic_cnx_t cnx = { 0 };
-    size_t consumed = 0;
     uint64_t current_time = 0;
 
     for (size_t i = 0; ret == 0 && i < test->list_size; i++) {
-        if (0 != picoquic_decode_stream_frame(&cnx, test->list[i].packet,
-                     test->list[i].packet_length, 1, &consumed, current_time)) {
+        const uint8_t* bytes = test->list[i].packet + 1;
+        if (0 != picoquic_decode_stream_frame(&cnx, &bytes, test->list[i].packet + test->list[i].packet_length,
+                                              1, current_time)) {
             FAIL(test, "packet %" PRIst, i);
             ret = -1;
         }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1619,7 +1619,7 @@ static void ping_pong_callback(picoquic_cnx_t* cnx,
     ping_pong_test_callback_ctx_t* ping_pong_ctx = (ping_pong_test_callback_ctx_t*)callback_ctx;
     if (stream_id == 0 && fin_or_event == picoquic_callback_challenge_response) {
         /* This is a special frame call back. */
-        if (length == ping_pong_ctx->ping_length && bytes[0] == picoquic_frame_type_path_response && memcmp(bytes + 1, &ping_pong_ctx->ping_frame[1], length - 1) == 0) {
+        if (length == ping_pong_ctx->ping_length-1 && memcmp(bytes, &ping_pong_ctx->ping_frame[1], length) == 0) {
             ping_pong_ctx->pong_received++;
         } else {
             ping_pong_ctx->error_received++;


### PR DESCRIPTION

This is a very large commit.

# Purpose

I am trying to clean up and simplify a lot of code to make the semantics of frame operations easier to read and understand and, consequently, easier to keep bug-free.

This is just the first step in this direction.  I've only changed piciquic_decode_* functions.

Each function and its helpers check their own byte constraints.

I have also changed how frame accounting works (but only for piciquic_decode_* functions so far).
Before:
- keeping three variables responsible for each frame (buffer ptr, buffer size, and consumed bytes as an output)
- requiring the function to keep updating both the current index and the remaining buffer size.
- requiring the caller to update its own the current index and the remaining buffer size, based on the consumed bytes output of the callee.

Now:
- keeping two variables responsible for each frame (address of buffer ptr, max buffer pointer)
- requiring the function to keep updating only a single buffer ptr as it consumes data
- caller does not need to do anything at all

This allowed me to save a lot of code and improve readability by removing extraneous bookkeeping.

Also, early return in many places simplified code and improved readability to placing logically sequential operations in a single control flow of the function, instead of the normal flow control continuing into a branch of some conditional.

# Testing

Since I work on Linux, I was only able to test via the demo client/server app.
I have had to make a number of changes to unit tests -- both to get them to work with the new API at times and to correct semantic differences.  I am worried about the latter ones.  It is important to run Windows tests before establishing a complete trust in this update.

# PS

There was a few places where I had to add code for "impedance matching" between the new-style and old-style accounting functions.  I expect these will go away and get more streamlined as more of the codebase gets converted.