### PR TITLE
Refactor decode and skip

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -679,14 +679,12 @@ void picoquic_update_stream_initial_remote(picoquic_cnx_t* cnx);
 picoquic_stream_head* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t stream_id, int create);
 picoquic_stream_head* picoquic_find_ready_stream(picoquic_cnx_t* cnx);
 int picoquic_is_tls_stream_ready(picoquic_cnx_t* cnx);
-int picoquic_stream_network_input(picoquic_cnx_t* cnx, uint64_t stream_id,
-    uint64_t offset, int fin, uint8_t* bytes, size_t length, uint64_t current_time);
-int picoquic_decode_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
-    size_t bytes_max, size_t* consumed, uint64_t current_time);
+uint8_t* picoquic_decode_stream_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    const uint8_t* bytes_max, uint64_t current_time);
 int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* stream,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
-int picoquic_decode_crypto_hs_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
-    size_t bytes_max, size_t* consumed, int epoch);
+uint8_t* picoquic_decode_crypto_hs_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
+    const uint8_t* bytes_max, int epoch);
 int picoquic_prepare_crypto_hs_frame(picoquic_cnx_t* cnx, int epoch,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
 int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -132,7 +132,6 @@ static int StreamZeroFrameOneTest(struct test_case_st* test)
     int ret = 0;
 
     picoquic_cnx_t cnx = { 0 };
-    size_t consumed = 0;
     uint64_t current_time = 0;
     
     cnx.local_parameters.initial_max_stream_data = 0x10000;
@@ -140,8 +139,8 @@ static int StreamZeroFrameOneTest(struct test_case_st* test)
     cnx.maxdata_local = 0x10000;
 
     for (size_t i = 0; ret == 0 && i < test->list_size; i++) {
-        if (0 != picoquic_decode_stream_frame(&cnx, test->list[i].packet,
-                     test->list[i].packet_length, &consumed, current_time)) {
+        if (NULL == picoquic_decode_stream_frame(&cnx, test->list[i].packet,
+                       test->list[i].packet + test->list[i].packet_length, current_time)) {
             FAIL(test, "packet %" PRIst, i);
             ret = -1;
         }
@@ -288,12 +287,10 @@ static int TlsStreamFrameOneTest(struct test_case_st* test)
     int ret = 0;
 
     picoquic_cnx_t cnx = { 0 };
-    size_t consumed = 0;
-    uint64_t current_time = 0;
 
     for (size_t i = 0; ret == 0 && i < test->list_size; i++) {
-        if (0 != picoquic_decode_crypto_hs_frame(&cnx, test->list[i].packet,
-            test->list[i].packet_length, &consumed, 2 /* epoch = 2 for handshake */)) {
+        if (NULL == picoquic_decode_crypto_hs_frame(&cnx, test->list[i].packet,
+                test->list[i].packet + test->list[i].packet_length, 2 /* epoch = 2 for handshake */)) {
             FAIL(test, "packet %" PRIst, i);
             ret = -1;
         }


### PR DESCRIPTION
This is a large PR.

# Purpose

I am trying to clean up and simplify a lot of code to make the semantics of frame operations easier to read and understand and, consequently, easier to keep bug-free.

This is just the first step in this direction.  I've only changed piciquic_decode_* and piciquic_skip_* functions.

Each function and its helpers check their own byte constraints.

I have also changed the internal frame decoding and skipping interface.  See #212 .
This allowed me to save a lot of code and improve readability by removing extraneous bookkeeping.

For now, all changes are limited to frame.c (and a few tests that reach into frame.c directly).

# Testing

The current tests, including CI tests work.  (Actually "request_client_authentication" also works.)