### PR TITLE
Use a splay tree to order connections by wake time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Release
 */*.dll
 */*.xbf
 */*.ilk
+*.b

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ SET(PICOQUIC_LIBRARY_FILES
     picoquic/packet.c
     picoquic/picohash.c
     picoquic/picosocks.c
+    picoquic/picosplay.c
     picoquic/quicctx.c
     picoquic/sacks.c
     picoquic/sender.c
@@ -50,6 +51,7 @@ SET(PICOQUIC_TEST_LIBRARY_FILES
     picoquictest/skip_frame_test.c
     picoquictest/sim_link.c
     picoquictest/socket_test.c
+    picoquictest/splay_test.c
     picoquictest/stream0_frame_test.c
     picoquictest/stresstest.c
     picoquictest/ticket_store_test.c

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -574,6 +574,15 @@ namespace UnitTest1
             int ret = stress_test();
 
             Assert::AreEqual(ret, 0);
-        }     
+        }
+
+
+        TEST_METHOD(splay)
+        {
+            int ret = splay_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+        
     };
 }

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -142,6 +142,7 @@
     <ClCompile Include="logger.c" />
     <ClCompile Include="newreno.c" />
     <ClCompile Include="picosocks.c" />
+    <ClCompile Include="picosplay.c" />
     <ClCompile Include="quicctx.c" />
     <ClCompile Include="packet.c" />
     <ClCompile Include="picohash.c" />
@@ -157,6 +158,7 @@
     <ClInclude Include="picohash.h" />
     <ClInclude Include="picoquic_internal.h" />
     <ClInclude Include="picosocks.h" />
+    <ClInclude Include="picosplay.h" />
     <ClInclude Include="picotlsapi.h" />
     <ClInclude Include="picoquic.h" />
     <ClInclude Include="tls_api.h" />

--- a/picoquic/picoquic.vcxproj.filters
+++ b/picoquic/picoquic.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="ticket_store.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="picosplay.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquic.h">
@@ -90,6 +93,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="picosocks.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="picosplay.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -23,7 +23,6 @@
 #define PICOQUIC_INTERNAL_H
 
 #include "picohash.h"
-#include "picosplay.h"
 #include "picoquic.h"
 #include "picotlsapi.h"
 #include "util.h"
@@ -183,7 +182,9 @@ typedef struct st_picoquic_quic_t {
     struct st_picoquic_cnx_t* cnx_list;
     struct st_picoquic_cnx_t* cnx_last;
 
-    picosplay_tree cnx_wake_tree;
+    struct st_picoquic_cnx_t* cnx_wake_first;
+    struct st_picoquic_cnx_t* cnx_wake_last;
+
     picohash_table* table_cnx_by_id;
     picohash_table* table_cnx_by_net;
 
@@ -242,7 +243,6 @@ typedef struct st_picoquic_sack_item_t {
     struct st_picoquic_sack_item_t* next_sack;
     uint64_t start_of_sack_range;
     uint64_t end_of_sack_range;
-    // uint64_t time_stamp_last_in_range;
 } picoquic_sack_item_t;
 
 /*
@@ -408,6 +408,8 @@ typedef struct st_picoquic_cnx_t {
 
     /* Next time sending data is expected */
     uint64_t next_wake_time;
+    struct st_picoquic_cnx_t* next_by_wake_time;
+    struct st_picoquic_cnx_t* previous_by_wake_time;
 
     /* TLS context, TLS Send Buffer, chain of receive buffers (todo) */
     void* tls_ctx;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -514,7 +514,7 @@ void picoquic_update_pacing_data(picoquic_path_t * path_x);
 
 /* Next time is used to order the list of available connections,
      * so ready connections are polled first */
-void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx);
+void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t next_time);
 
 void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -23,6 +23,7 @@
 #define PICOQUIC_INTERNAL_H
 
 #include "picohash.h"
+#include "picosplay.h"
 #include "picoquic.h"
 #include "picotlsapi.h"
 #include "util.h"
@@ -182,9 +183,7 @@ typedef struct st_picoquic_quic_t {
     struct st_picoquic_cnx_t* cnx_list;
     struct st_picoquic_cnx_t* cnx_last;
 
-    struct st_picoquic_cnx_t* cnx_wake_first;
-    struct st_picoquic_cnx_t* cnx_wake_last;
-
+    picosplay_tree cnx_wake_tree;
     picohash_table* table_cnx_by_id;
     picohash_table* table_cnx_by_net;
 
@@ -362,8 +361,6 @@ typedef struct st_picoquic_cnx_t {
     /* Management of context retrieval tables */
     struct st_picoquic_cnx_t* next_in_table;
     struct st_picoquic_cnx_t* previous_in_table;
-    struct st_picoquic_cnx_t* next_by_wake_time;
-    struct st_picoquic_cnx_t* previous_by_wake_time;
     struct st_picoquic_cnx_id_t* first_cnx_id;
     struct st_picoquic_net_id_t* first_net_id;
 

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -79,6 +79,13 @@ static void zigzag(picosplay_node *x) {
     rotate(x);
 }
 
+/* Initialize an empty tree, storing the picosplay_comparator. */
+void picosplay_init_tree(picosplay_tree* tree, picosplay_comparator comp) {
+    tree->comp = comp;
+    tree->root = NULL;
+    tree->size = 0;
+}
+
 /* Return an empty tree, storing the picosplay_comparator. */
 picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
     picosplay_tree *new = malloc(sizeof(picosplay_tree));
@@ -179,13 +186,12 @@ void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node) {
     tree->size--;
 }
 
-void picosplay_delete_tree(picosplay_tree * tree)
+void picosplay_empty_tree(picosplay_tree * tree)
 {
     if (tree != NULL) {
         while (tree->root != NULL) {
             picosplay_delete_hint(tree, tree->root);
         }
-        free(tree);
     }
 }
 

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -100,34 +100,40 @@ picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
  */
 picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
     picosplay_node *new = malloc(sizeof(picosplay_node));
-    new->value = value;
-    new->left = NULL;
-    new->right = NULL;
-    if(tree->root == NULL) {
-        tree->root = new;
-        new->parent = NULL;
-    } else {
-        picosplay_node *curr = tree->root;
-        picosplay_node *parent = NULL;
-        int left = 0;
-        while(curr != NULL) {
-            parent = curr;
-            if(tree->comp(new->value, curr->value) < 0) {
-                left = 1;
-                curr = curr->left;
-            } else {
-                left = 0;
-                curr = curr->right;
-            }
+
+    if (new != NULL) {
+        new->value = value;
+        new->left = NULL;
+        new->right = NULL;
+        if (tree->root == NULL) {
+            tree->root = new;
+            new->parent = NULL;
         }
-        new->parent = parent;
-        if(left)
-            parent->left = new;
-        else
-            parent->right = new;
+        else {
+            picosplay_node *curr = tree->root;
+            picosplay_node *parent = NULL;
+            int left = 0;
+            while (curr != NULL) {
+                parent = curr;
+                if (tree->comp(new->value, curr->value) < 0) {
+                    left = 1;
+                    curr = curr->left;
+                }
+                else {
+                    left = 0;
+                    curr = curr->right;
+                }
+            }
+            new->parent = parent;
+            if (left)
+                parent->left = new;
+            else
+                parent->right = new;
+        }
+        splay(tree, new);
+        tree->size++;
     }
-    splay(tree, new);
-    tree->size++;
+
     return new;
 }
 
@@ -145,6 +151,10 @@ picosplay_node* picosplay_find(picosplay_tree *tree, void *value) {
             curr = curr->right;
         }
     }
+
+    /* TODO: there may or may not be a need to perform a splay on a find operation.
+     * The Wikipedia example omits it, but this code keeps it. We should
+     * perform measurements with and without it and keep the best alternative. */
     if(curr != NULL)
         splay(tree, curr);
     return curr;

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -36,9 +36,9 @@ static picosplay_node* rightmost(picosplay_node *node);
 
 
 /* The meat: splay the node x. */
-static void zig(picosplay_node *x, picosplay_node *p);
+static void zig(picosplay_node *x);
 static void zigzig(picosplay_node *x, picosplay_node *p);
-static void zigzag(picosplay_node *x, picosplay_node *p);
+static void zigzag(picosplay_node *x);
 static void splay(picosplay_tree *tree, picosplay_node *x) {
     while(1) {
         picosplay_node *p = x->parent;
@@ -48,18 +48,18 @@ static void splay(picosplay_tree *tree, picosplay_node *x) {
         }
         picosplay_node *g = p->parent;
         if(p->parent == NULL)
-            zig(x, p);
+            zig(x);
         else
             if((x == p->left && p == g->left) ||
                     (x == p->right && p == g->right))
                 zigzig(x, p);
             else
-                zigzag(x, p);
+                zigzag(x);
     }
 }
 
 /* When p is root, rotate on the edge between x and p.*/
-static void zig(picosplay_node *x, picosplay_node *p) {
+static void zig(picosplay_node *x) {
     rotate(x);
 }
 
@@ -74,7 +74,7 @@ static void zigzig(picosplay_node *x, picosplay_node *p) {
 /* When one of x and p is a left child and the other a right child,
  * rotate on the edge between x and p, then on the new edge between x and g.
  */
-static void zigzag(picosplay_node *x, picosplay_node *p) {
+static void zigzag(picosplay_node *x) {
     rotate(x);
     rotate(x);
 }
@@ -101,8 +101,8 @@ picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
         new->parent = NULL;
     } else {
         picosplay_node *curr = tree->root;
-        picosplay_node *parent;
-        int left;
+        picosplay_node *parent = NULL;
+        int left = NULL;
         while(curr != NULL) {
             parent = curr;
             if(tree->comp(new->value, curr->value) < 0) {

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -109,7 +109,7 @@ picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
     } else {
         picosplay_node *curr = tree->root;
         picosplay_node *parent = NULL;
-        int left = NULL;
+        int left = 0;
         while(curr != NULL) {
             parent = curr;
             if(tree->comp(new->value, curr->value) < 0) {

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -1,0 +1,284 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2018, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* This code is copied and adapted from https://github.com/lrem/splay,
+* copyright (c) Remigiusz Modrzejewski 2014, filed on Github with MIT license.
+*/
+
+#include <stdlib.h>
+#include <assert.h>
+#include "picosplay.h"
+
+void picosplay_check_sanity(picosplay_tree *tree);
+
+/* The single most important utility function. */
+static void rotate(picosplay_node *child);
+/* And a few more. */
+static picosplay_node* leftmost(picosplay_node *node);
+static picosplay_node* rightmost(picosplay_node *node);
+
+
+/* The meat: splay the node x. */
+static void zig(picosplay_node *x, picosplay_node *p);
+static void zigzig(picosplay_node *x, picosplay_node *p);
+static void zigzag(picosplay_node *x, picosplay_node *p);
+static void splay(picosplay_tree *tree, picosplay_node *x) {
+    while(1) {
+        picosplay_node *p = x->parent;
+        if(p == NULL) {
+            tree->root = x;
+            return;
+        }
+        picosplay_node *g = p->parent;
+        if(p->parent == NULL)
+            zig(x, p);
+        else
+            if((x == p->left && p == g->left) ||
+                    (x == p->right && p == g->right))
+                zigzig(x, p);
+            else
+                zigzag(x, p);
+    }
+}
+
+/* When p is root, rotate on the edge between x and p.*/
+static void zig(picosplay_node *x, picosplay_node *p) {
+    rotate(x);
+}
+
+/* When both x and p are left (or both right) children,
+ * rotate on edge between p and g, then on edge between x and p.
+ */
+static void zigzig(picosplay_node *x, picosplay_node *p) {
+    rotate(p);
+    rotate(x);
+}
+
+/* When one of x and p is a left child and the other a right child,
+ * rotate on the edge between x and p, then on the new edge between x and g.
+ */
+static void zigzag(picosplay_node *x, picosplay_node *p) {
+    rotate(x);
+    rotate(x);
+}
+
+/* Return an empty tree, storing the picosplay_comparator. */
+picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
+    picosplay_tree *new = malloc(sizeof(picosplay_tree));
+    new->comp = comp;
+    new->root = NULL;
+    new->size = 0;
+    return new;
+}
+
+/* picosplay_insert and return a new node with the given value, splaying the tree. 
+ * The insertion is essentially a generic BST insertion.
+ */
+picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
+    picosplay_node *new = malloc(sizeof(picosplay_node));
+    new->value = value;
+    new->left = NULL;
+    new->right = NULL;
+    if(tree->root == NULL) {
+        tree->root = new;
+        new->parent = NULL;
+    } else {
+        picosplay_node *curr = tree->root;
+        picosplay_node *parent;
+        int left;
+        while(curr != NULL) {
+            parent = curr;
+            if(tree->comp(new->value, curr->value) < 0) {
+                left = 1;
+                curr = curr->left;
+            } else {
+                left = 0;
+                curr = curr->right;
+            }
+        }
+        new->parent = parent;
+        if(left)
+            parent->left = new;
+        else
+            parent->right = new;
+    }
+    splay(tree, new);
+    tree->size++;
+    return new;
+}
+
+/* Find a node with the given value, splaying the tree. */
+picosplay_node* picosplay_find(picosplay_tree *tree, void *value) {
+    picosplay_node *curr = tree->root;
+    int found = 0;
+    while(curr != NULL && !found) {
+        int relation = tree->comp(value, curr->value);
+        if(relation == 0) {
+            found = 1;
+        } else if(relation < 0) {
+            curr = curr->left;
+        } else {
+            curr = curr->right;
+        }
+    }
+    if(curr != NULL)
+        splay(tree, curr);
+    return curr;
+}
+
+/* Remove a node with the given value, splaying the tree. */
+void picosplay_delete(picosplay_tree *tree, void *value) {
+    picosplay_node *node = picosplay_find(tree, value);
+    picosplay_delete_hint(tree, node);
+}
+
+/* Remove the node given by the pointer, splaying the tree. */
+void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node) {
+    if(node == NULL)
+        return;
+    splay(tree, node); /* Now node is tree's root. */
+    if(node->left == NULL) {
+        tree->root = node->right;
+        if(tree->root != NULL)
+            tree->root->parent = NULL;
+    } else if(node->right == NULL) {
+        tree->root = node->left;
+        tree->root->parent = NULL;
+    } else {
+        picosplay_node *x = leftmost(node->right);
+        if(x->parent != node) {
+            x->parent->left = x->right;
+            if(x->right != NULL)
+                x->right->parent = x->parent;
+            x->right = node->right;
+            x->right->parent = x;
+        }
+        tree->root = x;
+        x->parent = NULL;
+        x->left = node->left;
+        x->left->parent = x;
+    }
+    free(node);
+    tree->size--;
+}
+
+void picosplay_delete_tree(picosplay_tree * tree)
+{
+    if (tree != NULL) {
+        while (tree->root != NULL) {
+            picosplay_delete_hint(tree, tree->root);
+        }
+        free(tree);
+    }
+}
+
+picosplay_node* picosplay_first(picosplay_tree *tree) {
+    return leftmost(tree->root);
+}
+
+/* Return the minimal node that is bigger than the given.
+ * This is either:
+ *  - leftmost child in the right subtree
+ *  - closest ascendant for which given node is in left subtree
+ */
+picosplay_node* picosplay_next(picosplay_node *node) {
+    if(node->right != NULL)
+        return leftmost(node->right);
+    while(node->parent != NULL && node == node->parent->right)
+        node = node->parent;
+    return node->parent;
+}
+
+picosplay_node* picosplay_last(picosplay_tree *tree) {
+    return rightmost(tree->root);
+}
+
+/* An in-order traversal of the tree. */
+static void store(picosplay_node *node, void ***out);
+void* picosplay_contents(picosplay_tree *tree) {
+    if(tree->size == 0)
+        return NULL;
+    void **out = malloc(tree->size * sizeof(void*));
+    void ***tmp = &out;
+    store(tree->root, tmp);
+    return out - tree->size;
+}
+
+static void store(picosplay_node *node, void ***out) {
+    if(node->left != NULL)
+        store(node->left, out);
+    **out = node->value;
+    (*out)++;
+    if(node->right != NULL)
+        store(node->right, out);
+}
+/* This mutates the parental relationships, copy pointer to old parent. */
+static void mark_gp(picosplay_node *child);
+
+/* Rotate to make the given child take its parent's place in the tree. */
+static void rotate(picosplay_node *child) {
+    picosplay_node *parent = child->parent;
+    assert(parent != NULL);
+    if(parent->left == child) { /* A left child given. */
+        mark_gp(child);
+        parent->left = child->right;
+        if(child->right != NULL)
+            child->right->parent = parent;
+        child->right = parent;
+    } else { /* A right child given. */ 
+        mark_gp(child);
+        parent->right = child->left;
+        if(child->left != NULL)
+            child->left->parent = parent;
+        child->left = parent;
+    }
+}
+
+static void mark_gp(picosplay_node *child) {
+    picosplay_node *parent = child->parent;
+    picosplay_node *grand = parent->parent;
+    child->parent = grand;
+    parent->parent = child;
+    if(grand == NULL)
+        return;
+    if(grand->left == parent)
+        grand->left = child;
+    else
+        grand->right = child;
+}
+
+static picosplay_node* leftmost(picosplay_node *node) {
+    picosplay_node *parent = NULL;
+    while(node != NULL) {
+        parent = node;
+        node = node->left;
+    }
+    return parent;
+}
+
+static picosplay_node* rightmost(picosplay_node *node) {
+    picosplay_node *parent = NULL;
+    while(node != NULL) {
+        parent = node;
+        node = node->right;
+    }
+    return parent;
+}
+

--- a/picoquic/picosplay.h
+++ b/picoquic/picosplay.h
@@ -38,6 +38,7 @@ typedef struct picosplay_tree {
     int size;
 } picosplay_tree;
 
+void picosplay_init_tree(picosplay_tree* tree, picosplay_comparator comp);
 picosplay_tree* picosplay_new_tree(picosplay_comparator comp);
 picosplay_node* picosplay_insert(picosplay_tree *tree, void *value);
 picosplay_node* picosplay_find(picosplay_tree *tree, void *value);
@@ -47,6 +48,6 @@ picosplay_node* picosplay_last(picosplay_tree *tree);
 void* picosplay_contents(picosplay_tree *tree);
 void picosplay_delete(picosplay_tree *tree, void *value);
 void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node);
-void picosplay_delete_tree(picosplay_tree *tree);
+void picosplay_empty_tree(picosplay_tree *tree);
 
 #endif /* PICOSPLAY_H */

--- a/picoquic/picosplay.h
+++ b/picoquic/picosplay.h
@@ -1,0 +1,52 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2018, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* This code is copied and adapted from https://github.com/lrem/splay,
+* copyright (c) Remigiusz Modrzejewski 2014, filed on Github with MIT license.
+*/
+
+#ifndef PICOSPLAY_H
+#define PICOSPLAY_H
+
+typedef int (*picosplay_comparator)(void *left, void *right);
+
+typedef struct picosplay_node {
+    struct picosplay_node *parent, *left, *right;
+    void *value;
+} picosplay_node;
+
+typedef struct picosplay_tree {
+    picosplay_node *root;
+    picosplay_comparator comp;
+    int size;
+} picosplay_tree;
+
+picosplay_tree* picosplay_new_tree(picosplay_comparator comp);
+picosplay_node* picosplay_insert(picosplay_tree *tree, void *value);
+picosplay_node* picosplay_find(picosplay_tree *tree, void *value);
+picosplay_node* picosplay_first(picosplay_tree *tree);
+picosplay_node* picosplay_next(picosplay_node *node);
+picosplay_node* picosplay_last(picosplay_tree *tree);
+void* picosplay_contents(picosplay_tree *tree);
+void picosplay_delete(picosplay_tree *tree, void *value);
+void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node);
+void picosplay_delete_tree(picosplay_tree *tree);
+
+#endif /* PICOSPLAY_H */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -414,6 +414,19 @@ void picoquic_init_transport_parameters(picoquic_transport_parameters* tp, int c
     tp->ack_delay_exponent = 3;
 }
 
+
+/* management of the list of connections in context */
+
+picoquic_cnx_t* picoquic_get_first_cnx(picoquic_quic_t* quic)
+{
+    return quic->cnx_list;
+}
+
+picoquic_cnx_t* picoquic_get_next_cnx(picoquic_cnx_t* cnx)
+{
+    return cnx->next_in_table;
+}
+
 static void picoquic_insert_cnx_in_list(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
 {
     if (quic->cnx_list != NULL) {
@@ -442,6 +455,8 @@ static void picoquic_remove_cnx_from_list(picoquic_cnx_t* cnx)
         cnx->previous_in_table->next_in_table = cnx->next_in_table;
     }
 }
+
+/* Management of the list of connections, sorted by wake time */
 
 static void picoquic_remove_cnx_from_wake_list(picoquic_cnx_t* cnx)
 {
@@ -486,16 +501,6 @@ void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
 {
     picoquic_remove_cnx_from_wake_list(cnx);
     picoquic_insert_cnx_by_wake_time(quic, cnx);
-}
-
-picoquic_cnx_t* picoquic_get_first_cnx(picoquic_quic_t* quic)
-{
-    return quic->cnx_list;
-}
-
-picoquic_cnx_t* picoquic_get_next_cnx(picoquic_cnx_t* cnx)
-{
-    return cnx->next_in_table;
 }
 
 picoquic_cnx_t* picoquic_get_earliest_cnx_to_wake(picoquic_quic_t* quic, uint64_t max_wake_time)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -259,9 +259,6 @@ void picoquic_free(picoquic_quic_t* quic)
             free(to_delete);
         }
 
-        /* Delete the wake tree */
-        picosplay_empty_tree(&quic->cnx_wake_tree);
-
         /* delete all the connection contexts */
         while (quic->cnx_list != NULL) {
             picoquic_delete_cnx(quic->cnx_list);
@@ -274,6 +271,9 @@ void picoquic_free(picoquic_quic_t* quic)
         if (quic->table_cnx_by_net != NULL) {
             picohash_delete(quic->table_cnx_by_net, 1);
         }
+
+        /* Delete the wake tree */
+        picosplay_empty_tree(&quic->cnx_wake_tree);
 
         if (quic->verify_certificate_ctx != NULL &&
             quic->free_verify_certificate_callback_fn != NULL) {
@@ -499,9 +499,10 @@ static void picoquic_insert_cnx_by_wake_time(picoquic_quic_t* quic, picoquic_cnx
     picosplay_insert(&quic->cnx_wake_tree, cnx);
 }
 
-void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
+void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t next_time)
 {
     picoquic_remove_cnx_from_wake_list(cnx);
+    cnx->next_wake_time = next_time;
     picoquic_insert_cnx_by_wake_time(quic, cnx);
 }
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -111,7 +111,8 @@ static const picoquic_test_def_t test_table[] = {
     { "zero_rtt_spurious", zero_rtt_spurious_test },
     { "zero_rtt_retry", zero_rtt_retry_test },
     { "parse_frames", parse_frame_test },
-    { "stress", stress_test }
+    { "stress", stress_test },
+    { "splay", splay_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -111,6 +111,7 @@ int zero_rtt_spurious_test();
 int zero_rtt_retry_test();
 int parse_frame_test();
 int stress_test();
+int splay_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -149,6 +149,7 @@
     <ClCompile Include="sacktest.c" />
     <ClCompile Include="skip_frame_test.c" />
     <ClCompile Include="socket_test.c" />
+    <ClCompile Include="splay_test.c" />
     <ClCompile Include="stream0_frame_test.c" />
     <ClCompile Include="stresstest.c" />
     <ClCompile Include="ticket_store_test.c" />

--- a/picoquictest/picoquictest.vcxproj.filters
+++ b/picoquictest/picoquictest.vcxproj.filters
@@ -75,6 +75,9 @@
     <ClCompile Include="stresstest.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="splay_test.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquictest.h">

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -23,6 +23,7 @@
 */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include "../picoquic/util.h"
 #include "../picoquic/picosplay.h"
 

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -1,0 +1,151 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2018, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+* This code is copied and adapted from https://github.com/lrem/splay,
+* copyright (c) Remigiusz Modrzejewski 2014, filed on Github with MIT license.
+*/
+
+#include <stdio.h>
+#include "../picoquic/util.h"
+#include "../picoquic/picosplay.h"
+
+static int compare_int(void *l, void *r) {
+    return *((int*)l) - *((int*)r);
+}
+
+static int check_node_sanity(picosplay_node *x, void *floor, void *ceil, picosplay_comparator comp) {
+    int count = 0;
+
+    if (x != NULL) {
+        count = 1;
+        if (x->left != NULL) {
+            if (x->left->parent == x) {
+                void *new_floor;
+                if (floor == NULL || comp(x->value, floor) < 0)
+                    new_floor = x->value;
+                else
+                    new_floor = floor;
+                count += check_node_sanity(x->left, new_floor, ceil, comp);
+            }
+            else {
+                DBG_PRINTF("%s", "Invalid node, left->parent != node.\n");
+                count = -1;
+            }
+        }
+        if (x->right != NULL && count > 0) {
+            if (x->right->parent == x) {
+                void *new_ceil;
+                if (ceil == NULL || comp(x->value, ceil) > 0)
+                    new_ceil = x->value;
+                else
+                    new_ceil = ceil;
+                count += check_node_sanity(x->right, floor, new_ceil, comp);
+            }
+            else {
+                DBG_PRINTF("%s", "Invalid node, left->parent != node.\n");
+                count = -1;
+            }
+        }
+    }
+
+    return count;
+}
+
+int splay_test() {
+    int ret = 0;
+    int count = 0;
+    picosplay_tree *tree = picosplay_new_tree(&compare_int);
+    int values[] = {3, 4, 1, 2, 8, 5, 7};
+    int values_first[] = { 3, 3, 1, 1, 1, 1, 1 };
+    int values_last[] = { 3, 4, 4, 4, 8, 8, 8 };
+    int value2_first[] = { 1, 1, 2, 5, 5, 7, 0 };
+    int value2_last[] = { 8, 8, 8, 8, 7, 7, 0 };
+
+    if (tree == NULL) {
+        DBG_PRINTF("%s", "Cannot create tree.\n");
+    }
+
+    for(int i = 0; ret == 0 && i < 7; i++) {
+        picosplay_insert(tree, &values[i]);
+        /* Verify sanity and count after each insertion */
+        count = check_node_sanity(tree->root, NULL, NULL, &compare_int);
+        if (count != i + 1) {
+            DBG_PRINTF("Insert v[%d] = %d, expected %d nodes, got %d instead\n",
+                i, values[i], i + 1, count);
+            ret = -1;
+        }
+        else if (tree->size != count) {
+            DBG_PRINTF("Insert v[%d] = %d, expected tree size %d, got %d instead\n",
+                i, values[i], count, tree->size);
+            ret = -1;
+        }
+        else if (*(int*)picosplay_first(tree)->value != values_first[i]) {
+            DBG_PRINTF("Insert v[%d] = %d, expected first = %d, got %d instead\n", 
+                i, values[i],
+                values_first[i], *(int*)picosplay_first(tree)->value);
+            ret = -1;
+        }
+        else if (*(int*)picosplay_last(tree)->value != values_last[i]) {
+            DBG_PRINTF("Insert v[%d] = %d, expected first = %d, got %d instead\n",
+                i, values[i],
+                values_last[i], *(int*)picosplay_last(tree)->value);
+            ret = -1;
+        }
+    }
+
+    for(int i = 0; ret == 0 && i < 7; i++) {
+        picosplay_delete(tree, &values[i]);
+        /* Verify sanity and count after each deletion */
+        count = check_node_sanity(tree->root, NULL, NULL, &compare_int);
+        if (count != 6 - i) {
+            DBG_PRINTF("Delete v[%d] = %d, expected %d nodes, got %d instead\n",
+                i, values[i], 6 - i, count);
+            ret = -1;
+        }
+        else if (tree->size != count) {
+            DBG_PRINTF("Insert v[%d] = %d, expected tree size %d, got %d instead\n",
+                i, values[i], count, tree->size);
+            ret = -1;
+        }
+        else if (i < 6) {
+            if (*(int*)picosplay_first(tree)->value != value2_first[i]) {
+                DBG_PRINTF("Delete v[%d] = %d, expected first = %d, got %d instead\n",
+                    i, values[i], value2_first[i], *(int*)picosplay_first(tree)->value);
+                ret = -1;
+            }
+            else if (*(int*)picosplay_last(tree)->value != value2_last[i]) {
+                DBG_PRINTF("Delete v[%d] = %d, expected first = %d, got %d instead\n",
+                    i, values[i], value2_last[i], *(int*)picosplay_last(tree)->value);
+                ret = -1;
+            }
+        }
+    }
+
+    if (tree != NULL) {
+        if (ret == 0 && tree->root != NULL) {
+            DBG_PRINTF("%s", "Final tree root should be NULL, is not.\n");
+            ret = -1;
+        }
+        picosplay_delete_tree(tree);
+        tree = NULL;
+    }
+
+    return ret;
+}

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -143,7 +143,8 @@ int splay_test() {
             DBG_PRINTF("%s", "Final tree root should be NULL, is not.\n");
             ret = -1;
         }
-        picosplay_delete_tree(tree);
+        picosplay_empty_tree(tree);
+        free(tree);
         tree = NULL;
     }
 

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -852,8 +852,8 @@ int stress_test()
 {
     int ret = 0;
     picoquic_stress_ctx_t stress_ctx;
-    int run_time_seconds = 0;
-    int wall_time_seconds = 0;
+    double run_time_seconds = 0;
+    double wall_time_seconds = 0;
     uint64_t wall_time_start = picoquic_current_time();
 
 
@@ -923,9 +923,9 @@ int stress_test()
     }
 
     /* Report */
-    run_time_seconds = (int)(stress_ctx.simulated_time / 1000000ull);
-    wall_time_seconds = (int)((picoquic_current_time() - wall_time_start) / 1000000ull);
-    DBG_PRINTF("Stress complete after simulating %d s. in %d s., returns %d\n",
+    run_time_seconds = ((double)stress_ctx.simulated_time) / 1000000.0;
+    wall_time_seconds = ((double)(picoquic_current_time() - wall_time_start)) / 1000000.0;
+    DBG_PRINTF("Stress complete after simulating %3f s. in %3f s., returns %d\n",
         run_time_seconds, wall_time_seconds, ret);
 
     return ret;

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -523,14 +523,11 @@ static int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_qu
     picoquic_cnx_t* cnx = picoquic_get_earliest_cnx_to_wake(q, 0);
     picoquictest_sim_link_t* target_link = NULL;
     int simulate_disconnect = 0;
-    int was_null = 0;
 
     if (packet != NULL && p != NULL && cnx != NULL) {
         /* Check that the client connection was properly terminated */
         picoquic_stress_client_callback_ctx_t* c_ctx = (c_index >= 0) ?
             (picoquic_stress_client_callback_ctx_t*)picoquic_get_callback_context(cnx) : NULL;
-
-        was_null = (c_ctx != 0);
 
         if (c_ctx == NULL || cnx->cnx_state == picoquic_state_disconnected || c_ctx->message_disconnect_trigger == 0 ||
             cnx->send_sequence <= c_ctx->message_disconnect_trigger) {


### PR DESCRIPTION
This was motivated by issue #206. When running the stress test for a long time, a large queue of connection builds up, and the program becomes much slower. The likely culprit was the code for ordering connections by increasing wake time, which used a double liked list of connection, i.e. O(N) with number of connections. Hence the need for something better.

I picked a splay because it is probably better adapted to the use case than the alternatives like red-black trees. In the common case, we will get a small number of active connections and maybe a large number of dormant ones. With the splay structure, the active connections will be closed to the root of the tree, which is good.

The performances improve significantly. With the previous code,  it took 127 seconds to run a stress simulation of 420 seconds of simulated time. With the new code, the same simulation runs in 10 seconds **(updated: that was not true, false result due to bug)**. But there is a catch: some of the stress tests fail, with a diagnostic: Too many retransmits, disconnect. This probably results from a lack of fairness, with some connections getting all the airtime while others are starving, but that's just a guess. This needs to be fixed before we actually check-in this PR.