### PR TITLE
Basic stress test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   # Now build picotls examples and test
   - cmake .
   - make
-  - ./picoquic_ct -x stress
+  - ./picoquic_ct

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ script:
   # Now build picotls examples and test
   - cmake .
   - make
-  - ./picoquic_ct
+  - ./picoquic_ct -x stress

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ SET(PICOQUIC_TEST_LIBRARY_FILES
     picoquictest/sim_link.c
     picoquictest/socket_test.c
     picoquictest/stream0_frame_test.c
+    picoquictest/stress_test.c
     picoquictest/ticket_store_test.c
     picoquictest/tls_api_test.c
     picoquictest/transport_param_test.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ SET(PICOQUIC_TEST_LIBRARY_FILES
     picoquictest/sim_link.c
     picoquictest/socket_test.c
     picoquictest/stream0_frame_test.c
-    picoquictest/stress_test.c
+    picoquictest/stresstest.c
     picoquictest/ticket_store_test.c
     picoquictest/tls_api_test.c
     picoquictest/transport_param_test.c

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -568,5 +568,12 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+
+        TEST_METHOD(stress)
+        {
+            int ret = stress_test();
+
+            Assert::AreEqual(ret, 0);
+        }     
     };
 }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1478,8 +1478,6 @@ int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time)
 
     if (cnx->highest_ack_sent + 2 <= cnx->first_sack_item.end_of_sack_range || cnx->highest_ack_time + cnx->ack_delay_local <= current_time) {
         ret = cnx->ack_needed;
-    } else if (cnx->ack_needed) {
-        ret = 0;
     }
 
     return ret;

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -916,13 +916,13 @@ size_t picoquic_log_segment(FILE* F, int log_cnxid, picoquic_quic_t* quic, picoq
     int ret = 0;
     picoquic_packet_header ph;
     picoquic_cnx_t* pcnx = cnx;
-    uint32_t consumed = length;
+    uint32_t consumed = (uint32_t) length;
     uint64_t log_cnxid64 = 0;
     uint8_t decrypted[PICOQUIC_MAX_PACKET_SIZE];
 
     /* Parse the header and decrypt the packet */
     memcpy(decrypted, bytes, length);
-    ret = picoquic_parse_header_and_decrypt(quic, decrypted, length, length, addr_peer,
+    ret = picoquic_parse_header_and_decrypt(quic, decrypted, (uint32_t)length, (uint32_t)length, addr_peer,
         current_time, &ph, &cnx, &consumed, receiving);
 
     if (log_cnxid != 0) {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -354,6 +354,8 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx);
 void picoquic_set_callback(picoquic_cnx_t* cnx,
     picoquic_stream_data_cb_fn callback_fn, void* callback_ctx);
 
+void * picoquic_get_callback_context(picoquic_cnx_t* cnx);
+
 /* Send extra frames */
 int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length);
 

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -476,7 +476,6 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
                 cmsg_2->cmsg_level = IPPROTO_IPV6;
                 cmsg_2->cmsg_type = IPV6_DONTFRAG;
                 cmsg_2->cmsg_len = CMSG_LEN(sizeof(int));
-//                *((int *)CMSG_DATA(cmsg_2)) = val;
                 memcpy(CMSG_DATA(cmsg_2), &val, sizeof(int));
                 control_length += CMSG_SPACE(sizeof(int));
             }

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -476,7 +476,8 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
                 cmsg_2->cmsg_level = IPPROTO_IPV6;
                 cmsg_2->cmsg_type = IPV6_DONTFRAG;
                 cmsg_2->cmsg_len = CMSG_LEN(sizeof(int));
-                *((int *)CMSG_DATA(cmsg_2)) = val;
+//                *((int *)CMSG_DATA(cmsg_2)) = val;
+                memcpy(CMSG_DATA(cmsg_2), &val, sizeof(int));
                 control_length += CMSG_SPACE(sizeof(int));
             }
         }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -832,6 +832,8 @@ int picoquic_start_client_cnx(picoquic_cnx_t * cnx)
 {
     int ret = picoquic_initialize_stream_zero(cnx);
 
+    picoquic_cnx_set_next_wake_time(cnx, picoquic_get_quic_time(cnx->quic));
+
     return ret;
 }
 
@@ -997,6 +999,11 @@ void picoquic_set_callback(picoquic_cnx_t* cnx,
 {
     cnx->callback_fn = callback_fn;
     cnx->callback_ctx = callback_ctx;
+}
+
+void * picoquic_get_callback_context(picoquic_cnx_t * cnx)
+{
+    return cnx->callback_ctx;
 }
 
 picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -63,21 +63,7 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
             int parity = cnx->client_mode ? 0 : 1;
             if ((stream_id & 1) != parity) {
                 ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-            } else {
-#if 0
-                if ((stream_id & 2) == 0) {
-                    if (stream_id > cnx->max_stream_id_bidir_remote) {
-                        ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-                    }
-                } else {
-                    is_unidir = 1;
-
-                    if (stream_id > cnx->max_stream_id_unidir_remote) {
-                        ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-                    }
-                }
-#endif
-            }
+            } 
 
             if (ret == 0) {
                 stream = picoquic_create_stream(cnx, stream_id);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1900,7 +1900,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx, picoquic_packet* packet,
     if ((cnx->cnx_state < picoquic_state_disconnecting && 
         (current_time - cnx->latest_progress_time) > (PICOQUIC_MICROSEC_SILENCE_MAX*(2 - cnx->client_mode))) ||
         (cnx->cnx_state < picoquic_state_client_ready &&
-            current_time > cnx->start_time + PICOQUIC_MICROSEC_HANDSHAKE_MAX))
+            current_time >= cnx->start_time + PICOQUIC_MICROSEC_HANDSHAKE_MAX))
     {
         /* Too long silence, break it. */
         cnx->cnx_state = picoquic_state_disconnected;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -110,7 +110,8 @@ static const picoquic_test_def_t test_table[] = {
     { "pn_vector", cleartext_pn_vector_test },
     { "zero_rtt_spurious", zero_rtt_spurious_test },
     { "zero_rtt_retry", zero_rtt_retry_test },
-    { "parse_frames", parse_frame_test }
+    { "parse_frames", parse_frame_test },
+    { "stress", stress_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -105,6 +105,7 @@ int cleartext_pn_vector_test();
 int zero_rtt_spurious_test();
 int zero_rtt_retry_test();
 int parse_frame_test();
+int stress_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -150,6 +150,7 @@
     <ClCompile Include="skip_frame_test.c" />
     <ClCompile Include="socket_test.c" />
     <ClCompile Include="stream0_frame_test.c" />
+    <ClCompile Include="stresstest.c" />
     <ClCompile Include="ticket_store_test.c" />
     <ClCompile Include="tls_api_test.c" />
     <ClCompile Include="transport_param_test.c" />

--- a/picoquictest/picoquictest.vcxproj.filters
+++ b/picoquictest/picoquictest.vcxproj.filters
@@ -72,6 +72,9 @@
     <ClCompile Include="ticket_store_test.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="stresstest.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquictest.h">

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -333,7 +333,6 @@ int parse_frame_test()
     int ret = 0;
     uint8_t buffer[PICOQUIC_MAX_PACKET_SIZE];
     const uint8_t extra_bytes[4] = { 0, 0, 0, 0 };
-    uint64_t random_context = 0xBABED011;
     uint64_t simulated_time = 0;
     struct sockaddr_in saddr;
     picoquic_quic_t * qclient = picoquic_create(8, NULL, NULL, NULL, NULL,

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -332,11 +332,8 @@ int parse_frame_test()
 {
     int ret = 0;
     uint8_t buffer[PICOQUIC_MAX_PACKET_SIZE];
-    uint8_t fuzz_buffer[PICOQUIC_MAX_PACKET_SIZE];
     const uint8_t extra_bytes[4] = { 0, 0, 0, 0 };
     uint64_t random_context = 0xBABED011;
-    int fuzz_count = 0;
-    int fuzz_fail = 0;
     uint64_t simulated_time = 0;
     struct sockaddr_in saddr;
     picoquic_quic_t * qclient = picoquic_create(8, NULL, NULL, NULL, NULL,

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -24,6 +24,8 @@
 #include "picoquictest_internal.h"
 #ifdef _WINDOWS
 #include "..\picoquic\wincompat.h"
+#else
+#include <signal.h>
 #endif
 #include <picotls.h>
 #include <stddef.h>
@@ -167,9 +169,9 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
                     if (bidir_id < PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS) {
                         size_t received = ctx->data_received_on_stream[bidir_id] + length;
                         if (ctx->data_received_on_stream[bidir_id] < PICOQUIC_STRESS_MINIMAL_QUERY_SIZE) {
-                            int processed = length;
+                            int processed = (int) length;
                             if (received >= PICOQUIC_STRESS_MINIMAL_QUERY_SIZE) {
-                                processed = received - PICOQUIC_STRESS_MINIMAL_QUERY_SIZE;
+                                processed = (int) received - PICOQUIC_STRESS_MINIMAL_QUERY_SIZE;
                             }
 
                             for (int i = 0; i < processed; i++) {
@@ -243,7 +245,7 @@ static void stress_client_start_streams(picoquic_cnx_t* cnx,
         int stream_index = -1;
         for (size_t i = 0; i < ctx->max_open_streams; i++) {
             if (ctx->stream_id[i] == (uint64_t)((int64_t) -1)) {
-                stream_index = i;
+                stream_index = (int) i;
                 break;
             }
         }
@@ -291,7 +293,7 @@ static void stress_client_callback(picoquic_cnx_t* cnx,
 
         for (size_t i = 0; i < ctx->max_open_streams; i++) {
             if (ctx->stream_id[i] == stream_id) {
-                stream_index = i;
+                stream_index = (int) i;
                 break;
             }
         }
@@ -612,9 +614,7 @@ static int stress_loop_poll_context(picoquic_stress_ctx_t * ctx)
 {
     int ret = 0;
     int best_index = -1;
-    int last_index = -1;
     int64_t delay_max = 100000000;
-    uint64_t worst_wake_time = ctx->simulated_time + delay_max;
     uint64_t best_wake_time = ctx->simulated_time + picoquic_get_next_wake_delay(
         ctx->qserver, ctx->simulated_time, delay_max);
 
@@ -814,7 +814,7 @@ int stress_test()
             stress_ctx.nb_clients, PICOQUIC_MAX_STRESS_CLIENTS);
         ret = -1;
     } else {
-        stress_ctx.nb_clients = picoquic_stress_nb_clients;
+        stress_ctx.nb_clients = (int) picoquic_stress_nb_clients;
         stress_ctx.qserver = picoquic_create(PICOQUIC_MAX_STRESS_CLIENTS,
 #ifdef _WINDOWS
 #ifdef _WINDOWS64

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -43,15 +43,15 @@
 #define PICOQUIC_TEST_ALPN "picoquic-test"
 
 uint64_t picoquic_stress_test_duration = 120000000; /* Default to 2 minutes */
-size_t picoquic_stress_nb_clients = 1; /* Default to 4 clients */
-uint64_t picoquic_stress_max_bidir = 1 * 4; /* Default to 8 streams max per connection */
-size_t picoquic_stress_max_open_streams = 1; /* Default to 4 simultaneous streams max per connection */
+size_t picoquic_stress_nb_clients = 4; /* Default to 4 clients */
+uint64_t picoquic_stress_max_bidir = 8 * 4; /* Default to 8 streams max per connection */
+size_t picoquic_stress_max_open_streams = 4; /* Default to 4 simultaneous streams max per connection */
 
 typedef struct st_picoquic_stress_server_callback_ctx_t {
     // picoquic_first_server_stream_ctx_t* first_stream;
-    uint8_t buffer[PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE];
     size_t data_received_on_stream[PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS];
     uint32_t data_sum_of_stream[PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS];
+    uint8_t buffer[PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE];
 } picoquic_stress_server_callback_ctx_t;
 
 typedef struct st_picoquic_stress_client_callback_ctx_t {
@@ -181,6 +181,7 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
                                 response_length = ctx->data_sum_of_stream[bidir_id] % PICOQUIC_STRESS_RESPONSE_LENGTH_MAX;
                             }
                         }
+                        ctx->data_received_on_stream[bidir_id] += length;
                     }
 
                     /* for all streams above the limit, or all streams with short queries,just send a fixed size answer,

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -1,0 +1,175 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2018, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "../picoquic/picoquic_internal.h"
+#include "../picoquic/tls_api.h"
+#include "picoquictest_internal.h"
+#ifdef _WINDOWS
+#include "..\picoquic\wincompat.h"
+#endif
+#include <picotls.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <openssl/pem.h>
+
+/* Stress server callback: the same call back as the demo server.
+ */
+
+/* Stress client callback: same as the demo client callback, 
+ * based on scenarios. But we need to account for failures,
+ * effectively doing debugbreak in case of execution
+ * failure, so the stress can be run under debugger.
+ *
+ * Consider also adding client misbehavior in the future,
+ * including silent departure, version negotiation, or
+ * zero share start.
+ */
+
+/* Orchestration of the simulation: one server, N simulation
+ * links. On each link, there may be a new client added in
+ * the future. Links have different delays, capacity, and
+ * different client arrival rates.
+ */
+
+#define PICOQUIC_MAX_STRESS_CLIENTS 256
+
+typedef struct st_picoquic_stress_client_t {
+    picoquic_quic_t* qclient;
+    struct sockaddr_in client_addr;
+    picoquictest_sim_link_t* c_to_s_link;
+    picoquictest_sim_link_t* s_to_c_link;
+    int sum_data_received_at_client;
+} picoquic_stress_client_t;
+
+typedef struct st_picoquic_stress_ctx_t {
+    picoquic_quic_t* qserver;
+    size_t nb_stress_client;
+    int sum_data_received_at_server;
+    int sum_data_sent_at_server;
+    int nb_clients;
+    picoquic_stress_client_t * c_ctx[PICOQUIC_MAX_STRESS_CLIENTS];
+} picoquic_stress_ctx_t;
+
+/*
+ * Message loop
+ */
+
+int stress_submit_sp_packet(picoquic_stress_ctx_t * ctx, picoquic_stateless_packet_t* sp, int c_index)
+{
+    int ret = 0;
+    picoquictest_sim_link_t* target_link = NULL;
+    picoquictest_sim_packet_t* packet = picoquictest_sim_link_create_packet();
+
+    if (packet == NULL) {
+        ret = -1;
+    }
+    else {
+        if (sp->length > 0) {
+            memcpy(&packet->addr_from, &sp->addr_local,
+                (sp->addr_local.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+            memcpy(&packet->addr_to, &sp->addr_to,
+                (sp->addr_to.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+            memcpy(packet->bytes, sp->bytes, sp->length);
+            packet->length = sp->length;
+
+            if (c_index > 0)
+            {
+                target_link = ctx->c_ctx[c_index]->s_to_c_link;
+            }
+            else {
+                /* TODO: find target list from address */
+            }
+        }
+        picoquic_delete_stateless_packet(sp);
+    }
+
+    return ret;
+}
+
+int stress_loop_poll_context(picoquic_stress_ctx_t * ctx, uint64_t next_time, uint64_t current_time) {
+    int best_index = -1;
+    int last_index = -1;
+    int64_t delay_max = 100000000;
+    picoquic_stateless_packet_t* sp;
+    uint64_t worst_wake_time = current_time + delay_max;
+    uint64_t best_wake_time = current_time + picoquic_get_next_wake_delay(
+        ctx->qserver, current_time, delay_max);
+
+
+    while ((sp = picoquic_dequeue_stateless_packet(ctx->qserver)) != NULL)
+    {
+        /* send all the queued packets -- need to find out to which client. */
+    }
+
+    for (int x = 0; x < ctx->nb_clients; x++) {
+        /* Find the arrival time of the next packet, by looking at
+         * the various links. remember the winner */
+
+        if (ctx->c_ctx[x]->s_to_c_link->first_packet != NULL && 
+            ctx->c_ctx[x]->s_to_c_link->first_packet->arrival_time < best_wake_time) {
+            best_wake_time = ctx->c_ctx[x]->s_to_c_link->first_packet->arrival_time;
+            best_index = x;
+        }
+
+        if (ctx->c_ctx[x]->s_to_c_link->first_packet != NULL &&
+            ctx->c_ctx[x]->s_to_c_link->first_packet->arrival_time < best_wake_time) {
+            best_wake_time = ctx->c_ctx[x]->s_to_c_link->first_packet->arrival_time;
+            best_index = x;
+        }
+
+        if (ctx->c_ctx[x]->qclient->cnx_wake_first != NULL &&
+            ctx->c_ctx[x]->qclient->cnx_wake_first->next_wake_time < best_wake_time) {
+            best_wake_time = ctx->c_ctx[x]->qclient->cnx_wake_first->next_wake_time;
+            best_index = x;
+        }
+
+        while ((sp = picoquic_dequeue_stateless_packet(ctx->c_ctx[x]->qclient)) != NULL)
+        {
+            /* send all the queued packets -- need to find out to which client. */
+        }
+    }
+
+    /* Progress the current time */
+    current_time = best_wake_time;
+
+    if (best_index < 0) {
+        /* The server is ready first */
+    }
+    else {
+        if (ctx->c_ctx[best_index]->s_to_c_link->first_packet != NULL &&
+            ctx->c_ctx[best_index]->s_to_c_link->first_packet->arrival_time <= current_time) {
+            /* dequeue packet and submit */
+        }
+
+        if (ctx->c_ctx[best_index]->s_to_c_link->first_packet != NULL &&
+            ctx->c_ctx[best_index]->s_to_c_link->first_packet->arrival_time <= current_time) {
+            /* dequeue packet and submit */
+        }
+
+        if (ctx->c_ctx[best_index]->qclient->cnx_wake_first != NULL &&
+            ctx->c_ctx[best_index]->qclient->cnx_wake_first->next_wake_time <= current_time) {
+            /* prepare packet and submit */
+        }
+    }
+
+    return -1;
+}

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -825,7 +825,7 @@ int stress_test()
 #else
             "certs/cert.pem", "certs/key.pem",
 #endif
-            PICOQUIC_TEST_ALPN, stress_server_callback, (void*)&stress_ctx, NULL, NULL, NULL,
+            PICOQUIC_TEST_ALPN, stress_server_callback, NULL, NULL, NULL, NULL,
             stress_ctx.simulated_time, &stress_ctx.simulated_time, NULL,
             stress_ticket_encrypt_key, sizeof(stress_ticket_encrypt_key));
 

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -31,6 +31,60 @@
 #include <string.h>
 #include <openssl/pem.h>
 
+#define PICOQUIC_MAX_STRESS_CLIENTS 256
+#define PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS 16
+#define PICOQUIC_STRESS_MINIMAL_QUERY_SIZE 127
+#define PICOQUIC_STRESS_DEFAULT_RESPONSE_SIZE 257
+#define PICOQUIC_STRESS_RESPONSE_LENGTH_MAX 1000000
+#define PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE 0x10000
+#define PICOQUIC_STRESS_MAX_CLIENT_STREAMS 16
+
+#define PICOQUIC_TEST_SNI "picoquic.test"
+#define PICOQUIC_TEST_ALPN "picoquic-test"
+
+uint64_t picoquic_stress_test_duration = 120000000; /* Default to 2 minutes */
+size_t picoquic_stress_nb_clients = 1; /* Default to 4 clients */
+uint64_t picoquic_stress_max_bidir = 1 * 4; /* Default to 8 streams max per connection */
+size_t picoquic_stress_max_open_streams = 1; /* Default to 4 simultaneous streams max per connection */
+
+typedef struct st_picoquic_stress_server_callback_ctx_t {
+    // picoquic_first_server_stream_ctx_t* first_stream;
+    uint8_t buffer[PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE];
+    size_t data_received_on_stream[PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS];
+    uint32_t data_sum_of_stream[PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS];
+} picoquic_stress_server_callback_ctx_t;
+
+typedef struct st_picoquic_stress_client_callback_ctx_t {
+    uint64_t test_id;
+    uint64_t max_bidir;
+    uint64_t next_bidir;
+    size_t max_open_streams;
+    size_t nb_open_streams;
+    uint64_t stream_id[PICOQUIC_STRESS_MAX_CLIENT_STREAMS];
+    uint32_t nb_client_streams;
+    uint64_t last_interaction_time;
+    int progress_observed;
+} picoquic_stress_client_callback_ctx_t;
+
+typedef struct st_picoquic_stress_client_t {
+    picoquic_quic_t* qclient;
+    struct sockaddr_in client_addr;
+    char ticket_file_name[32];
+    picoquictest_sim_link_t* c_to_s_link;
+    picoquictest_sim_link_t* s_to_c_link;
+} picoquic_stress_client_t;
+
+typedef struct st_picoquic_stress_ctx_t {
+    picoquic_quic_t* qserver;
+    struct sockaddr_in server_addr;
+    uint64_t simulated_time;
+    int sum_data_received_at_server;
+    int sum_data_sent_at_server;
+    int sum_connections;
+    int nb_clients;
+    picoquic_stress_client_t * c_ctx[PICOQUIC_MAX_STRESS_CLIENTS];
+} picoquic_stress_ctx_t;
+
 /*
  * Portable abort call, should work on Linux and Windows.
  * We deliberately do not call the ASSERT macros, becuse these
@@ -54,19 +108,6 @@ static void stress_debug_break()
 * little state as possible.
 * TODO: add debug_break on error condition.
 */
-
-#define STRESS_MAX_NUMBER_TRACKED_STREAMS 16
-#define STRESS_MINIMAL_QUERY_SIZE 127
-#define STRESS_DEFAULT_RESPONSE_SIZE 257
-#define STRESS_RESPONSE_LENGTH_MAX 1000000
-#define STRESS_MESSAGE_BUFFER_SIZE 0x10000
-
-typedef struct st_picoquic_stress_server_callback_ctx_t {
-    // picoquic_first_server_stream_ctx_t* first_stream;
-    uint8_t buffer[STRESS_MESSAGE_BUFFER_SIZE];
-    size_t data_received_on_stream[STRESS_MAX_NUMBER_TRACKED_STREAMS];
-    uint32_t data_sum_of_stream[STRESS_MAX_NUMBER_TRACKED_STREAMS];
-} picoquic_stress_server_callback_ctx_t;
 
 static void stress_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
@@ -123,12 +164,12 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
                     size_t response_length = 0;
 
 
-                    if (bidir_id < STRESS_MAX_NUMBER_TRACKED_STREAMS) {
+                    if (bidir_id < PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS) {
                         size_t received = ctx->data_received_on_stream[bidir_id] + length;
-                        if (ctx->data_received_on_stream[bidir_id] < STRESS_MINIMAL_QUERY_SIZE) {
+                        if (ctx->data_received_on_stream[bidir_id] < PICOQUIC_STRESS_MINIMAL_QUERY_SIZE) {
                             int processed = length;
-                            if (received >= STRESS_MINIMAL_QUERY_SIZE) {
-                                processed = received - STRESS_MINIMAL_QUERY_SIZE;
+                            if (received >= PICOQUIC_STRESS_MINIMAL_QUERY_SIZE) {
+                                processed = received - PICOQUIC_STRESS_MINIMAL_QUERY_SIZE;
                             }
 
                             for (int i = 0; i < processed; i++) {
@@ -136,8 +177,8 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
                                     ctx->data_sum_of_stream[bidir_id] * 101 + bytes[i];
                             }
 
-                            if (received >= STRESS_MINIMAL_QUERY_SIZE) {
-                                response_length = ctx->data_sum_of_stream[bidir_id] % STRESS_RESPONSE_LENGTH_MAX;
+                            if (received >= PICOQUIC_STRESS_MINIMAL_QUERY_SIZE) {
+                                response_length = ctx->data_sum_of_stream[bidir_id] % PICOQUIC_STRESS_RESPONSE_LENGTH_MAX;
                             }
                         }
                     }
@@ -145,22 +186,22 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
                     /* for all streams above the limit, or all streams with short queries,just send a fixed size answer,
                     * after receiving all the client data */
                     if (fin_or_event == picoquic_callback_stream_fin &&
-                        (bidir_id >= STRESS_MAX_NUMBER_TRACKED_STREAMS ||
-                            ctx->data_received_on_stream[bidir_id] < STRESS_MINIMAL_QUERY_SIZE)) {
+                        (bidir_id >= PICOQUIC_STRESS_MAX_NUMBER_TRACKED_STREAMS ||
+                            ctx->data_received_on_stream[bidir_id] < PICOQUIC_STRESS_MINIMAL_QUERY_SIZE)) {
 
-                        response_length = STRESS_DEFAULT_RESPONSE_SIZE;
+                        response_length = PICOQUIC_STRESS_DEFAULT_RESPONSE_SIZE;
                     }
 
                     if (response_length > 0) {
                         /* Push data on the stream */
 
-                        while (response_length > STRESS_MESSAGE_BUFFER_SIZE) {
+                        while (response_length > PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE) {
                             if ( (ret = picoquic_add_to_stream(cnx, stream_id, ctx->buffer,
-                                STRESS_MESSAGE_BUFFER_SIZE, 0)) != 0) {
+                                PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE, 0)) != 0) {
                                 stress_debug_break();
                             }
 
-                            response_length -= STRESS_MESSAGE_BUFFER_SIZE;
+                            response_length -= PICOQUIC_STRESS_MESSAGE_BUFFER_SIZE;
                         }
                         if ((ret = picoquic_add_to_stream(cnx, stream_id, ctx->buffer,
                                 response_length, 1)) != 0) {
@@ -189,19 +230,6 @@ static void stress_server_callback(picoquic_cnx_t* cnx,
  * zero share start.
  */
 
-#define STRESS_MAX_CLIENT_STREAMS 16
-
-typedef struct st_picoquic_stress_client_callback_ctx_t {
-    uint64_t test_id;
-    uint64_t max_bidir;
-    uint64_t next_bidir;
-    size_t max_open_streams;
-    size_t nb_open_streams;
-    uint64_t stream_id[STRESS_MAX_CLIENT_STREAMS];
-    uint32_t nb_client_streams;
-    uint64_t last_interaction_time;
-    int progress_observed;
-} picoquic_stress_client_callback_ctx_t;
 
 static void stress_client_start_streams(picoquic_cnx_t* cnx,
     picoquic_stress_client_callback_ctx_t* ctx) 
@@ -305,7 +333,7 @@ static void stress_client_callback(picoquic_cnx_t* cnx,
                 }
                 else {
                     /* Initialize the next bidir stream  */
-                    stress_client_start_streams(ctx, cnx);
+                    stress_client_start_streams(cnx, ctx);
                 }
             }
         }
@@ -314,41 +342,54 @@ static void stress_client_callback(picoquic_cnx_t* cnx,
     /* that's it */
 }
 
+int stress_client_set_callback(picoquic_cnx_t* cnx) 
+{
+    static uint64_t test_id = 0;
+    int ret = 0;
+
+    if (picoquic_get_callback_context(cnx) != NULL) {
+        /* Duplicate init call. This is a bug */
+        stress_debug_break();
+        ret = -1;
+    }
+    else {
+        picoquic_stress_client_callback_ctx_t* ctx = 
+            (picoquic_stress_client_callback_ctx_t*)malloc(sizeof(picoquic_stress_client_callback_ctx_t));
+        if (ctx == NULL) {
+            stress_debug_break();
+            ret = -1;
+        }
+        else {
+            memset(ctx, 0, sizeof(picoquic_stress_client_callback_ctx_t));
+            ctx->test_id = test_id++;
+            ctx->max_bidir = picoquic_stress_max_bidir;
+            ctx->max_open_streams = picoquic_stress_max_open_streams;
+            ctx->next_bidir = 4; /* TODO: change to zero when cream/crack gets done */
+            for (size_t i = 0; i < ctx->max_open_streams; i++) {
+                ctx->stream_id[i] = (uint64_t)((int64_t)-1);
+            }
+            picoquic_set_callback(cnx, stress_client_callback, ctx);
+
+            stress_client_start_streams(cnx, ctx);
+        }
+    }
+
+    return ret;
+}
+
 /* Orchestration of the simulation: one server, N simulation
  * links. On each link, there may be a new client added in
  * the future. Links have different delays, capacity, and
  * different client arrival rates.
  */
 
-#define PICOQUIC_MAX_STRESS_CLIENTS 256
-
-typedef struct st_picoquic_stress_client_t {
-    picoquic_quic_t* qclient;
-    struct sockaddr_in client_addr;
-    picoquictest_sim_link_t* c_to_s_link;
-    picoquictest_sim_link_t* s_to_c_link;
-    int sum_data_received_at_client;
-} picoquic_stress_client_t;
-
-typedef struct st_picoquic_stress_ctx_t {
-    picoquic_quic_t* qserver;
-    uint64_t simulated_time;
-    size_t nb_stress_client;
-    int sum_data_received_at_server;
-    int sum_data_sent_at_server;
-    int nb_clients;
-    picoquic_stress_client_t * c_ctx[PICOQUIC_MAX_STRESS_CLIENTS];
-} picoquic_stress_ctx_t;
-
 /*
  * Message loop and related functions
  */
 
-void stress_set_ip_address_from_index(struct sockaddr_in * addr, int c_index)
+static void stress_set_ip_address_from_index(struct sockaddr_in * addr, int c_index)
 {
-    int ret = 0;
-
-    memset(&addr, 0, sizeof(struct sockaddr_in));
+    memset(addr, 0, sizeof(struct sockaddr_in));
     addr->sin_family = AF_INET;
 #ifdef _WINDOWS
     addr->sin_addr.S_un.S_addr = (ULONG) c_index;
@@ -358,9 +399,9 @@ void stress_set_ip_address_from_index(struct sockaddr_in * addr, int c_index)
     addr->sin_port = 4321;
 }
 
-int stress_get_index_from_ip_address(struct sockaddr_in * addr)
+static int stress_get_index_from_ip_address(struct sockaddr_in * addr)
 {
-    uint32_t c_index = -1;
+    uint32_t c_index;
 #ifdef _WINDOWS
     c_index = (int)addr->sin_addr.S_un.S_addr;
 #else
@@ -370,43 +411,55 @@ int stress_get_index_from_ip_address(struct sockaddr_in * addr)
 }
 
 
-int stress_submit_sp_packets(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, int c_index)
+static int stress_submit_sp_packets(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, int c_index)
 {
     int ret = 0;
     picoquic_stateless_packet_t* sp = NULL;
     picoquictest_sim_link_t* target_link = NULL;
-    picoquictest_sim_packet_t* packet = picoquictest_sim_link_create_packet();
 
-    if (packet == NULL) {
-        ret = -1;
-    }
-    else while ((sp = picoquic_dequeue_stateless_packet(q)) != NULL) {
+    while ((sp = picoquic_dequeue_stateless_packet(q)) != NULL) {
         if (sp->length > 0) {
-            memcpy(&packet->addr_from, &sp->addr_local,
-                (sp->addr_local.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
-            memcpy(&packet->addr_to, &sp->addr_to,
-                (sp->addr_to.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
-            memcpy(packet->bytes, sp->bytes, sp->length);
-            packet->length = sp->length;
+            picoquictest_sim_packet_t* packet = picoquictest_sim_link_create_packet();
 
-            if (c_index > 0)
-            {
-                target_link = ctx->c_ctx[c_index]->c_to_s_link;
+            if (packet == NULL) {
+                stress_debug_break();
+                ret = -1;
+                break;
             }
             else {
-                /* find target from address */
-                int d_index = stress_get_index_from_ip_address((struct sockaddr_in *) &sp->addr_to);
+                memcpy(&packet->addr_from, &sp->addr_local,
+                    (sp->addr_local.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+                memcpy(&packet->addr_to, &sp->addr_to,
+                    (sp->addr_to.ss_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
+                memcpy(packet->bytes, sp->bytes, sp->length);
+                packet->length = sp->length;
 
-                if (d_index < 0 || d_index >= ctx->nb_clients) {
-                    ret = -1;
+                if (c_index >= 0)
+                {
+                    target_link = ctx->c_ctx[c_index]->c_to_s_link;
                 }
                 else {
-                    target_link = ctx->c_ctx[c_index]->s_to_c_link;
-                }
-            }
+                    /* find target from address */
+                    int d_index = stress_get_index_from_ip_address((struct sockaddr_in *) &sp->addr_to);
 
-            if (target_link != NULL) {
-                picoquictest_sim_link_submit(target_link, packet, ctx->simulated_time);
+                    if (d_index < 0 || d_index >= ctx->nb_clients) {
+                        stress_debug_break();
+                        ret = -1;
+                    }
+                    else {
+                        target_link = ctx->c_ctx[d_index]->s_to_c_link;
+                    }
+                }
+
+                if (target_link != NULL) {
+                    picoquictest_sim_link_submit(target_link, packet, ctx->simulated_time);
+                }
+                else {
+                    free(packet);
+                    stress_debug_break();
+                    ret = -1;
+                    break;
+                }
             }
         }
         picoquic_delete_stateless_packet(sp);
@@ -415,7 +468,7 @@ int stress_submit_sp_packets(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, i
     return ret;
 }
 
-int stress_handle_packet_arrival(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, picoquictest_sim_link_t* link)
+static int stress_handle_packet_arrival(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, picoquictest_sim_link_t* link)
 {
     int ret = 0;
     /* dequeue packet from server to client and submit */
@@ -426,12 +479,15 @@ int stress_handle_packet_arrival(picoquic_stress_ctx_t * ctx, picoquic_quic_t * 
             (struct sockaddr*)&packet->addr_from,
             (struct sockaddr*)&packet->addr_to, 0,
             ctx->simulated_time);
+        if (ret != 0){
+            stress_debug_break();
+        }
     }
 
     return ret;
 }
 
-int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, int c_index)
+static int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_quic_t * q, int c_index)
 {
     /* prepare packet and submit */
     int ret = 0;
@@ -447,7 +503,7 @@ int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_quic_t * 
             memcpy(&packet->addr_from, &cnx->path[0]->dest_addr, sizeof(struct sockaddr_in));
             memcpy(&packet->addr_to, &cnx->path[0]->peer_addr, sizeof(struct sockaddr_in));
 
-            if (c_index > 0)
+            if (c_index >= 0)
             {
                 target_link = ctx->c_ctx[c_index]->c_to_s_link;
             }
@@ -456,23 +512,59 @@ int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_quic_t * 
                 int d_index = stress_get_index_from_ip_address((struct sockaddr_in *) &packet->addr_to);
 
                 if (d_index < 0 || d_index >= ctx->nb_clients) {
+                    stress_debug_break();
                     ret = -1;
                 }
                 else {
-                    target_link = ctx->c_ctx[c_index]->s_to_c_link;
+                    target_link = ctx->c_ctx[d_index]->s_to_c_link;
                 }
             }
-
-            picoquictest_sim_link_submit(target_link, packet, ctx->simulated_time);
+            if (target_link != NULL) {
+                picoquictest_sim_link_submit(target_link, packet, ctx->simulated_time);
+            }
         }
         else {
             free(p);
+            p = NULL;
+            free(packet);
+            packet = NULL;
+
+            if (ret == PICOQUIC_ERROR_DISCONNECTED) {
+                if (c_index >= 0) {
+                    /* Check that the client connection was properly terminated */
+                    picoquic_stress_client_callback_ctx_t* c_ctx = 
+                        (picoquic_stress_client_callback_ctx_t*)picoquic_get_callback_context(cnx);
+                    ret = 0;
+                    if (c_ctx != NULL) {
+                        if (c_ctx->next_bidir <= c_ctx->max_bidir ||
+                            c_ctx->nb_open_streams != 0) {
+                            stress_debug_break();
+                            ret = -1;
+                        }
+                        free(c_ctx);
+                        picoquic_set_callback(cnx, NULL, NULL);
+                    }
+                }
+                else {
+                    ret = 0;
+                }
+                picoquic_delete_cnx(cnx);
+                if (c_index >= 0 && q->cnx_wake_first != NULL) {
+                    stress_debug_break();
+                    ret = -1;
+                }
+            }
+            else if (ret != 0) {
+                stress_debug_break();
+            }
         }
-        free(packet);
     }
     else
     {
-        ret = -1;
+        if (cnx != NULL) {
+            stress_debug_break();
+            ret = -1;
+        }
         if (packet != NULL) {
             free(packet);
         }
@@ -485,7 +577,38 @@ int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_quic_t * 
     return ret;
 }
 
-int stress_loop_poll_context(picoquic_stress_ctx_t * ctx, uint64_t next_time) {
+static int stress_start_client_connection(picoquic_quic_t * qclient, picoquic_stress_ctx_t * ctx)
+{
+    int ret = 0;
+
+    picoquic_cnx_t * cnx = picoquic_create_cnx(qclient,
+        picoquic_null_connection_id, picoquic_null_connection_id,
+        (struct sockaddr*)&ctx->server_addr, ctx->simulated_time,
+        0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, 1);
+
+    if (cnx == NULL) {
+        stress_debug_break();
+        ret = -1;
+    }
+    else {
+        ret = stress_client_set_callback(cnx);
+
+        if (ret == 0) {
+            ret = picoquic_start_client_cnx(cnx);
+            if (ret != 0) {
+                stress_debug_break();
+            }
+        }
+        else {
+            stress_debug_break();
+        }
+    }
+
+    return ret;
+}
+
+static int stress_loop_poll_context(picoquic_stress_ctx_t * ctx) 
+{
     int ret = 0;
     int best_index = -1;
     int last_index = -1;
@@ -519,6 +642,10 @@ int stress_loop_poll_context(picoquic_stress_ctx_t * ctx, uint64_t next_time) {
         }
 
         ret = stress_submit_sp_packets(ctx, ctx->c_ctx[x]->qclient, x);
+
+        if (ret != 0) {
+            stress_debug_break();
+        }
     }
 
     if (ret == 0) {
@@ -528,24 +655,38 @@ int stress_loop_poll_context(picoquic_stress_ctx_t * ctx, uint64_t next_time) {
         if (best_index < 0) {
             /* The server is ready first */
             ret = stress_handle_packet_prepare(ctx, ctx->qserver, -1);
+
+            if (ret != 0) {
+                stress_debug_break();
+            }
         }
         else {
             if (ret == 0 && ctx->c_ctx[best_index]->s_to_c_link->first_packet != NULL &&
                 ctx->c_ctx[best_index]->s_to_c_link->first_packet->arrival_time <= ctx->simulated_time) {
                 /* dequeue packet from server to client and submit */
                 ret = stress_handle_packet_arrival(ctx, ctx->c_ctx[best_index]->qclient, ctx->c_ctx[best_index]->s_to_c_link);
+                if (ret != 0) {
+                    stress_debug_break();
+                }
             }
 
             if (ret == 0 && ctx->c_ctx[best_index]->c_to_s_link->first_packet != NULL &&
                 ctx->c_ctx[best_index]->c_to_s_link->first_packet->arrival_time <= ctx->simulated_time) {
                 /* dequeue packet from client to server and submit */
                 ret = stress_handle_packet_arrival(ctx, ctx->qserver, ctx->c_ctx[best_index]->c_to_s_link);
+                if (ret != 0) {
+                    stress_debug_break();
+                }
             }
 
-            if (ctx->c_ctx[best_index]->qclient->cnx_wake_first != NULL &&
-                ctx->c_ctx[best_index]->qclient->cnx_wake_first->next_wake_time <= ctx->simulated_time) {
-
-                ret = stress_handle_packet_prepare(ctx, ctx->c_ctx[best_index]->qclient, best_index);
+            if (ctx->c_ctx[best_index]->qclient->cnx_wake_first != NULL) {
+                /* If the connection is valid, check whether it is ready */
+                if (ctx->c_ctx[best_index]->qclient->cnx_wake_first->next_wake_time <= ctx->simulated_time) {
+                    ret = stress_handle_packet_prepare(ctx, ctx->c_ctx[best_index]->qclient, best_index);
+                    if (ret != 0) {
+                        stress_debug_break();
+                    }
+                }
             }
         }
     }
@@ -553,3 +694,181 @@ int stress_loop_poll_context(picoquic_stress_ctx_t * ctx, uint64_t next_time) {
     return ret;
 }
 
+/* Stress test management
+ * Parameters:
+ *    Number of clients
+ *    Simulated duration of stress test
+ *    Profile of client run, i.e. max number of queries/client.
+ *
+ * Operation:
+ *    Initialize the context:
+ *    Loop:
+ *        Clean terminated connections (part of simulation loop)
+ *        Create connection for empty client contexts (part of simulation loop?)
+ *        Run the loop, sending packets, etc.
+ *    Clean up:
+ *        Set termination flag for all contexts: close existing connections, do not create new ones.
+ *        Run the loop until all contexts are freed.
+ *        Fail if cannot clean up on a timeout.
+ *    Report:
+ *        Statistics on duration, volume, connections.
+ *
+ * Stress succeeds if it comes to a successful end.
+ */
+
+static const uint8_t stress_ticket_encrypt_key[32] = {
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+};
+
+static int stress_create_client_context(int client_index, picoquic_stress_ctx_t * stress_ctx)
+{
+    int ret = 0;
+    picoquic_stress_client_t * ctx = (picoquic_stress_client_t *)malloc(sizeof(picoquic_stress_client_t));
+    stress_ctx->c_ctx[client_index] = ctx;
+
+    if (ctx == NULL) {
+        DBG_PRINTF("Cannot create the client context #%d.\n", (int)client_index);
+        ret = -1;
+    }
+    if (ret == 0) {
+        memset(ctx, 0, sizeof(picoquic_stress_client_t));
+        /* Initialize client specific address */
+        stress_set_ip_address_from_index(&ctx->client_addr, (int)client_index);
+        /* set stream ID to default value */
+
+        /* initialize client specific ticket file */
+        memcpy(ctx->ticket_file_name, "stress_ticket_000.bin", 19);
+        ctx->ticket_file_name[14] = (uint8_t)('0' + client_index / 100);
+        ctx->ticket_file_name[15] = (uint8_t)('0' + (client_index / 10) % 10);
+        ctx->ticket_file_name[16] = (uint8_t)('0' + client_index % 10);
+        ctx->ticket_file_name[21] = 0;
+        if (ret == 0) {
+            ret = picoquic_save_tickets(NULL, stress_ctx->simulated_time, ctx->ticket_file_name);
+            if (ret != 0) {
+                DBG_PRINTF("Cannot create ticket file <%s>.\n", ctx->ticket_file_name);
+            }
+        }
+    }
+    if (ret == 0) {
+        /* initialize the simulation links from client to server and back. */
+        ctx->c_to_s_link = picoquictest_sim_link_create(0.01, 10000, 0, 0, 0);
+        ctx->s_to_c_link = picoquictest_sim_link_create(0.01, 10000, 0, 0, 0);
+        if (ctx->c_to_s_link == NULL ||
+            ctx->s_to_c_link == NULL) {
+            DBG_PRINTF("Cannot create the sim links for client #%d.\n", (int)client_index);
+            ret = -1;
+        }
+    }
+
+    if (ret == 0) {
+        /* Create the quic context for this client*/
+        ctx->qclient = picoquic_create(8, NULL, NULL, NULL, NULL,
+            NULL, NULL, NULL, NULL, stress_ctx->simulated_time, &stress_ctx->simulated_time,
+            ctx->ticket_file_name, NULL, 0);
+        if (ctx->qclient == NULL) {
+            DBG_PRINTF("Cannot create the quic client #%d.\n", (int)client_index);
+            ret = -1;
+        }
+    }
+
+    return ret;
+}
+
+static void stress_delete_client_context(int client_index, picoquic_stress_ctx_t * stress_ctx)
+{
+    picoquic_stress_client_t * ctx = stress_ctx->c_ctx[client_index];
+
+    if (ctx != NULL) {
+        if (ctx->qclient != NULL) {
+            picoquic_free(ctx->qclient);
+            ctx->qclient = NULL;
+        }
+
+        if (ctx->c_to_s_link != NULL) {
+            picoquictest_sim_link_delete(ctx->c_to_s_link);
+            ctx->c_to_s_link = NULL;
+        }
+
+        if (ctx->s_to_c_link != NULL) {
+            picoquictest_sim_link_delete(ctx->s_to_c_link);
+            ctx->s_to_c_link = NULL;
+        }
+        free(ctx);
+
+        stress_ctx->c_ctx[client_index] = NULL;
+    }
+}
+
+int stress_test()
+{
+    int ret = 0;
+    picoquic_stress_ctx_t stress_ctx;
+
+    /* Initialization */
+    memset(&stress_ctx, 0, sizeof(picoquic_stress_ctx_t));
+    stress_set_ip_address_from_index(&stress_ctx.server_addr, -1);
+    if (stress_ctx.nb_clients > PICOQUIC_MAX_STRESS_CLIENTS) {
+        DBG_PRINTF("Number of stress clients too high (%d). Should be lower than %d\n",
+            stress_ctx.nb_clients, PICOQUIC_MAX_STRESS_CLIENTS);
+        ret = -1;
+    } else {
+        stress_ctx.nb_clients = picoquic_stress_nb_clients;
+        stress_ctx.qserver = picoquic_create(PICOQUIC_MAX_STRESS_CLIENTS,
+#ifdef _WINDOWS
+#ifdef _WINDOWS64
+            "..\\..\\certs\\cert.pem", "..\\..\\certs\\key.pem",
+#else
+            "..\\certs\\cert.pem", "..\\certs\\key.pem",
+#endif
+#else
+            "certs/cert.pem", "certs/key.pem",
+#endif
+            PICOQUIC_TEST_ALPN, stress_server_callback, (void*)&stress_ctx, NULL, NULL, NULL,
+            stress_ctx.simulated_time, &stress_ctx.simulated_time, NULL,
+            stress_ticket_encrypt_key, sizeof(stress_ticket_encrypt_key));
+
+        if (stress_ctx.qserver == NULL) {
+            DBG_PRINTF("%s", "Cannot create the test server.\n");
+            ret = -1;
+        }
+        else {
+            for (int i = 0; ret == 0 && i < stress_ctx.nb_clients; i++) {
+                ret = stress_create_client_context(i, &stress_ctx);
+            }
+        }
+    }
+
+    /* Run the simulation until the specified time */
+    while (ret == 0 && stress_ctx.simulated_time < picoquic_stress_test_duration) {
+        /* Poll for new packet transmission */
+        ret = stress_loop_poll_context(&stress_ctx);
+
+        if (ret == 0) {
+            /* Check whether there is a need for new connections */
+            for (int i = 0; ret == 0 && i < stress_ctx.nb_clients; i++) {
+                if (stress_ctx.c_ctx[i]->qclient->cnx_list == NULL) {
+                    ret = stress_start_client_connection(stress_ctx.c_ctx[i]->qclient, &stress_ctx);
+                    if (ret != 0) {
+                        stress_debug_break();
+                    }
+                }
+            }
+        }
+        else {
+            stress_debug_break();
+        }
+    }
+
+    /* Shut down everything */
+    for (int i = 0; i < stress_ctx.nb_clients; i++) {
+        stress_delete_client_context((int)i, &stress_ctx);
+    }
+
+    if (stress_ctx.qserver != NULL) {
+        picoquic_free(stress_ctx.qserver);
+        stress_ctx.qserver = NULL;
+    }
+
+    return ret;
+}

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1239,7 +1239,7 @@ int tls_api_very_long_max_test()
 
 int tls_api_very_long_with_err_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 10000000, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 11000000, NULL);
 }
 
 int tls_api_very_long_congestion_test()

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -302,9 +302,9 @@ static void test_api_callback(picoquic_cnx_t* cnx,
 
     if (stream_id > 0) {
         if (cb_ctx->client_mode) {
-            ctx->sum_data_received_at_client += length;
+            ctx->sum_data_received_at_client += (int) length;
         } else {
-            ctx->sum_data_received_at_server += length;
+            ctx->sum_data_received_at_server += (int) length;
         }
     }
 


### PR DESCRIPTION
Create a stress test. The test is parameterized by duration, number of clients, and number of queries in a client session. The default stress run, part of the unit test, runs for 2 minutes with 4 clients and 16 streams. The plan is to use additional "-s" parameters to the picoquic_ct test exe to change these parameters, but we need to keep it simple initially. These parameters are not yet implemented.

We can also think of adding some variability in the client profiles. For example, we could simulate clients that go away without completing the connection, or without closing it. This is not implemented yet. We could also add a fuzzing option, in which clients sometimes send bogus messages. That, too, is not implemented.

The simple stress test found many "hot loops" bugs, which are also fixed in this PR.