### PR TITLE
Three seqs

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -998,9 +998,10 @@ int picoquic_parse_ack_header(uint8_t const* bytes, size_t bytes_max,
 }
 
 void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
-    uint64_t start_of_range, uint64_t end_of_range, uint64_t current_time)
+    uint64_t start_of_range, uint64_t end_of_range, uint64_t current_time,
+    picoquic_packet_context_enum pc)
 {
-    picoquic_packet* p = cnx->retransmitted_newest;
+    picoquic_packet* p = cnx->pkt_ctx[pc].retransmitted_newest;
 
     while (p != NULL) {
         picoquic_packet* should_delete = NULL;
@@ -1008,8 +1009,8 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
         if (p->sequence_number >= start_of_range && p->sequence_number <= end_of_range) {
 
             uint64_t max_spurious_rtt = current_time - p->send_time;
-            uint64_t max_reorder_delay = cnx->latest_time_acknowledged - p->send_time;
-            uint64_t max_reorder_gap = cnx->highest_acknowledged - p->sequence_number;
+            uint64_t max_reorder_delay = cnx->pkt_ctx[pc].latest_time_acknowledged - p->send_time;
+            uint64_t max_reorder_gap = cnx->pkt_ctx[pc].highest_acknowledged - p->sequence_number;
             picoquic_path_t * old_path = p->send_path;
 
             if (p->length + p->checksum_overhead > old_path->send_mtu) {
@@ -1034,7 +1035,7 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
             cnx->nb_spurious++;
             should_delete = p;
-        } else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->latest_time_acknowledged) {
+        } else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->pkt_ctx[pc].latest_time_acknowledged) {
             should_delete = p;
         }
 
@@ -1042,13 +1043,13 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
         if (should_delete != NULL) {
             if (should_delete->previous_packet == NULL) {
-                cnx->retransmitted_newest = should_delete->next_packet;
+                cnx->pkt_ctx[pc].retransmitted_newest = should_delete->next_packet;
             } else {
                 should_delete->previous_packet->next_packet = should_delete->next_packet;
             }
 
             if (should_delete->next_packet == NULL) {
-                cnx->retransmitted_oldest = should_delete->previous_packet;
+                cnx->pkt_ctx[pc].retransmitted_oldest = should_delete->previous_packet;
             } else {
                 should_delete->next_packet->previous_packet = should_delete->previous_packet;
             }
@@ -1059,13 +1060,13 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 }
 
 static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t largest,
-    uint64_t current_time, uint64_t ack_delay)
+    uint64_t current_time, uint64_t ack_delay, picoquic_packet_context_enum pc)
 {
-    picoquic_packet* packet = cnx->retransmit_newest;
+    picoquic_packet* packet = cnx->pkt_ctx[pc].retransmit_newest;
 
     /* Check whether this is a new acknowledgement */
-    if (largest > cnx->highest_acknowledged || cnx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
-        cnx->highest_acknowledged = largest;
+    if (largest > cnx->pkt_ctx[pc].highest_acknowledged || cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
+        cnx->pkt_ctx[pc].highest_acknowledged = largest;
 
         if (ack_delay < PICOQUIC_ACK_DELAY_MAX) {
             /* if the ACK is reasonably recent, use it to update the RTT */
@@ -1083,8 +1084,8 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                 uint64_t acknowledged_time = current_time - ack_delay;
                 int64_t rtt_estimate = acknowledged_time - packet->send_time;
 
-                if (cnx->latest_time_acknowledged < packet->send_time) {
-                    cnx->latest_time_acknowledged = packet->send_time;
+                if (cnx->pkt_ctx[pc].latest_time_acknowledged < packet->send_time) {
+                    cnx->pkt_ctx[pc].latest_time_acknowledged = packet->send_time;
                 }
                 cnx->latest_progress_time = current_time;
 
@@ -1100,9 +1101,9 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                         old_path->rtt_variant = rtt_estimate / 2;
                         old_path->rtt_min = rtt_estimate;
                         old_path->retransmit_timer = 3 * rtt_estimate + old_path->max_ack_delay;
-                        cnx->ack_delay_local = old_path->rtt_min / 4;
-                        if (cnx->ack_delay_local < 1000) {
-                            cnx->ack_delay_local = 1000;
+                        cnx->pkt_ctx[pc].ack_delay_local = old_path->rtt_min / 4;
+                        if (cnx->pkt_ctx[pc].ack_delay_local < 1000) {
+                            cnx->pkt_ctx[pc].ack_delay_local = 1000;
                         }
                     } else {
                         /* Computation per RFC 6298 */
@@ -1120,11 +1121,11 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                         if (rtt_estimate < (int64_t)old_path->rtt_min) {
                             old_path->rtt_min = rtt_estimate;
 
-                            cnx->ack_delay_local = old_path->rtt_min / 4;
-                            if (cnx->ack_delay_local < 1000) {
-                                cnx->ack_delay_local = 1000;
-                            } else if (cnx->ack_delay_local > 10000) {
-                                cnx->ack_delay_local = 10000;
+                            cnx->pkt_ctx[pc].ack_delay_local = old_path->rtt_min / 4;
+                            if (cnx->pkt_ctx[pc].ack_delay_local < 1000) {
+                                cnx->pkt_ctx[pc].ack_delay_local = 1000;
+                            } else if (cnx->pkt_ctx[pc].ack_delay_local > 10000) {
+                                cnx->pkt_ctx[pc].ack_delay_local = 10000;
                             }
                         }
 
@@ -1352,8 +1353,8 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_pa
 
     while (ret == 0 && byte_index < p->length) {
         if (p->bytes[byte_index] == picoquic_frame_type_ack) {
-            ret = picoquic_process_ack_of_ack_frame(&cnx->first_sack_item, &p->bytes[byte_index],
-                p->length - byte_index, &frame_length);
+            ret = picoquic_process_ack_of_ack_frame(&cnx->pkt_ctx[p->pc].first_sack_item, 
+                &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
         } else if (p->bytes[byte_index] >= picoquic_frame_type_stream_range_min && p->bytes[byte_index] <= picoquic_frame_type_stream_range_max) {
             ret = picoquic_process_ack_of_stream_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
@@ -1367,8 +1368,9 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_pa
 }
 
 static picoquic_packet* picoquic_process_ack_range(
-    picoquic_cnx_t* cnx, uint64_t highest, uint64_t range, picoquic_packet* p,
-    uint64_t current_time, int epoch, int* ret)
+    picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
+    uint64_t highest, uint64_t range, picoquic_packet* p,
+    uint64_t current_time)
 {
     /* Compare the range to the retransmit queue */
     while (p != NULL && range > 0) {
@@ -1376,19 +1378,6 @@ static picoquic_packet* picoquic_process_ack_range(
             p = p->next_packet;
         } else {
             if (p->sequence_number == highest) {
-#if 0
-                /* TODO: check ack range per epoch */
-                if (restricted) {
-                    /* check that the packet was sent in clear text */
-                    if (picoquic_is_packet_encrypted(p->ptype)) {
-                        /* Protocol error! */
-                        *ret = picoquic_connection_error(cnx,
-                            PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-                        p = NULL;
-                        break;
-                    }
-                }
-#endif
                 /* TODO: RTT Estimate */
                 picoquic_packet* next = p->next_packet;
                 picoquic_path_t * old_path = p->send_path;
@@ -1411,7 +1400,7 @@ static picoquic_packet* picoquic_process_ack_range(
                 picoquic_dequeue_retransmit_packet(cnx, p, 1);
                 p = next;
                 /* Any acknowledgement shows progress */
-                cnx->nb_retransmit = 0;
+                cnx->pkt_ctx[pc].nb_retransmit = 0;
             }
 
             range--;
@@ -1429,6 +1418,7 @@ int picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     uint64_t num_block;
     uint64_t largest;
     uint64_t ack_delay;
+    picoquic_packet_context_enum pc = picoquic_context_from_epoch(epoch);
 
     ret = picoquic_parse_ack_header(bytes, bytes_max,
         &num_block, &largest, &ack_delay, consumed,
@@ -1441,7 +1431,7 @@ int picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
         size_t byte_index = *consumed;
 
         /* Attempt to update the RTT */ /* TODO: different ack spaces for different epochs */
-        picoquic_packet* top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay);
+        picoquic_packet* top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay, pc);
 
         while (ret == 0) {
             uint64_t range;
@@ -1474,15 +1464,15 @@ int picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
                 break;
             }
 
-            top_packet = picoquic_process_ack_range(cnx, largest, range,
-                top_packet, current_time, epoch, &ret);
+            top_packet = picoquic_process_ack_range(cnx, pc, largest, range,
+                top_packet, current_time);
 
             if (ret != 0) {
                 break;
             }
 
             if (range > 0) {
-                picoquic_check_spurious_retransmission(cnx, largest + 1 - range, largest, current_time);
+                picoquic_check_spurious_retransmission(cnx, largest + 1 - range, largest, current_time, pc);
             }
 
             if (num_block-- == 0)
@@ -1529,6 +1519,7 @@ int picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
 }
 
 int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
+    picoquic_packet_context_enum pc,
     uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
@@ -1537,7 +1528,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
     size_t l_largest = 0;
     size_t l_delay = 0;
     size_t l_first_range = 0;
-    picoquic_sack_item_t* next_sack = cnx->first_sack_item.next_sack;
+    picoquic_sack_item_t* next_sack = cnx->pkt_ctx[pc].first_sack_item.next_sack;
     uint64_t ack_delay = 0;
     uint64_t ack_range = 0;
     uint64_t ack_gap = 0;
@@ -1546,7 +1537,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
     uint8_t ack_type_byte = picoquic_frame_type_ack;
 
     /* Check that there is enough room in the packet, and something to acknowledge */
-    if (cnx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
+    if (cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
         *consumed = 0;
     } else if (bytes_max < 13) {
         /* A valid ACK, with our encoding, uses at least 13 bytes.
@@ -1560,13 +1551,13 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
         /* Encode the largest seen */
         if (byte_index < bytes_max) {
             l_largest = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
-                cnx->first_sack_item.end_of_sack_range);
+                cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range);
             byte_index += l_largest;
         }
         /* Encode the ack delay */
         if (byte_index < bytes_max) {
-            if (current_time > cnx->time_stamp_largest_received) {
-                ack_delay = current_time - cnx->time_stamp_largest_received;
+            if (current_time > cnx->pkt_ctx[pc].time_stamp_largest_received) {
+                ack_delay = current_time - cnx->pkt_ctx[pc].time_stamp_largest_received;
                 ack_delay >>= cnx->local_parameters.ack_delay_exponent;
             }
             l_delay = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
@@ -1578,7 +1569,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
         byte_index++;
         /* Encode the size of the first ack range */
         if (byte_index < bytes_max) {
-            ack_range = cnx->first_sack_item.end_of_sack_range - cnx->first_sack_item.start_of_sack_range;
+            ack_range = cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range - cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range;
             l_first_range = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
                 ack_range);
             byte_index += l_first_range;
@@ -1590,8 +1581,8 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         } else {
             /* Set the lowest acknowledged */
-            lowest_acknowledged = cnx->first_sack_item.start_of_sack_range;
-            /* Encode the ack blocks that fir in the allocated space */
+            lowest_acknowledged = cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range;
+            /* Encode the ack blocks that fit in the allocated space */
             while (num_block < 63 && next_sack != NULL) {
                 size_t l_gap = 0;
                 size_t l_range = 0;
@@ -1622,26 +1613,27 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
             bytes[num_block_index] = (uint8_t)num_block;
 
             /* Remember the ACK value and time */
-            cnx->highest_ack_sent = cnx->first_sack_item.end_of_sack_range;
-            cnx->highest_ack_time = current_time;
+            cnx->pkt_ctx[pc].highest_ack_sent = cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range;
+            cnx->pkt_ctx[pc].highest_ack_time = current_time;
 
             *consumed = byte_index;
         }
     }
 
     if (ret == 0) {
-        cnx->ack_needed = 0;
+        cnx->pkt_ctx[pc].ack_needed = 0;
     }
 
     return ret;
 }
 
-int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time)
+int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoquic_packet_context_enum pc)
 {
     int ret = 0;
 
-    if (cnx->highest_ack_sent + 2 <= cnx->first_sack_item.end_of_sack_range || cnx->highest_ack_time + cnx->ack_delay_local <= current_time) {
-        ret = cnx->ack_needed;
+    if (cnx->pkt_ctx[pc].highest_ack_sent + 2 <= cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range || 
+        cnx->pkt_ctx[pc].highest_ack_time + cnx->pkt_ctx[pc].ack_delay_local <= current_time) {
+        ret = cnx->pkt_ctx[pc].ack_needed;
     }
 
     return ret;
@@ -2129,6 +2121,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
 {
     int ret = 0;
     size_t byte_index = 0;
+    picoquic_packet_context_enum pc = picoquic_context_from_epoch(epoch);
 
     while (byte_index < bytes_max && ret == 0) {
         uint8_t first_byte = bytes[byte_index];
@@ -2141,7 +2134,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
             } else {
                 ret = picoquic_decode_stream_frame(cnx, bytes + byte_index,
                     bytes_max - byte_index, &consumed, current_time);
-                cnx->ack_needed = 1;
+                cnx->pkt_ctx[pc].ack_needed = 1;
                 byte_index += consumed;
             }
         } else if (first_byte == picoquic_frame_type_ack) {
@@ -2259,7 +2252,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
 
                 if (ret == 0 && ack_needed != 0) {
                     cnx->latest_progress_time = current_time;
-                    cnx->ack_needed = 1;
+                    cnx->pkt_ctx[pc].ack_needed = 1;
                 }
             }
         }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1099,7 +1099,7 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t largest,
     uint64_t current_time, uint64_t ack_delay, picoquic_packet_context_enum pc)
 {
-    picoquic_packet* packet = cnx->retransmit_newest;
+    picoquic_packet* packet = cnx->pkt_ctx[pc].retransmit_newest;
 
     /* Check whether this is a new acknowledgement */
     if (largest > cnx->pkt_ctx[pc].highest_acknowledged || cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
@@ -1488,7 +1488,7 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
                 break;
             }
 
-            if (picoquic_process_ack_range(cnx, pc, largest, range, &top_packet, current_time, epoch) != 0) {
+            if (picoquic_process_ack_range(cnx, pc, largest, range, &top_packet, current_time) != 0) {
                 bytes = NULL;
                 break;
             }
@@ -1635,7 +1635,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
     return ret;
 }
 
-int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time)
+int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoquic_packet_context_enum pc)
 {
     int ret = 0;
 
@@ -1967,7 +1967,7 @@ int picoquic_prepare_path_challenge_frame(uint8_t* bytes,
 
 uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, uint8_t* bytes, const uint8_t* bytes_max)
 {
-    if (bytes_max - bytes <= challenge_length) {
+    if (bytes_max - bytes <= (int) challenge_length) {
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR);
         bytes = NULL;
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1035,9 +1035,10 @@ int picoquic_parse_ack_header(uint8_t const* bytes, size_t bytes_max,
 }
 
 void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
-    uint64_t start_of_range, uint64_t end_of_range, uint64_t current_time)
+    uint64_t start_of_range, uint64_t end_of_range, uint64_t current_time,
+    picoquic_packet_context_enum pc)
 {
-    picoquic_packet* p = cnx->retransmitted_newest;
+    picoquic_packet* p = cnx->pkt_ctx[pc].retransmitted_newest;
 
     while (p != NULL) {
         picoquic_packet* should_delete = NULL;
@@ -1045,8 +1046,8 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
         if (p->sequence_number >= start_of_range && p->sequence_number <= end_of_range) {
 
             uint64_t max_spurious_rtt = current_time - p->send_time;
-            uint64_t max_reorder_delay = cnx->latest_time_acknowledged - p->send_time;
-            uint64_t max_reorder_gap = cnx->highest_acknowledged - p->sequence_number;
+            uint64_t max_reorder_delay = cnx->pkt_ctx[pc].latest_time_acknowledged - p->send_time;
+            uint64_t max_reorder_gap = cnx->pkt_ctx[pc].highest_acknowledged - p->sequence_number;
             picoquic_path_t * old_path = p->send_path;
 
             if (p->length + p->checksum_overhead > old_path->send_mtu) {
@@ -1071,7 +1072,7 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
             cnx->nb_spurious++;
             should_delete = p;
-        } else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->latest_time_acknowledged) {
+        } else if (p->send_time + PICOQUIC_SPURIOUS_RETRANSMIT_DELAY_MAX < cnx->pkt_ctx[pc].latest_time_acknowledged) {
             should_delete = p;
         }
 
@@ -1079,13 +1080,13 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
         if (should_delete != NULL) {
             if (should_delete->previous_packet == NULL) {
-                cnx->retransmitted_newest = should_delete->next_packet;
+                cnx->pkt_ctx[pc].retransmitted_newest = should_delete->next_packet;
             } else {
                 should_delete->previous_packet->next_packet = should_delete->next_packet;
             }
 
             if (should_delete->next_packet == NULL) {
-                cnx->retransmitted_oldest = should_delete->previous_packet;
+                cnx->pkt_ctx[pc].retransmitted_oldest = should_delete->previous_packet;
             } else {
                 should_delete->next_packet->previous_packet = should_delete->previous_packet;
             }
@@ -1096,13 +1097,13 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 }
 
 static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t largest,
-    uint64_t current_time, uint64_t ack_delay)
+    uint64_t current_time, uint64_t ack_delay, picoquic_packet_context_enum pc)
 {
     picoquic_packet* packet = cnx->retransmit_newest;
 
     /* Check whether this is a new acknowledgement */
-    if (largest > cnx->highest_acknowledged || cnx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
-        cnx->highest_acknowledged = largest;
+    if (largest > cnx->pkt_ctx[pc].highest_acknowledged || cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
+        cnx->pkt_ctx[pc].highest_acknowledged = largest;
 
         if (ack_delay < PICOQUIC_ACK_DELAY_MAX) {
             /* if the ACK is reasonably recent, use it to update the RTT */
@@ -1120,8 +1121,8 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                 uint64_t acknowledged_time = current_time - ack_delay;
                 int64_t rtt_estimate = acknowledged_time - packet->send_time;
 
-                if (cnx->latest_time_acknowledged < packet->send_time) {
-                    cnx->latest_time_acknowledged = packet->send_time;
+                if (cnx->pkt_ctx[pc].latest_time_acknowledged < packet->send_time) {
+                    cnx->pkt_ctx[pc].latest_time_acknowledged = packet->send_time;
                 }
                 cnx->latest_progress_time = current_time;
 
@@ -1137,9 +1138,9 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                         old_path->rtt_variant = rtt_estimate / 2;
                         old_path->rtt_min = rtt_estimate;
                         old_path->retransmit_timer = 3 * rtt_estimate + old_path->max_ack_delay;
-                        cnx->ack_delay_local = old_path->rtt_min / 4;
-                        if (cnx->ack_delay_local < 1000) {
-                            cnx->ack_delay_local = 1000;
+                        cnx->pkt_ctx[pc].ack_delay_local = old_path->rtt_min / 4;
+                        if (cnx->pkt_ctx[pc].ack_delay_local < 1000) {
+                            cnx->pkt_ctx[pc].ack_delay_local = 1000;
                         }
                     } else {
                         /* Computation per RFC 6298 */
@@ -1157,11 +1158,11 @@ static picoquic_packet* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larges
                         if (rtt_estimate < (int64_t)old_path->rtt_min) {
                             old_path->rtt_min = rtt_estimate;
 
-                            cnx->ack_delay_local = old_path->rtt_min / 4;
-                            if (cnx->ack_delay_local < 1000) {
-                                cnx->ack_delay_local = 1000;
-                            } else if (cnx->ack_delay_local > 10000) {
-                                cnx->ack_delay_local = 10000;
+                            cnx->pkt_ctx[pc].ack_delay_local = old_path->rtt_min / 4;
+                            if (cnx->pkt_ctx[pc].ack_delay_local < 1000) {
+                                cnx->pkt_ctx[pc].ack_delay_local = 1000;
+                            } else if (cnx->pkt_ctx[pc].ack_delay_local > 10000) {
+                                cnx->pkt_ctx[pc].ack_delay_local = 10000;
                             }
                         }
 
@@ -1389,8 +1390,8 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_pa
 
     while (ret == 0 && byte_index < p->length) {
         if (p->bytes[byte_index] == picoquic_frame_type_ack) {
-            ret = picoquic_process_ack_of_ack_frame(&cnx->first_sack_item, &p->bytes[byte_index],
-                p->length - byte_index, &frame_length);
+            ret = picoquic_process_ack_of_ack_frame(&cnx->pkt_ctx[p->pc].first_sack_item,
+                &p->bytes[byte_index], p->length - byte_index, &frame_length);
             byte_index += frame_length;
         } else if (PICOQUIC_IN_RANGE(p->bytes[byte_index], picoquic_frame_type_stream_range_min, picoquic_frame_type_stream_range_max)) {
             ret = picoquic_process_ack_of_stream_frame(cnx, &p->bytes[byte_index], p->length - byte_index, &frame_length);
@@ -1404,8 +1405,8 @@ void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_pa
 }
 
 static int picoquic_process_ack_range(
-    picoquic_cnx_t* cnx, uint64_t highest, uint64_t range, picoquic_packet** ppacket,
-    uint64_t current_time, int epoch)
+    picoquic_cnx_t* cnx, picoquic_packet_context_enum pc, uint64_t highest, uint64_t range, picoquic_packet** ppacket,
+    uint64_t current_time)
 {
     picoquic_packet* p = *ppacket;
     int ret = 0;
@@ -1415,18 +1416,6 @@ static int picoquic_process_ack_range(
             p = p->next_packet;
         } else {
             if (p->sequence_number == highest) {
-#if 0
-                /* TODO: check ack range per epoch */
-                if (restricted) {
-                    /* check that the packet was sent in clear text */
-                    if (picoquic_is_packet_encrypted(p->ptype)) {
-                        /* Protocol error! */
-                        ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
-                        p = NULL;
-                        break;
-                    }
-                }
-#endif
                 /* TODO: RTT Estimate */
                 picoquic_packet* next = p->next_packet;
                 picoquic_path_t * old_path = p->send_path;
@@ -1449,7 +1438,7 @@ static int picoquic_process_ack_range(
                 picoquic_dequeue_retransmit_packet(cnx, p, 1);
                 p = next;
                 /* Any acknowledgement shows progress */
-                cnx->nb_retransmit = 0;
+                cnx->pkt_ctx[pc].nb_retransmit = 0;
             }
 
             range--;
@@ -1468,6 +1457,7 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     uint64_t largest;
     uint64_t ack_delay;
     size_t   consumed;
+    picoquic_packet_context_enum pc = picoquic_context_from_epoch(epoch);
 
     if (picoquic_parse_ack_header(bytes, bytes_max-bytes, &num_block, &largest, &ack_delay, &consumed,
                                   cnx->remote_parameters.ack_delay_exponent) != 0) {
@@ -1477,7 +1467,7 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
         bytes += consumed;
 
         /* Attempt to update the RTT */ /* TODO: different ack spaces for different epochs */
-        picoquic_packet* top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay);
+        picoquic_packet* top_packet = picoquic_update_rtt(cnx, largest, current_time, ack_delay, pc);
 
         while (bytes != NULL) {
             uint64_t range;
@@ -1498,13 +1488,13 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
                 break;
             }
 
-            if (picoquic_process_ack_range(cnx, largest, range, &top_packet, current_time, epoch) != 0) {
+            if (picoquic_process_ack_range(cnx, pc, largest, range, &top_packet, current_time, epoch) != 0) {
                 bytes = NULL;
                 break;
             }
 
             if (range > 0) {
-                picoquic_check_spurious_retransmission(cnx, largest + 1 - range, largest, current_time);
+                picoquic_check_spurious_retransmission(cnx, largest + 1 - range, largest, current_time, pc);
             }
 
             if (num_block-- == 0)
@@ -1537,6 +1527,7 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
 }
 
 int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
+    picoquic_packet_context_enum pc,
     uint8_t* bytes, size_t bytes_max, size_t* consumed)
 {
     int ret = 0;
@@ -1545,7 +1536,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
     size_t l_largest = 0;
     size_t l_delay = 0;
     size_t l_first_range = 0;
-    picoquic_sack_item_t* next_sack = cnx->first_sack_item.next_sack;
+    picoquic_sack_item_t* next_sack = cnx->pkt_ctx[pc].first_sack_item.next_sack;
     uint64_t ack_delay = 0;
     uint64_t ack_range = 0;
     uint64_t ack_gap = 0;
@@ -1554,7 +1545,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
     uint8_t ack_type_byte = picoquic_frame_type_ack;
 
     /* Check that there is enough room in the packet, and something to acknowledge */
-    if (cnx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
+    if (cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
         *consumed = 0;
     } else if (bytes_max < 13) {
         /* A valid ACK, with our encoding, uses at least 13 bytes.
@@ -1568,13 +1559,13 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
         /* Encode the largest seen */
         if (byte_index < bytes_max) {
             l_largest = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
-                cnx->first_sack_item.end_of_sack_range);
+                cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range);
             byte_index += l_largest;
         }
         /* Encode the ack delay */
         if (byte_index < bytes_max) {
-            if (current_time > cnx->time_stamp_largest_received) {
-                ack_delay = current_time - cnx->time_stamp_largest_received;
+            if (current_time > cnx->pkt_ctx[pc].time_stamp_largest_received) {
+                ack_delay = current_time - cnx->pkt_ctx[pc].time_stamp_largest_received;
                 ack_delay >>= cnx->local_parameters.ack_delay_exponent;
             }
             l_delay = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
@@ -1586,7 +1577,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
         byte_index++;
         /* Encode the size of the first ack range */
         if (byte_index < bytes_max) {
-            ack_range = cnx->first_sack_item.end_of_sack_range - cnx->first_sack_item.start_of_sack_range;
+            ack_range = cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range - cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range;
             l_first_range = picoquic_varint_encode(bytes + byte_index, bytes_max - byte_index,
                 ack_range);
             byte_index += l_first_range;
@@ -1598,8 +1589,8 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
         } else {
             /* Set the lowest acknowledged */
-            lowest_acknowledged = cnx->first_sack_item.start_of_sack_range;
-            /* Encode the ack blocks that fir in the allocated space */
+            lowest_acknowledged = cnx->pkt_ctx[pc].first_sack_item.start_of_sack_range;
+            /* Encode the ack blocks that fit in the allocated space */
             while (num_block < 63 && next_sack != NULL) {
                 size_t l_gap = 0;
                 size_t l_range = 0;
@@ -1630,15 +1621,15 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
             bytes[num_block_index] = (uint8_t)num_block;
 
             /* Remember the ACK value and time */
-            cnx->highest_ack_sent = cnx->first_sack_item.end_of_sack_range;
-            cnx->highest_ack_time = current_time;
+            cnx->pkt_ctx[pc].highest_ack_sent = cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range;
+            cnx->pkt_ctx[pc].highest_ack_time = current_time;
 
             *consumed = byte_index;
         }
     }
 
     if (ret == 0) {
-        cnx->ack_needed = 0;
+        cnx->pkt_ctx[pc].ack_needed = 0;
     }
 
     return ret;
@@ -1648,8 +1639,9 @@ int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time)
 {
     int ret = 0;
 
-    if (cnx->highest_ack_sent + 2 <= cnx->first_sack_item.end_of_sack_range || cnx->highest_ack_time + cnx->ack_delay_local <= current_time) {
-        ret = cnx->ack_needed;
+    if (cnx->pkt_ctx[pc].highest_ack_sent + 2 <= cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range || 
+        cnx->pkt_ctx[pc].highest_ack_time + cnx->pkt_ctx[pc].ack_delay_local <= current_time) {
+        ret = cnx->pkt_ctx[pc].ack_needed;
     }
 
     return ret;
@@ -2079,6 +2071,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
 {
     const uint8_t *bytes_max = bytes + bytes_maxsize;
     int ack_needed = 0;
+    picoquic_packet_context_enum pc = picoquic_context_from_epoch(epoch);
 
     while (bytes != NULL && bytes < bytes_max) {
         uint8_t first_byte = bytes[0];
@@ -2092,7 +2085,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
             }
 
             bytes = picoquic_decode_stream_frame(cnx, bytes, bytes_max, current_time);
-            cnx->ack_needed = 1;
+            cnx->pkt_ctx[pc].ack_needed = 1;
 
         } else if (first_byte == picoquic_frame_type_ack) {
             bytes = picoquic_decode_ack_frame(cnx, bytes, bytes_max, current_time, epoch);
@@ -2186,7 +2179,7 @@ int picoquic_decode_frames(picoquic_cnx_t* cnx, uint8_t* bytes,
 
     if (bytes != NULL && ack_needed != 0) {
         cnx->latest_progress_time = current_time;
-        cnx->ack_needed = 1;
+        cnx->pkt_ctx[pc].ack_needed = 1;
     }
 
     return bytes != NULL ? 0 : 1;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -170,12 +170,20 @@ typedef enum {
     picoquic_packet_type_max
 } picoquic_packet_type_enum;
 
+typedef enum {
+    picoquic_packet_context_application = 0,
+    picoquic_packet_context_handshake = 1,
+    picoquic_packet_context_initial = 2,
+    picoquic_nb_packet_context = 3
+} picoquic_packet_context_enum;
+
 /*
-	 * The simple packet structure is used to store packets that
-	 * have been sent but are not yet acknowledged.
-	 * Packets are stored in unencrypted format.
-	 * The checksum length is the difference between encrypted and unencrypted.
-	 */
+ * The simple packet structure is used to store packets that
+ * have been sent but are not yet acknowledged.
+ * Packets are stored in unencrypted format.
+ * The checksum length is the difference between encrypted and unencrypted.
+ */
+
 typedef struct _picoquic_packet {
     struct _picoquic_packet* previous_packet;
     struct _picoquic_packet* next_packet;
@@ -186,6 +194,7 @@ typedef struct _picoquic_packet {
     uint32_t checksum_overhead;
     uint32_t offset;
     picoquic_packet_type_enum ptype;
+    picoquic_packet_context_enum pc;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquic_packet;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -417,9 +417,6 @@ typedef struct st_picoquic_cnx_t {
     unsigned int use_pn_encryption : 1;
     unsigned int is_0RTT_accepted : 1; /* whether 0-RTT is accepted */
     unsigned int remote_parameters_received : 1; /* whether remote parameters where received */
-#if 0
-    unsigned int ack_needed : 1;
-#endif
     unsigned int current_spin : 1; /* Current value of the spin bit */             
     unsigned int client_mode : 1; /* Is this connection the client side? */
     unsigned int prev_spin : 1;  /* previous Spin bit */
@@ -460,12 +457,9 @@ typedef struct st_picoquic_cnx_t {
     struct st_picoquic_cnx_t* next_by_wake_time;
     struct st_picoquic_cnx_t* previous_by_wake_time;
 
-    /* TLS context, TLS Send Buffer, chain of receive buffers (todo) */
+    /* TLS context, TLS Send Buffer, streams, epochs */
     void* tls_ctx;
     struct st_ptls_buffer_t* tls_sendbuf;
-#if 0
-    uint64_t send_sequence;
-#endif
     uint16_t psk_cipher_suite_id;
     picoquic_stream_head tls_stream;
     size_t epoch_offsets[5]; /* documents the offset for the sending side of the tls_stream */
@@ -480,33 +474,15 @@ typedef struct st_picoquic_cnx_t {
     /* Sequence and retransmission state */
     picoquic_packet_context_t pkt_ctx[picoquic_nb_packet_context];
 
-    /* Receive state */
-#if 0
-    picoquic_sack_item_t first_sack_item;
-    uint64_t time_stamp_largest_received;
-    uint64_t highest_ack_sent;
-    uint64_t highest_ack_time;
-    uint64_t ack_delay_local;
-#endif
-
-    /* Retransmission state */
+    /* Statistics */
     uint32_t nb_path_challenge_sent;
     uint32_t nb_path_response_received;
     uint32_t nb_zero_rtt_sent;
     uint32_t nb_zero_rtt_acked;
     uint64_t nb_retransmission_total;
     uint64_t nb_spurious;
-#if 0
-    uint64_t nb_retransmit;
-    uint64_t nb_spurious;
-    uint64_t latest_retransmit_time;
-    uint64_t highest_acknowledged;
-    uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
-    picoquic_packet* retransmit_newest;
-    picoquic_packet* retransmit_oldest;
-    picoquic_packet* retransmitted_newest;
-    picoquic_packet* retransmitted_oldest;
-#endif
+
+    /* Congestion algorithm */
     picoquic_congestion_algorithm_t const* congestion_alg;
 
     /* Flow control information */

--- a/picoquic/sacks.c
+++ b/picoquic/sacks.c
@@ -34,10 +34,11 @@
 /*
  * Check whether the packet was already received.
  */
-int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, uint64_t pn64)
+int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, 
+    picoquic_packet_context_enum pc, uint64_t pn64)
 {
     int is_received = 0;
-    picoquic_sack_item_t* sack = &cnx->first_sack_item;
+    picoquic_sack_item_t* sack = &cnx->pkt_ctx[pc].first_sack_item;
 
     if (sack->start_of_sack_range != (uint64_t)((int64_t)-1)) {
         do {
@@ -172,20 +173,22 @@ int picoquic_update_sack_list(picoquic_sack_item_t* sack,
     return ret;
 }
 
-int picoquic_record_pn_received(picoquic_cnx_t* cnx, uint64_t pn64, uint64_t current_microsec)
+int picoquic_record_pn_received(picoquic_cnx_t* cnx,
+    picoquic_packet_context_enum pc, uint64_t pn64,
+    uint64_t current_microsec)
 {
     int ret = 0;
-    picoquic_sack_item_t* sack = &cnx->first_sack_item;
+    picoquic_sack_item_t* sack = &cnx->pkt_ctx[pc].first_sack_item;
 
     if (sack->start_of_sack_range == (uint64_t)((int64_t)-1)) {
         /* This is the first packet ever received.. */
         sack->start_of_sack_range = pn64;
         sack->end_of_sack_range = pn64;
-        cnx->time_stamp_largest_received = current_microsec;
+        cnx->pkt_ctx[pc].time_stamp_largest_received = current_microsec;
     } 
     else {
         if (pn64 > sack->end_of_sack_range) {
-            cnx->time_stamp_largest_received = current_microsec;
+            cnx->pkt_ctx[pc].time_stamp_largest_received = current_microsec;
         }
 
         ret = picoquic_update_sack_list(sack, pn64, pn64);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -531,19 +531,21 @@ void picoquic_update_pacing_after_send(picoquic_path_t * send_path, uint64_t cur
 void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
     size_t length, uint64_t current_time)
 {
+    picoquic_packet_context_enum pc = packet->pc;
+
     /* Account for bytes in transit, for congestion control */
     path_x->bytes_in_transit += length;
 
     /* Manage the double linked packet list for retransmissions */
     packet->previous_packet = NULL;
-    if (cnx->retransmit_newest == NULL) {
+    if (cnx->pkt_ctx[pc].retransmit_newest == NULL) {
         packet->next_packet = NULL;
-        cnx->retransmit_oldest = packet;
+        cnx->pkt_ctx[pc].retransmit_oldest = packet;
     } else {
-        packet->next_packet = cnx->retransmit_newest;
+        packet->next_packet = cnx->pkt_ctx[pc].retransmit_newest;
         packet->next_packet->previous_packet = packet;
     }
-    cnx->retransmit_newest = packet;
+    cnx->pkt_ctx[pc].retransmit_newest = packet;
 
     /* Update the pacing data */
     picoquic_update_pacing_after_send(path_x, current_time);
@@ -558,9 +560,13 @@ void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet *
     size_t * send_length, uint8_t * send_buffer, picoquic_path_t * path_x,
     uint64_t current_time)
 {
+
     if (ret == 0 && length > 0) {
+        DBG_PRINTF("Sending packet (%d), type: %d, pc: %d, pn: %d, l: %d\n",
+            cnx->client_mode, packet->ptype, packet->pc, (int)packet->sequence_number, length);
+
         packet->length = length;
-        cnx->send_sequence++;
+        cnx->pkt_ctx[packet->pc].send_sequence++;
 
         switch (packet->ptype) {
 
@@ -625,7 +631,8 @@ void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet *
 static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
     picoquic_packet* p, uint64_t current_time, int* timer_based)
 {
-    int64_t delta_seq = cnx->highest_acknowledged - p->sequence_number;
+    picoquic_packet_context_enum pc = p->pc;
+    int64_t delta_seq = cnx->pkt_ctx[pc].highest_acknowledged - p->sequence_number;
     int should_retransmit = 0;
 
     if (delta_seq > 3) {
@@ -635,7 +642,7 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
          */
         should_retransmit = 1;
     } else {
-        int64_t delta_t = cnx->latest_time_acknowledged - p->send_time;
+        int64_t delta_t = cnx->pkt_ctx[pc].latest_time_acknowledged - p->send_time;
 
         /* TODO: out of order delivery time ought to be dynamic */
         if (delta_t > PICOQUIC_RACK_DELAY && p->ptype != picoquic_packet_0rtt_protected) {
@@ -648,7 +655,7 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
             /* If the delta-t is larger than zero, add the time since the
             * last ACK was received. If that is larger than the inter packet
             * time, consider that there is a loss */
-            uint64_t time_from_last_ack = current_time - cnx->latest_time_acknowledged + delta_t;
+            uint64_t time_from_last_ack = current_time - cnx->pkt_ctx[pc].latest_time_acknowledged + delta_t;
 
             if (time_from_last_ack > 10000) {
                 should_retransmit = 1;
@@ -658,8 +665,8 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
         if (should_retransmit == 0) {
             /* Don't fire yet, because of possible out of order delivery */
             int64_t time_out = current_time - p->send_time;
-            uint64_t retransmit_timer = (cnx->nb_retransmit == 0) ? 
-                cnx->path[0]->retransmit_timer : (1000000ull << (cnx->nb_retransmit - 1));
+            uint64_t retransmit_timer = (cnx->pkt_ctx[pc].nb_retransmit == 0) ?
+                cnx->path[0]->retransmit_timer : (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1));
 
             if ((uint64_t)time_out < retransmit_timer) {
                 /* Do not retransmit if the timer has not yet elapsed */
@@ -674,10 +681,12 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
     return should_retransmit;
 }
 
-int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, uint64_t current_time,
+int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
+    picoquic_packet_context_enum pc,
+    picoquic_path_t * path_x, uint64_t current_time,
     picoquic_packet* packet, int* is_cleartext_mode, uint32_t* header_length)
 {
-    picoquic_packet* p = cnx->retransmit_oldest;
+    picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
     uint32_t length = 0;
 
     /* TODO: while packets are pure ACK, drop them from retransmit queue */
@@ -735,14 +744,16 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, ui
             }
 
             if (should_retransmit != 0) {
-                packet->sequence_number = cnx->send_sequence;
+                packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
                 packet->send_path = path_x;
+                packet->pc = pc;
 
                 *header_length = length;
 
                 if (p->ptype < picoquic_packet_1rtt_protected_phi0) {
-                    DBG_PRINTF("Retransmit packet type %d, seq = %llx, is_client = %d\n",
-                        p->ptype, (unsigned long long)p->sequence_number, cnx->client_mode);
+                    DBG_PRINTF("Retransmit packet type %d, pc=%d, seq = %llx, is_client = %d\n",
+                        p->ptype, p->pc,
+                        (unsigned long long)p->sequence_number, cnx->client_mode);
                 }
 
                 if (p->ptype == picoquic_packet_1rtt_protected_phi0 || p->ptype == picoquic_packet_1rtt_protected_phi1 || p->ptype == picoquic_packet_0rtt_protected) {
@@ -758,10 +769,6 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, ui
                     /* MTU probes should not be retransmitted */
                     packet_is_pure_ack = 1;
                     do_not_detect_spurious = 0;
-                } else if (p->ptype == picoquic_packet_initial && cnx->client_mode != 0 &&
-                    cnx->cnx_state >= picoquic_state_client_handshake_start) {
-                    /* pretending this is a pure ACK to avoid undue retransmission */
-                    packet_is_pure_ack = 1;
                 } else {
                     checksum_length = picoquic_get_checksum_length(cnx, *is_cleartext_mode);
 
@@ -807,7 +814,7 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, ui
                     should_retransmit = 0;
                 } else {
                     if (timer_based_retransmit != 0) {
-                        if (cnx->nb_retransmit > 4) {
+                        if (cnx->pkt_ctx[pc].nb_retransmit > 4) {
                             /*
                              * Max retransmission count was exceeded. Disconnect.
                              */
@@ -820,8 +827,8 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, ui
                             should_retransmit = 0;
                             break;
                         } else {
-                            cnx->nb_retransmit++;
-                            cnx->latest_retransmit_time = current_time;
+                            cnx->pkt_ctx[pc].nb_retransmit++;
+                            cnx->pkt_ctx[pc].latest_retransmit_time = current_time;
                         }
                     }
 
@@ -861,33 +868,38 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx, picoquic_path_t * path_x, ui
  */
 int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx)
 {
-    picoquic_packet* p = cnx->retransmit_oldest;
     int backlog_empty = 1;
 
-    while (p != NULL && backlog_empty == 1) {
-        /* check if this is an ACK only packet */
-        int ret = 0;
-        int frame_is_pure_ack = 0;
-        size_t frame_length = 0;
-        size_t byte_index = 0; /* Used when parsing the old packet */
+    for (picoquic_packet_context_enum pc = 0;
+        backlog_empty == 1 && pc < picoquic_nb_packet_context; pc++)
+    {
+        picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+
+        while (p != NULL && backlog_empty == 1) {
+            /* check if this is an ACK only packet */
+            int ret = 0;
+            int frame_is_pure_ack = 0;
+            size_t frame_length = 0;
+            size_t byte_index = 0; /* Used when parsing the old packet */
 
 
-        /* Copy the relevant bytes from one packet to the next */
-        byte_index = p->offset;
+            /* Copy the relevant bytes from one packet to the next */
+            byte_index = p->offset;
 
 
-        while (ret == 0 && byte_index < p->length) {
-            ret = picoquic_skip_frame(&p->bytes[byte_index],
-                p->length - p->offset, &frame_length, &frame_is_pure_ack);
+            while (ret == 0 && byte_index < p->length) {
+                ret = picoquic_skip_frame(&p->bytes[byte_index],
+                    p->length - p->offset, &frame_length, &frame_is_pure_ack);
 
-            if (!frame_is_pure_ack) {
-                backlog_empty = 0;
-                break;
+                if (!frame_is_pure_ack) {
+                    backlog_empty = 0;
+                    break;
+                }
+                byte_index += frame_length;
             }
-            byte_index += frame_length;
-        }
 
-        p = p->previous_packet;
+            p = p->previous_packet;
+        }
     }
 
     return backlog_empty;
@@ -959,7 +971,6 @@ uint32_t picoquic_prepare_mtu_probe(picoquic_cnx_t* cnx,
 static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t current_time)
 {
     uint64_t next_time = cnx->start_time + PICOQUIC_MICROSEC_HANDSHAKE_MAX;
-    picoquic_packet* p = cnx->retransmit_oldest;
     picoquic_stream_head* stream = NULL;
     int timer_based = 0;
     int blocked = 1;
@@ -973,32 +984,35 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
     }
     else
     {
-        while (p != NULL)
-        {
-            if (p->ptype < picoquic_packet_0rtt_protected) {
-                if (picoquic_retransmit_needed_by_packet(cnx, p, current_time, &timer_based)) {
-                    blocked = 0;
-                }
-                break;
-            }
-            p = p->next_packet;
-        }
+        for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
+            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
 
-
-        if (blocked != 0)
-        {
-            if (picoquic_is_ack_needed(cnx, current_time)) {
-                blocked = 0;
-            }
-            else if (path_x->cwin > path_x->bytes_in_transit && path_x->challenge_verified == 1) {
-                if (picoquic_should_send_max_data(cnx) ||
-                    picoquic_is_tls_stream_ready(cnx) ||
-                    (cnx->crypto_context[1].aead_encrypt != NULL && (stream = picoquic_find_ready_stream(cnx)) != NULL)) {
-                    if (path_x->next_pacing_time < current_time + path_x->pacing_margin_micros) {
+            while (p != NULL)
+            {
+                if (p->ptype < picoquic_packet_0rtt_protected) {
+                    if (picoquic_retransmit_needed_by_packet(cnx, p, current_time, &timer_based)) {
                         blocked = 0;
                     }
-                    else {
-                        pacing = 1;
+                    break;
+                }
+                p = p->next_packet;
+            }
+
+            if (blocked != 0)
+            {
+                if (picoquic_is_ack_needed(cnx, current_time, pc)) {
+                    blocked = 0;
+                }
+                else if (path_x->cwin > path_x->bytes_in_transit && path_x->challenge_verified == 1) {
+                    if (picoquic_should_send_max_data(cnx) ||
+                        picoquic_is_tls_stream_ready(cnx) ||
+                        (cnx->crypto_context[1].aead_encrypt != NULL && (stream = picoquic_find_ready_stream(cnx)) != NULL)) {
+                        if (path_x->next_pacing_time < current_time + path_x->pacing_margin_micros) {
+                            blocked = 0;
+                        }
+                        else {
+                            pacing = 1;
+                        }
                     }
                 }
             }
@@ -1011,36 +1025,39 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
             next_time = path_x->next_pacing_time;
         }
         else {
-            /* Consider delayed ACK */
-            if (cnx->ack_needed) {
-                next_time = cnx->highest_ack_time + cnx->ack_delay_local;
-            }
-
-            /* Consider path challenges */
-            if (path_x->challenge_verified == 0) {
-                uint64_t next_challenge_time = path_x->challenge_time + path_x->retransmit_timer;
-                if (current_time < next_challenge_time) {
-                    if (next_time > next_challenge_time) {
-                        next_time = next_challenge_time;
-                    }
-                } else {
-                    next_time = current_time;
+            for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
+                picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+                /* Consider delayed ACK */
+                if (cnx->pkt_ctx[pc].ack_needed) {
+                    next_time = cnx->pkt_ctx[pc].highest_ack_time + cnx->pkt_ctx[pc].ack_delay_local;
                 }
-            }
 
-            if (p != NULL) {
-                if (cnx->nb_retransmit == 0) {
-                    if (p->send_time + path_x->retransmit_timer < next_time) {
-                        next_time = p->send_time + path_x->retransmit_timer;
+                if (p != NULL) {
+                    if (cnx->pkt_ctx[pc].nb_retransmit == 0) {
+                        if (p->send_time + path_x->retransmit_timer < next_time) {
+                            next_time = p->send_time + path_x->retransmit_timer;
+                        }
                     }
-                }
-                else {
-                    if (p->send_time + (1000000ull << (cnx->nb_retransmit - 1)) < next_time) {
-                        next_time = p->send_time + (1000000ull << (cnx->nb_retransmit - 1));
+                    else {
+                        if (p->send_time + (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1)) < next_time) {
+                            next_time = p->send_time + (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1));
+                        }
                     }
                 }
             }
+        }
+    }
 
+    /* Consider path challenges */
+    if (path_x->challenge_verified == 0) {
+        uint64_t next_challenge_time = path_x->challenge_time + path_x->retransmit_timer;
+        if (current_time < next_challenge_time) {
+            if (next_time > next_challenge_time) {
+                next_time = next_challenge_time;
+            }
+        }
+        else {
+            next_time = current_time;
         }
     }
 
@@ -1053,7 +1070,6 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
 void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
 {
     uint64_t next_time = cnx->latest_progress_time + PICOQUIC_MICROSEC_SILENCE_MAX;
-    picoquic_packet* p = cnx->retransmit_oldest;
     picoquic_stream_head* stream = NULL;
     int timer_based = 0;
     int blocked = 1;
@@ -1070,21 +1086,35 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
 
     if (cnx->cnx_state == picoquic_state_disconnecting || cnx->cnx_state == picoquic_state_handshake_failure || cnx->cnx_state == picoquic_state_closing_received) {
         blocked = 0;
-    } else if (p != NULL && ret == 0 && picoquic_retransmit_needed_by_packet(cnx, p, current_time, /* &ph,*/ &timer_based)) {
+    }
+    else if (path_x->cwin > path_x->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx, path_x)) {
         blocked = 0;
-    } else if (picoquic_is_ack_needed(cnx, current_time)) {
-        blocked = 0;
-    } else if (path_x->cwin > path_x->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx, path_x)) {
-        blocked = 0;
-    } else if (path_x->cwin > path_x->bytes_in_transit) {
-        if (picoquic_should_send_max_data(cnx) ||
-            picoquic_is_tls_stream_ready(cnx) ||
-            ((cnx->cnx_state == picoquic_state_client_ready || cnx->cnx_state == picoquic_state_server_ready) &&
-            (stream = picoquic_find_ready_stream(cnx)) != NULL)) {
-            if (path_x->next_pacing_time < current_time + path_x->pacing_margin_micros) {
+    }
+    else {
+        for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
+            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+
+            if (p != NULL && ret == 0 && picoquic_retransmit_needed_by_packet(cnx, p, current_time, /* &ph,*/ &timer_based)) {
                 blocked = 0;
-            } else {
-                pacing = 1;
+            }
+            else if (picoquic_is_ack_needed(cnx, current_time, pc)) {
+                blocked = 0;
+            }
+        }
+
+        if (blocked != 0) {
+            if (path_x->cwin > path_x->bytes_in_transit) {
+                if (picoquic_should_send_max_data(cnx) ||
+                    picoquic_is_tls_stream_ready(cnx) ||
+                    ((cnx->cnx_state == picoquic_state_client_ready || cnx->cnx_state == picoquic_state_server_ready) &&
+                    (stream = picoquic_find_ready_stream(cnx)) != NULL)) {
+                    if (path_x->next_pacing_time < current_time + path_x->pacing_margin_micros) {
+                        blocked = 0;
+                    }
+                    else {
+                        pacing = 1;
+                    }
+                }
             }
         }
     }
@@ -1093,14 +1123,36 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
         next_time = current_time;
     } else if (pacing != 0) {
         next_time = path_x->next_pacing_time;
-    }
-    else {
-        /* Consider delayed ACK */
-        if (cnx->ack_needed) {
-            uint64_t ack_time = cnx->highest_ack_time + cnx->ack_delay_local;
+    } else {
+        for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
+            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+            /* Consider delayed ACK */
+            if (cnx->pkt_ctx[pc].ack_needed) {
+                uint64_t ack_time = cnx->pkt_ctx[pc].highest_ack_time + cnx->pkt_ctx[pc].ack_delay_local;
 
-            if (ack_time < next_time) {
-                next_time = ack_time;
+                if (ack_time < next_time) {
+                    next_time = ack_time;
+                }
+            }
+
+            /* Consider delayed RACK */
+            if (p != NULL) {
+                if (cnx->pkt_ctx[pc].latest_time_acknowledged > p->send_time
+                    && p->send_time + PICOQUIC_RACK_DELAY < next_time
+                    && p->ptype != picoquic_packet_0rtt_protected) {
+                    next_time = p->send_time + PICOQUIC_RACK_DELAY;
+                }
+
+                if (cnx->pkt_ctx[pc].nb_retransmit == 0) {
+                    if (p->send_time + path_x->retransmit_timer < next_time) {
+                        next_time = p->send_time + path_x->retransmit_timer;
+                    }
+                }
+                else {
+                    if (p->send_time + (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1)) < next_time) {
+                        next_time = p->send_time + (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1));
+                    }
+                }
             }
         }
 
@@ -1110,24 +1162,6 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
             if (current_time < next_challenge_time) {
                 if (next_time > next_challenge_time) {
                     next_time = next_challenge_time;
-                }
-            }
-        }
-
-        /* Consider delayed RACK */
-        if (p != NULL) {
-            if (cnx->latest_time_acknowledged > p->send_time && p->send_time + PICOQUIC_RACK_DELAY < next_time
-                && p->ptype != picoquic_packet_0rtt_protected) {
-                next_time = p->send_time + PICOQUIC_RACK_DELAY;
-            }
-
-            if (cnx->nb_retransmit == 0) {
-                if (p->send_time + path_x->retransmit_timer < next_time) {
-                    next_time = p->send_time + path_x->retransmit_timer;
-                }
-            } else {
-                if (p->send_time + (1000000ull << (cnx->nb_retransmit - 1)) < next_time) {
-                    next_time = p->send_time + (1000000ull << (cnx->nb_retransmit - 1));
                 }
             }
         }
@@ -1162,7 +1196,8 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, 
     packet->ptype = picoquic_packet_0rtt_protected;
     packet->offset = length;
     header_length = length;
-    packet->sequence_number = cnx->send_sequence;
+    packet->pc = picoquic_packet_context_application;
+    packet->sequence_number = cnx->pkt_ctx[picoquic_packet_context_application].send_sequence;
     packet->send_time = current_time;
     packet->send_path = path_x;
 
@@ -1230,7 +1265,51 @@ picoquic_packet_type_enum picoquic_packet_type_from_epoch(int epoch)
     return ptype;
 }
 
-/* Prepare the next packet to send when in one the client initial states */
+/* Prepare a required repetition or ack  in a previous context */
+uint32_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
+    picoquic_path_t * path_x, picoquic_packet* packet, uint64_t current_time, uint32_t * header_length)
+{
+    int is_cleartext_mode = (pc == picoquic_packet_context_initial) ? 1 : 0;
+    uint32_t length = 0;
+    size_t data_bytes = 0;
+    uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+
+    *header_length = 0;
+
+    length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, packet, 
+        &is_cleartext_mode, header_length);
+    
+    if (length == 0 && cnx->pkt_ctx[pc].ack_needed != 0) {
+        packet->ptype =
+            (pc == picoquic_packet_context_initial) ? picoquic_packet_initial :
+            ((pc == picoquic_packet_context_handshake) ? picoquic_packet_handshake :
+                picoquic_packet_0rtt_protected);
+        length = picoquic_predict_packet_header_length(cnx, packet->ptype);
+        packet->offset = length;
+        *header_length = length;
+        packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+        packet->send_time = current_time;
+        packet->send_path = path_x;
+    }
+
+    if (length > 0) {
+        /* Check whether it makes sens to add an ACK at the end of the retransmission */
+        if (picoquic_prepare_ack_frame(cnx, current_time, pc, &packet->bytes[length],
+            path_x->send_mtu - checksum_overhead - length, &data_bytes)
+            == 0) {
+            length += (uint32_t)data_bytes;
+        }
+        packet->length = length;
+        /* document the send time & overhead */
+        packet->send_time = current_time;
+        packet->checksum_overhead = checksum_overhead;
+        packet->pc = pc;
+    }
+
+    return length;
+}
+
+/* Prepare the next packet to send when in one of the client initial states */
 int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t* send_length)
 {
@@ -1246,6 +1325,7 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
     uint32_t length = 0;
     int epoch = 0;
     int next_offset = cnx->epoch_offsets[1];
+    picoquic_packet_context_enum pc = picoquic_packet_context_initial;
 
     while (cnx->tls_stream.sent_offset >= next_offset && epoch < 2) {
         epoch++;
@@ -1268,125 +1348,143 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
         packet_type = picoquic_packet_initial;
         break;
     case picoquic_state_client_handshake_start:
+        pc = picoquic_packet_context_handshake;
         retransmit_possible = 1;
         break;
     case picoquic_state_client_handshake_progress:
+        pc = picoquic_packet_context_handshake;
         retransmit_possible = 1;
         break;
     case picoquic_state_client_almost_ready:
+        pc = picoquic_packet_context_handshake;
         break;
     default:
         ret = -1;
         break;
     }
-    checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
-    tls_ready = picoquic_is_tls_stream_ready(cnx);
+    /* If context is handshake, verify first that there is no need for retransmit or ack
+     * on initial context */
+    if (ret == 0 && pc == picoquic_packet_context_handshake) {
+        length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_initial,
+            path_x, packet, current_time, &header_length);
+    }
 
-    if (ret == 0 && retransmit_possible && 
-        (length = picoquic_retransmit_needed(cnx, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
-        /* Set the new checksum length */
+    /* If there is nothing to send in previous context, check this one too */
+    if (length == 0) {
         checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
-        /* Check whether it makes sens to add an ACK at the end of the retransmission */
-        if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            path_x->send_mtu - checksum_overhead - length, &data_bytes)
-            == 0) {
-            length += (uint32_t) data_bytes;
-            packet->length = length;
-        }
-        /* document the send time & overhead */
-        packet->send_time = current_time;
         packet->checksum_overhead = checksum_overhead;
-    } else if (ret == 0 && is_cleartext_mode && tls_ready == 0 && cnx->first_misc_frame == NULL && cnx->ack_needed == 0) {
-        /* when in a clear text mode, only send packets if there is
-        * actually something to send, or resend */
+        packet->pc = pc;
 
-        packet->length = 0;
-    } else if (ret == 0) {
-        if (cnx->crypto_context[epoch].aead_encrypt == NULL) {
+        tls_ready = picoquic_is_tls_stream_ready(cnx);
+
+        if (ret == 0 && retransmit_possible &&
+            (length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
+            /* Check whether it makes sens to add an ACK at the end of the retransmission */
+            if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
+                path_x->send_mtu - checksum_overhead - length, &data_bytes)
+                == 0) {
+                length += (uint32_t)data_bytes;
+                packet->length = length;
+            }
+            /* document the send time & overhead */
+            packet->send_time = current_time;
+            packet->checksum_overhead = checksum_overhead;
+        }
+        else if (ret == 0 && is_cleartext_mode && tls_ready == 0
+            && cnx->first_misc_frame == NULL && cnx->pkt_ctx[pc].ack_needed == 0) {
+            /* when in a clear text mode, only send packets if there is
+            * actually something to send, or resend */
+
             packet->length = 0;
         }
-        else {
-            length = picoquic_predict_packet_header_length(cnx, packet_type);
-            packet->ptype = packet_type;
-            packet->offset = length;
-            header_length = length;
-            packet->sequence_number = cnx->send_sequence;
-            packet->send_time = current_time;
-            packet->send_path = path_x;
-
-            if ((tls_ready == 0 || path_x->cwin <= path_x->bytes_in_transit) && (cnx->cnx_state == picoquic_state_client_almost_ready || picoquic_is_ack_needed(cnx, current_time) == 0)
-                && cnx->first_misc_frame == NULL) {
-                length = 0;
+        else if (ret == 0) {
+            if (cnx->crypto_context[epoch].aead_encrypt == NULL) {
+                packet->length = 0;
             }
             else {
-                if (cnx->cnx_state != picoquic_state_client_almost_ready) {
-                    ret = picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
+                length = picoquic_predict_packet_header_length(cnx, packet_type);
+                packet->ptype = packet_type;
+                packet->offset = length;
+                header_length = length;
+                packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+                packet->send_time = current_time;
+                packet->send_path = path_x;
+
+                if ((tls_ready == 0 || path_x->cwin <= path_x->bytes_in_transit)
+                    && (cnx->cnx_state == picoquic_state_client_almost_ready
+                        || picoquic_is_ack_needed(cnx, current_time, pc) == 0)
+                    && cnx->first_misc_frame == NULL) {
+                    length = 0;
+                }
+                else {
+                    ret = picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
                         path_x->send_mtu - checksum_overhead - length, &data_bytes);
                     if (ret == 0) {
                         length += (uint32_t)data_bytes;
-                    }
-                    else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                        data_bytes = 0;
+                    } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
                         ret = 0;
                     }
-                }
-
-                /* If present, send misc frame */
-                while (cnx->first_misc_frame != NULL) {
-                    ret = picoquic_prepare_first_misc_frame(cnx, &bytes[length],
-                        path_x->send_mtu - checksum_overhead - length, &data_bytes);
-                    if (ret == 0) {
-                        length += (uint32_t)data_bytes;
-                    }
-                    else {
-                        if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-                            ret = 0;
-                        }
-                        break;
-                    }
-                }
-
-                if (ret == 0 && path_x->cwin > path_x->bytes_in_transit) {
-                    /* Encode the stream frame */
-                    if (tls_ready != 0) {
-                        ret = picoquic_prepare_crypto_hs_frame(cnx, epoch,
-                            &bytes[length],
+                
+                    /* If present, send misc frame */
+                    while (cnx->first_misc_frame != NULL) {
+                        ret = picoquic_prepare_first_misc_frame(cnx, &bytes[length],
                             path_x->send_mtu - checksum_overhead - length, &data_bytes);
-
                         if (ret == 0) {
                             length += (uint32_t)data_bytes;
+                            data_bytes = 0;
                         }
-                        else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-                            ret = 0;
-                        }
-                    }
-
-                    if (packet_type == picoquic_packet_initial) {
-                        while (length < path_x->send_mtu - checksum_overhead) {
-                            bytes[length++] = 0;
+                        else {
+                            if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                                ret = 0;
+                            }
+                            break;
                         }
                     }
 
-                    if (packet_type == picoquic_packet_0rtt_protected) {
-                        cnx->nb_zero_rtt_sent++;
-                    }
-                }
+                    if (ret == 0 && path_x->cwin > path_x->bytes_in_transit) {
+                        /* Encode the crypto handshake frame */
+                        if (tls_ready != 0) {
+                            ret = picoquic_prepare_crypto_hs_frame(cnx, epoch,
+                                &bytes[length],
+                                path_x->send_mtu - checksum_overhead - length, &data_bytes);
 
-                /* If stream zero packets are sent, progress the state */
-                if (ret == 0 && tls_ready != 0 && data_bytes > 0 && cnx->tls_stream.send_queue == NULL) {
-                    switch (cnx->cnx_state) {
-                    case picoquic_state_client_init:
-                        cnx->cnx_state = picoquic_state_client_init_sent;
-                        path_x->next_pacing_time = current_time + 10000;
-                        break;
-                    case picoquic_state_client_renegotiate:
-                        cnx->cnx_state = picoquic_state_client_init_resent;
-                        break;
-                    case picoquic_state_client_almost_ready:
-                        cnx->cnx_state = picoquic_state_client_ready;
-                        break;
-                    default:
-                        break;
+                            if (ret == 0) {
+                                length += (uint32_t)data_bytes;
+                            }
+                            else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                                ret = 0;
+                            }
+                        }
+
+                        if (packet_type == picoquic_packet_initial) {
+                            while (length < path_x->send_mtu - checksum_overhead) {
+                                bytes[length++] = 0;
+                            }
+                        }
+
+                        if (packet_type == picoquic_packet_0rtt_protected) {
+                            cnx->nb_zero_rtt_sent++;
+                        }
+                    }
+
+                    /* If stream zero packets are sent, progress the state */
+                    if (ret == 0 && tls_ready != 0 && data_bytes > 0 && cnx->tls_stream.send_queue == NULL) {
+                        switch (cnx->cnx_state) {
+                        case picoquic_state_client_init:
+                            cnx->cnx_state = picoquic_state_client_init_sent;
+                            path_x->next_pacing_time = current_time + 10000;
+                            break;
+                        case picoquic_state_client_renegotiate:
+                            cnx->cnx_state = picoquic_state_client_init_resent;
+                            break;
+                        case picoquic_state_client_almost_ready:
+                            cnx->cnx_state = picoquic_state_client_ready;
+                            break;
+                        default:
+                            break;
+                        }
                     }
                 }
             }
@@ -1417,6 +1515,7 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
     int tls_ready = 0;
     int epoch = 0;
     picoquic_packet_type_enum packet_type = picoquic_packet_initial;
+    picoquic_packet_context_enum pc = picoquic_packet_context_initial;
     uint32_t checksum_overhead = 8;
     int is_cleartext_mode = 1;
     size_t data_bytes = 0;
@@ -1429,100 +1528,117 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
         epoch++;
         next_offset = cnx->epoch_offsets[epoch+1];
         packet_type = picoquic_packet_handshake;
+        pc = picoquic_packet_context_handshake;
     }
 
-    checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
-    tls_ready = picoquic_is_tls_stream_ready(cnx);
-
-    length = picoquic_predict_packet_header_length(cnx, packet_type);
-    packet->ptype = packet_type;
-    packet->offset = length;
-    header_length = length;
-    packet->sequence_number = cnx->send_sequence;
-    packet->send_time = current_time;
-    packet->send_path = path_x;
-
-    if (tls_ready != 0 && path_x->cwin <= path_x->bytes_in_transit && path_x->challenge_time == 0) {
-        /* Should send a path challenge and get a reply before sending more data */
-        path_x->challenge_verified = 0;
+    /* If context is handshake, verify first that there is no need for retransmit or ack
+    * on initial context */
+    if (ret == 0 && pc == picoquic_packet_context_handshake) {
+        length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_initial,
+            path_x, packet, current_time, &header_length);
     }
 
-    if (path_x->challenge_verified == 0) {
-        if (path_x->challenge_time + path_x->retransmit_timer <= current_time || path_x->challenge_time == 0) {
-            /* When blocked, repeat the path challenge or wait */
-            if (picoquic_prepare_path_challenge_frame(&bytes[length],
-                path_x->send_mtu - checksum_overhead - length, &data_bytes, path_x) == 0) {
-                length += (uint32_t)data_bytes;
-                path_x->challenge_time = current_time;
-                path_x->challenge_repeat_count++;
+    if (length == 0) {
+
+        checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+
+        tls_ready = picoquic_is_tls_stream_ready(cnx);
+
+        length = picoquic_predict_packet_header_length(cnx, packet_type);
+        packet->ptype = packet_type;
+        packet->offset = length;
+        header_length = length;
+        packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+        packet->send_time = current_time;
+        packet->send_path = path_x;
+        packet->pc = pc;
+
+        if (tls_ready != 0 && path_x->cwin <= path_x->bytes_in_transit && path_x->challenge_time == 0) {
+            /* Should send a path challenge and get a reply before sending more data */
+            path_x->challenge_verified = 0;
+        }
+
+        if (path_x->challenge_verified == 0) {
+            if (path_x->challenge_time + path_x->retransmit_timer <= current_time || path_x->challenge_time == 0) {
+                /* When blocked, repeat the path challenge or wait */
+                if (picoquic_prepare_path_challenge_frame(&bytes[length],
+                    path_x->send_mtu - checksum_overhead - length, &data_bytes, path_x) == 0) {
+                    length += (uint32_t)data_bytes;
+                    path_x->challenge_time = current_time;
+                    path_x->challenge_repeat_count++;
+                }
+                /* add an ACK just to be nice */
+                if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
+                    path_x->send_mtu - checksum_overhead - length, &data_bytes)
+                    == 0) {
+                    length += (uint32_t)data_bytes;
+                }
+
+                if (path_x->challenge_repeat_count > PICOQUIC_CHALLENGE_REPEAT_MAX) {
+                    DBG_PRINTF("%s\n", "Too many challenge retransmits, disconnect");
+                    cnx->cnx_state = picoquic_state_disconnected;
+                    if (cnx->callback_fn) {
+                        (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+                    }
+                    length = 0;
+                }
+
+                packet->length = length;
             }
-            /* add an ACK just to be nice */
-            if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
+        }
+        else if (tls_ready != 0 && path_x->cwin > path_x->bytes_in_transit) {
+            if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
                 path_x->send_mtu - checksum_overhead - length, &data_bytes)
                 == 0) {
                 length += (uint32_t)data_bytes;
             }
 
-            if (path_x->challenge_repeat_count > PICOQUIC_CHALLENGE_REPEAT_MAX) {
-                DBG_PRINTF("%s\n", "Too many challenge retransmits, disconnect");
-                cnx->cnx_state = picoquic_state_disconnected;
-                if (cnx->callback_fn) {
-                    (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+            /* Encode the stream frame */
+            ret = picoquic_prepare_crypto_hs_frame(cnx, epoch, &bytes[length],
+                path_x->send_mtu - checksum_overhead - length, &data_bytes);
+            if (ret == 0) {
+                length += (uint32_t)data_bytes;
+            }
+            else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                /* todo: reset offset to previous position? */
+                ret = 0;
+            }
+
+            /* progress the state if the epoch data is all sent */
+
+            if (ret == 0 && tls_ready != 0 && data_bytes > 0 && cnx->tls_stream.sent_offset >= next_offset) {
+                if (epoch == 2) {
+                    cnx->cnx_state = picoquic_state_server_ready;
                 }
-                length = 0;
+                else {
+                    cnx->cnx_state = picoquic_state_server_handshake;
+                }
             }
 
             packet->length = length;
-        }
-    } else if (tls_ready != 0 && path_x->cwin > path_x->bytes_in_transit) {
-        if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            path_x->send_mtu - checksum_overhead - length, &data_bytes)
-            == 0) {
-            length += (uint32_t)data_bytes;
-        }
 
-        /* Encode the stream frame */
-        ret = picoquic_prepare_crypto_hs_frame(cnx, epoch, &bytes[length],
-            path_x->send_mtu - checksum_overhead - length, &data_bytes);
-        if (ret == 0) {
-            length += (uint32_t)data_bytes;
-        } else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-            /* todo: reset offset to previous position? */
-            ret = 0;
         }
-
-        /* progress the state if the epoch data is all sent */
-
-        if (ret == 0 && tls_ready != 0 && data_bytes > 0 && cnx->tls_stream.sent_offset >= next_offset) {
-            if (epoch == 2) {
-                cnx->cnx_state = picoquic_state_server_ready;
+        else  if ((length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
+            /* Set the new checksum length */
+            checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+            /* Check whether it makes sens to add an ACK at the end of the retransmission */
+            if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
+                path_x->send_mtu - checksum_overhead - length, &data_bytes)
+                == 0) {
+                length += (uint32_t)data_bytes;
+                packet->length = length;
             }
-            else {
-                cnx->cnx_state = picoquic_state_server_handshake;
-            }
+            /* document the send time & overhead */
+            packet->send_time = current_time;
+            packet->checksum_overhead = checksum_overhead;
         }
-
-        packet->length = length;
-
-    } else  if ((length = picoquic_retransmit_needed(cnx, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
-        /* Set the new checksum length */
-        checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
-        /* Check whether it makes sens to add an ACK at the end of the retransmission */
-        if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            path_x->send_mtu - checksum_overhead - length, &data_bytes)
-            == 0) {
-            length += (uint32_t)data_bytes;
-            packet->length = length;
+        else {
+            /* when in a clear text mode, only send packets if there is
+            * actually something to send, or resend */
+            length = 0;
+            packet->length = 0;
         }
-        /* document the send time & overhead */
-        packet->send_time = current_time;
-        packet->checksum_overhead = checksum_overhead;
-    } else {
-        /* when in a clear text mode, only send packets if there is
-        * actually something to send, or resend */
-        length = 0;
-        packet->length = 0;
     }
 
     picoquic_finalize_and_protect_packet(cnx, packet,
@@ -1546,11 +1662,14 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
     uint32_t header_length = 0;
     uint8_t* bytes = packet->bytes;
     uint32_t length = 0;
+    picoquic_packet_context_enum pc = picoquic_packet_context_application;
 
     /* Prepare header -- depend on connection state */
     /* TODO: 0-RTT work. */
     switch (cnx->cnx_state) {
     case picoquic_state_handshake_failure:
+        /* TODO: check whether closing can be requested in "initial" mode */
+        pc = picoquic_packet_context_handshake;
         packet_type = picoquic_packet_handshake;
         break;
     case picoquic_state_disconnecting:
@@ -1577,138 +1696,162 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
         break;
     }
 
-    checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
-
-    if (ret == 0 && cnx->cnx_state == picoquic_state_closing_received) {
-        /* Send a closing frame, move to closing state */
-        size_t consumed = 0;
-        uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
-
-        length = picoquic_predict_packet_header_length(cnx, packet_type);
-        packet->ptype = packet_type;
-        packet->offset = length;
-        header_length = length;
-        packet->sequence_number = cnx->send_sequence;
-        packet->send_time = current_time;
-        packet->send_path = path_x;
-
-        /* Send the disconnect frame */
-        ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
-            path_x->send_mtu - checksum_overhead - length, &consumed);
-
-        if (ret == 0) {
-            length += (uint32_t)consumed;
+    /* Verify first that there is no need for retransmit or ack
+    * on initial or handshake context */
+    if (ret == 0) {
+        length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_initial,
+            path_x, packet, current_time, &header_length);
+        /* TODO: consider special case of EOED on 0-RTT stream */
+        if (length == 0) {
+            length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_handshake,
+                path_x, packet, current_time, &header_length);
         }
-        cnx->cnx_state = picoquic_state_draining;
-        picoquic_reinsert_by_wake_time(cnx->quic, cnx, exit_time);
-    } else if (ret == 0 && cnx->cnx_state == picoquic_state_closing) {
-        /* if more than 3*RTO is elapsed, move to disconnected */
-        uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
+    }
 
-        if (current_time >= exit_time) {
-            cnx->cnx_state = picoquic_state_disconnected;
-        } else if (current_time >= cnx->next_wake_time) {
-            uint64_t delta_t = path_x->rtt_min;
-            uint64_t next_time = 0;
+    if (length == 0) {
+        checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+        packet->pc = pc;
 
-            if (delta_t * 2 < path_x->retransmit_timer) {
-                delta_t = path_x->retransmit_timer / 2;
-            }
-            /* if more than N packet received, repeat and erase */
-            if (cnx->ack_needed) {
-                size_t consumed = 0;
-                length = picoquic_predict_packet_header_length(
-                    cnx, packet_type);
-                packet->ptype = packet_type;
-                packet->offset = length;
-                header_length = length;
-                packet->sequence_number = cnx->send_sequence;
-                packet->send_time = current_time;
-                packet->send_path = path_x;
+        if (ret == 0 && cnx->cnx_state == picoquic_state_closing_received) {
+            /* Send a closing frame, move to closing state */
+            size_t consumed = 0;
+            uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
 
-                /* Resend the disconnect frame */
-                if (cnx->local_error == 0) {
-                    ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
-                        path_x->send_mtu - checksum_overhead - length, &consumed);
-                } else {
-                    ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
-                        path_x->send_mtu - checksum_overhead - length, &consumed);
-                }
-                if (ret == 0) {
-                    length += (uint32_t)consumed;
-                }
-                cnx->ack_needed = 0;
-            }
-            next_time = current_time + delta_t;
-            if (next_time > exit_time) {
-                next_time = exit_time;
-            }
-            picoquic_reinsert_by_wake_time(cnx->quic, cnx, next_time);
-        }
-    } else if (ret == 0 && cnx->cnx_state == picoquic_state_draining) {
-        /* Nothing is ever sent in the draining state */
-        /* if more than 3*RTO is elapsed, move to disconnected */
-        uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
+            length = picoquic_predict_packet_header_length(cnx, packet_type);
+            packet->ptype = packet_type;
+            packet->offset = length;
+            header_length = length;
+            packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+            packet->send_time = current_time;
+            packet->send_path = path_x;
 
-        if (current_time >= exit_time) {
-            cnx->cnx_state = picoquic_state_disconnected;
-        } else {
-            picoquic_reinsert_by_wake_time(cnx->quic, cnx, exit_time);
-        }
-        length = 0;
-    } else if (ret == 0 && (cnx->cnx_state == picoquic_state_disconnecting || cnx->cnx_state == picoquic_state_handshake_failure)) {
-        length = picoquic_predict_packet_header_length(
-            cnx, packet_type);
-        packet->ptype = packet_type;
-        packet->offset = length;
-        header_length = length;
-        packet->sequence_number = cnx->send_sequence;
-        packet->send_time = current_time;
-        packet->send_path = path_x;
-
-        /* send either app close or connection close, depending on error code */
-        size_t consumed = 0;
-        uint64_t delta_t = path_x->rtt_min;
-
-        if (2 * delta_t < path_x->retransmit_timer) {
-            delta_t = path_x->retransmit_timer / 2;
-        }
-
-        /* add a final ack so receiver gets clean state */
-        ret = picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-            path_x->send_mtu - checksum_overhead - length, &consumed);
-        if (ret == 0) {
-            length += (uint32_t)consumed;
-        }
-
-        consumed = 0;
-        /* Send the disconnect frame */
-        if (cnx->local_error == 0) {
-            ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
-                path_x->send_mtu - checksum_overhead - length, &consumed);
-        } else {
+            /* Send the disconnect frame */
             ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
                 path_x->send_mtu - checksum_overhead - length, &consumed);
-        }
 
-        if (ret == 0) {
-            length += (uint32_t)consumed;
+            if (ret == 0) {
+                length += (uint32_t)consumed;
+            }
+            cnx->cnx_state = picoquic_state_draining;
+            picoquic_reinsert_by_wake_time(cnx->quic, cnx, exit_time);
         }
+        else if (ret == 0 && cnx->cnx_state == picoquic_state_closing) {
+            /* if more than 3*RTO is elapsed, move to disconnected */
+            uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
 
-        if (cnx->cnx_state == picoquic_state_handshake_failure) {
-            cnx->cnx_state = picoquic_state_disconnected;
-        } else {
-            cnx->cnx_state = picoquic_state_closing;
-        }
-        cnx->latest_progress_time = current_time;
-        picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time + delta_t);
-        cnx->ack_needed = 0;
+            if (current_time >= exit_time) {
+                cnx->cnx_state = picoquic_state_disconnected;
+            }
+            else if (current_time >= cnx->next_wake_time) {
+                uint64_t delta_t = path_x->rtt_min;
+                uint64_t next_time = 0;
 
-        if (cnx->callback_fn) {
-            (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+                if (delta_t * 2 < path_x->retransmit_timer) {
+                    delta_t = path_x->retransmit_timer / 2;
+                }
+                /* if more than N packet received, repeat and erase */
+                if (cnx->pkt_ctx[pc].ack_needed) {
+                    size_t consumed = 0;
+                    length = picoquic_predict_packet_header_length(
+                        cnx, packet_type);
+                    packet->ptype = packet_type;
+                    packet->offset = length;
+                    header_length = length;
+                    packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+                    packet->send_time = current_time;
+                    packet->send_path = path_x;
+
+                    /* Resend the disconnect frame */
+                    if (cnx->local_error == 0) {
+                        ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
+                            path_x->send_mtu - checksum_overhead - length, &consumed);
+                    }
+                    else {
+                        ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
+                            path_x->send_mtu - checksum_overhead - length, &consumed);
+                    }
+                    if (ret == 0) {
+                        length += (uint32_t)consumed;
+                    }
+                    cnx->pkt_ctx[pc].ack_needed = 0;
+                }
+                next_time = current_time + delta_t;
+                if (next_time > exit_time) {
+                    next_time = exit_time;
+                }
+                picoquic_reinsert_by_wake_time(cnx->quic, cnx, next_time);
+            }
         }
-    } else {
-        length = 0;
+        else if (ret == 0 && cnx->cnx_state == picoquic_state_draining) {
+            /* Nothing is ever sent in the draining state */
+            /* if more than 3*RTO is elapsed, move to disconnected */
+            uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
+
+            if (current_time >= exit_time) {
+                cnx->cnx_state = picoquic_state_disconnected;
+            }
+            else {
+                picoquic_reinsert_by_wake_time(cnx->quic, cnx, exit_time);
+            }
+            length = 0;
+        }
+        else if (ret == 0 && (cnx->cnx_state == picoquic_state_disconnecting || cnx->cnx_state == picoquic_state_handshake_failure)) {
+            length = picoquic_predict_packet_header_length(
+                cnx, packet_type);
+            packet->ptype = packet_type;
+            packet->offset = length;
+            header_length = length;
+            packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+            packet->send_time = current_time;
+            packet->send_path = path_x;
+
+            /* send either app close or connection close, depending on error code */
+            size_t consumed = 0;
+            uint64_t delta_t = path_x->rtt_min;
+
+            if (2 * delta_t < path_x->retransmit_timer) {
+                delta_t = path_x->retransmit_timer / 2;
+            }
+
+            /* add a final ack so receiver gets clean state */
+            ret = picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
+                path_x->send_mtu - checksum_overhead - length, &consumed);
+            if (ret == 0) {
+                length += (uint32_t)consumed;
+            }
+
+            consumed = 0;
+            /* Send the disconnect frame */
+            if (cnx->local_error == 0) {
+                ret = picoquic_prepare_application_close_frame(cnx, bytes + length,
+                    path_x->send_mtu - checksum_overhead - length, &consumed);
+            }
+            else {
+                ret = picoquic_prepare_connection_close_frame(cnx, bytes + length,
+                    path_x->send_mtu - checksum_overhead - length, &consumed);
+            }
+
+            if (ret == 0) {
+                length += (uint32_t)consumed;
+            }
+
+            if (cnx->cnx_state == picoquic_state_handshake_failure) {
+                cnx->cnx_state = picoquic_state_disconnected;
+            }
+            else {
+                cnx->cnx_state = picoquic_state_closing;
+            }
+            cnx->latest_progress_time = current_time;
+            picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time + delta_t);
+            cnx->pkt_ctx[pc].ack_needed = 0;
+
+            if (cnx->callback_fn) {
+                (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+            }
+        }
+        else {
+            length = 0;
+        }
     }
 
     picoquic_finalize_and_protect_packet(cnx, packet,
@@ -1726,6 +1869,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x,
     /* TODO: manage multiple streams. */
     picoquic_stream_head* stream = NULL;
     picoquic_packet_type_enum packet_type = picoquic_packet_1rtt_protected_phi0;
+    picoquic_packet_context_enum pc = picoquic_packet_context_application;
     int tls_ready = 0;
     int is_cleartext_mode = 0;
     int is_pure_ack = 1;
@@ -1736,183 +1880,201 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x,
     uint32_t length = 0;
     uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
-    tls_ready = picoquic_is_tls_stream_ready(cnx);
-    stream = picoquic_find_ready_stream(cnx);
 
-    if (ret == 0 && retransmit_possible && (length = picoquic_retransmit_needed(cnx, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
-        /* Set the new checksum length */
-        checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
-        /* Check whether it makes sense to add an ACK at the end of the retransmission */
-        /* Don't do that if it risks mixing clear text and encrypted ack */
-        if (is_cleartext_mode == 0) {
-            if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
-                path_x->send_mtu - checksum_overhead - length, &data_bytes)
-                == 0) {
-                length += (uint32_t)data_bytes;
-                packet->length = length;
-            }
+    /* Verify first that there is no need for retransmit or ack
+     * on initial or handshake context */
+    if (ret == 0) {
+        length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_initial,
+            path_x, packet, current_time, &header_length);
+        /* TODO: consider special case of EOED on 0-RTT stream */
+        if (length == 0) {
+            length = picoquic_prepare_packet_old_context(cnx, picoquic_packet_context_handshake,
+                path_x, packet, current_time, &header_length);
         }
-        /* document the send time & overhead */
-        is_pure_ack = 0;
-        packet->send_time = current_time;
-        packet->checksum_overhead = checksum_overhead;
     }
-    else if (ret == 0) {
-        length = picoquic_predict_packet_header_length(
-            cnx, packet_type);
-        packet->ptype = packet_type;
-        packet->offset = length;
-        header_length = length;
-        packet->sequence_number = cnx->send_sequence;
-        packet->send_time = current_time;
-        packet->send_path = path_x;
 
-        if (((stream == NULL && tls_ready == 0 && cnx->first_misc_frame == NULL) || path_x->cwin <= path_x->bytes_in_transit)
-            && picoquic_is_ack_needed(cnx, current_time) == 0
-            && (path_x->challenge_verified == 1 || current_time < path_x->challenge_time + path_x->retransmit_timer)) {
-            if (ret == 0 && path_x->cwin > path_x->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx, path_x)) {
-                length = picoquic_prepare_mtu_probe(cnx, path_x, header_length, checksum_overhead, bytes);
-                packet->length = length;
-                path_x->mtu_probe_sent = 1;
-                is_pure_ack = 0;
-            }
-            else {
-                length = 0;
-            }
-        }
-        else {
-            if (path_x->challenge_verified == 0 && current_time >= (path_x->challenge_time + path_x->retransmit_timer)) {
-                if (picoquic_prepare_path_challenge_frame(&bytes[length],
-                    path_x->send_mtu - checksum_overhead - length, &data_bytes, path_x) == 0) {
-                    length += (uint32_t)data_bytes;
-                    path_x->challenge_time = current_time;
-                    path_x->challenge_repeat_count++;
+    if (length == 0) {
+        tls_ready = picoquic_is_tls_stream_ready(cnx);
+        stream = picoquic_find_ready_stream(cnx);
+        packet->pc = pc;
 
-
-                    if (path_x->challenge_repeat_count > PICOQUIC_CHALLENGE_REPEAT_MAX) {
-                        DBG_PRINTF("%s\n", "Too many challenge retransmits, disconnect");
-                        cnx->cnx_state = picoquic_state_disconnected;
-                        if (cnx->callback_fn) {
-                            (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
-                        }
-                        length = 0;
-                    }
-                }
-            }
-
-            if (cnx->cnx_state != picoquic_state_disconnected) {
-                if (picoquic_prepare_ack_frame(cnx, current_time, &bytes[length],
+        if (ret == 0 && retransmit_possible &&
+            (length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, packet, &is_cleartext_mode, &header_length)) > 0) {
+            /* Set the new checksum length */
+            checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+            /* Check whether it makes sense to add an ACK at the end of the retransmission */
+            /* Don't do that if it risks mixing clear text and encrypted ack */
+            if (is_cleartext_mode == 0) {
+                if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
                     path_x->send_mtu - checksum_overhead - length, &data_bytes)
                     == 0) {
                     length += (uint32_t)data_bytes;
-                }
-
-                if (path_x->cwin > path_x->bytes_in_transit) {
-                    /* if present, send tls data */
-                    if (tls_ready) {
-                        ret = picoquic_prepare_crypto_hs_frame(cnx, 3, &bytes[length],
-                            path_x->send_mtu - checksum_overhead - length, &data_bytes);
-
-                        if (ret == 0) {
-                            length += (uint32_t)data_bytes;
-                            if (data_bytes > 0)
-                            {
-                                is_pure_ack = 0;
-                            }
-                        }
-                    }
-                    /* If present, send misc frame */
-                    while (cnx->first_misc_frame != NULL) {
-                        ret = picoquic_prepare_first_misc_frame(cnx, &bytes[length],
-                            path_x->send_mtu - checksum_overhead - length, &data_bytes);
-                        if (ret == 0) {
-                            length += (uint32_t)data_bytes;
-                        }
-                        else {
-                            if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-                                ret = 0;
-                            }
-                            break;
-                        }
-                    }
-                    /* If necessary, encode the max data frame */
-                    if (ret == 0 && 2 * cnx->data_received > cnx->maxdata_local) {
-                        ret = picoquic_prepare_max_data_frame(cnx, 2 * cnx->data_received, &bytes[length],
-                            path_x->send_mtu - checksum_overhead - length, &data_bytes);
-
-                        if (ret == 0) {
-                            length += (uint32_t)data_bytes;
-                            if (data_bytes > 0)
-                            {
-                                is_pure_ack = 0;
-                            }
-                        }
-                        else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-                            ret = 0;
-                        }
-                    }
-                    /* If necessary, encode the max stream data frames */
-                    ret = picoquic_prepare_required_max_stream_data_frames(cnx, &bytes[length],
-                        path_x->send_mtu - checksum_overhead - length, &data_bytes);
-
-                    if (ret == 0) {
-                        length += (uint32_t)data_bytes;
-                        if (data_bytes > 0)
-                        {
-                            is_pure_ack = 0;
-                        }
-                    }
-                    /* Encode the stream frame, or frames */
-                    while (stream != NULL) {
-                        ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
-                            path_x->send_mtu - checksum_overhead - length, &data_bytes);
-
-                        if (ret == 0) {
-                            length += (uint32_t)data_bytes;
-                            if (data_bytes > 0)
-                            {
-                                is_pure_ack = 0;
-                            }
-
-                            if (path_x->send_mtu > checksum_overhead + length + 8) {
-                                stream = picoquic_find_ready_stream(cnx);
-                            }
-                            else {
-                                break;
-                            }
-                        }
-                        else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
-                            ret = 0;
-                            break;
-                        }
-                    }
+                    packet->length = length;
                 }
             }
+            /* document the send time & overhead */
+            is_pure_ack = 0;
+            packet->send_time = current_time;
+            packet->checksum_overhead = checksum_overhead;
         }
-    }
-
-    if (cnx->cnx_state != picoquic_state_disconnected) {
-        /* If necessary, encode and send the keep alive packet!
-         * We only send keep alive packets when no other data is sent!
-         */
-        if (is_pure_ack == 0)
-        {
-            cnx->latest_progress_time = current_time;
-        }
-        else if (
-            cnx->keep_alive_interval != 0
-            && cnx->latest_progress_time + cnx->keep_alive_interval <= current_time && length == 0) {
+        else if (ret == 0) {
             length = picoquic_predict_packet_header_length(
                 cnx, packet_type);
             packet->ptype = packet_type;
             packet->offset = length;
             header_length = length;
-            packet->sequence_number = cnx->send_sequence;
-            packet->send_path = path_x;
+            packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
             packet->send_time = current_time;
-            bytes[length++] = picoquic_frame_type_ping;
-            bytes[length++] = 0;
-            cnx->latest_progress_time = current_time;
+            packet->send_path = path_x;
+
+            if (((stream == NULL && tls_ready == 0 && cnx->first_misc_frame == NULL) || path_x->cwin <= path_x->bytes_in_transit)
+                && picoquic_is_ack_needed(cnx, current_time, pc) == 0
+                && (path_x->challenge_verified == 1 || current_time < path_x->challenge_time + path_x->retransmit_timer)) {
+                if (ret == 0 && path_x->cwin > path_x->bytes_in_transit && picoquic_is_mtu_probe_needed(cnx, path_x)) {
+                    length = picoquic_prepare_mtu_probe(cnx, path_x, header_length, checksum_overhead, bytes);
+                    packet->length = length;
+                    path_x->mtu_probe_sent = 1;
+                    is_pure_ack = 0;
+                }
+                else {
+                    length = 0;
+                }
+            }
+            else {
+                if (path_x->challenge_verified == 0 && current_time >= (path_x->challenge_time + path_x->retransmit_timer)) {
+                    if (picoquic_prepare_path_challenge_frame(&bytes[length],
+                        path_x->send_mtu - checksum_overhead - length, &data_bytes, path_x) == 0) {
+                        length += (uint32_t)data_bytes;
+                        path_x->challenge_time = current_time;
+                        path_x->challenge_repeat_count++;
+
+
+                        if (path_x->challenge_repeat_count > PICOQUIC_CHALLENGE_REPEAT_MAX) {
+                            DBG_PRINTF("%s\n", "Too many challenge retransmits, disconnect");
+                            cnx->cnx_state = picoquic_state_disconnected;
+                            if (cnx->callback_fn) {
+                                (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+                            }
+                            length = 0;
+                        }
+                    }
+                }
+
+                if (cnx->cnx_state != picoquic_state_disconnected) {
+                    if (picoquic_prepare_ack_frame(cnx, current_time, pc, &bytes[length],
+                        path_x->send_mtu - checksum_overhead - length, &data_bytes)
+                        == 0) {
+                        length += (uint32_t)data_bytes;
+                    }
+
+                    if (path_x->cwin > path_x->bytes_in_transit) {
+                        /* if present, send tls data */
+                        if (tls_ready) {
+                            ret = picoquic_prepare_crypto_hs_frame(cnx, 3, &bytes[length],
+                                path_x->send_mtu - checksum_overhead - length, &data_bytes);
+
+                            if (ret == 0) {
+                                length += (uint32_t)data_bytes;
+                                if (data_bytes > 0)
+                                {
+                                    is_pure_ack = 0;
+                                }
+                            }
+                        }
+                        /* If present, send misc frame */
+                        while (cnx->first_misc_frame != NULL) {
+                            ret = picoquic_prepare_first_misc_frame(cnx, &bytes[length],
+                                path_x->send_mtu - checksum_overhead - length, &data_bytes);
+                            if (ret == 0) {
+                                length += (uint32_t)data_bytes;
+                            }
+                            else {
+                                if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                                    ret = 0;
+                                }
+                                break;
+                            }
+                        }
+                        /* If necessary, encode the max data frame */
+                        if (ret == 0 && 2 * cnx->data_received > cnx->maxdata_local) {
+                            ret = picoquic_prepare_max_data_frame(cnx, 2 * cnx->data_received, &bytes[length],
+                                path_x->send_mtu - checksum_overhead - length, &data_bytes);
+
+                            if (ret == 0) {
+                                length += (uint32_t)data_bytes;
+                                if (data_bytes > 0)
+                                {
+                                    is_pure_ack = 0;
+                                }
+                            }
+                            else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                                ret = 0;
+                            }
+                        }
+                        /* If necessary, encode the max stream data frames */
+                        ret = picoquic_prepare_required_max_stream_data_frames(cnx, &bytes[length],
+                            path_x->send_mtu - checksum_overhead - length, &data_bytes);
+
+                        if (ret == 0) {
+                            length += (uint32_t)data_bytes;
+                            if (data_bytes > 0)
+                            {
+                                is_pure_ack = 0;
+                            }
+                        }
+                        /* Encode the stream frame, or frames */
+                        while (stream != NULL) {
+                            ret = picoquic_prepare_stream_frame(cnx, stream, &bytes[length],
+                                path_x->send_mtu - checksum_overhead - length, &data_bytes);
+
+                            if (ret == 0) {
+                                length += (uint32_t)data_bytes;
+                                if (data_bytes > 0)
+                                {
+                                    is_pure_ack = 0;
+                                }
+
+                                if (path_x->send_mtu > checksum_overhead + length + 8) {
+                                    stream = picoquic_find_ready_stream(cnx);
+                                }
+                                else {
+                                    break;
+                                }
+                            }
+                            else if (ret == PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL) {
+                                ret = 0;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (cnx->cnx_state != picoquic_state_disconnected) {
+            /* If necessary, encode and send the keep alive packet!
+             * We only send keep alive packets when no other data is sent!
+             */
+            if (is_pure_ack == 0)
+            {
+                cnx->latest_progress_time = current_time;
+            }
+            else if (
+                cnx->keep_alive_interval != 0
+                && cnx->latest_progress_time + cnx->keep_alive_interval <= current_time && length == 0) {
+                length = picoquic_predict_packet_header_length(
+                    cnx, packet_type);
+                packet->ptype = packet_type;
+                packet->pc = pc;
+                packet->offset = length;
+                header_length = length;
+                packet->sequence_number = cnx->pkt_ctx[pc].send_sequence;
+                packet->send_path = path_x;
+                packet->send_time = current_time;
+                bytes[length++] = picoquic_frame_type_ping;
+                bytes[length++] = 0;
+                cnx->latest_progress_time = current_time;
+            }
         }
     }
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1052,13 +1052,10 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
     /* Consider path challenges */
     if (path_x->challenge_verified == 0) {
         uint64_t next_challenge_time = path_x->challenge_time + path_x->retransmit_timer;
-        if (current_time < next_challenge_time) {
-            if (next_time > next_challenge_time) {
-                next_time = next_challenge_time;
-            }
-        }
-        else {
+        if (next_challenge_time <= current_time) {
             next_time = current_time;
+        } else if (next_challenge_time < next_time) {
+            next_time = next_challenge_time;
         }
     }
 
@@ -1284,8 +1281,8 @@ uint32_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packe
     if (length == 0 && cnx->pkt_ctx[pc].ack_needed != 0) {
         packet->ptype =
             (pc == picoquic_packet_context_initial) ? picoquic_packet_initial :
-            ((pc == picoquic_packet_context_handshake) ? picoquic_packet_handshake :
-                picoquic_packet_0rtt_protected);
+            (pc == picoquic_packet_context_handshake) ? picoquic_packet_handshake :
+                picoquic_packet_0rtt_protected;
         length = picoquic_predict_packet_header_length(cnx, packet->ptype);
         packet->offset = length;
         *header_length = length;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -666,9 +666,6 @@ static int picoquic_update_traffic_key_callback(ptls_update_traffic_key_t * self
 
     int ret = picoquic_set_key_from_secret(cnx, cipher, is_enc, epoch, secret);
 
-    DBG_PRINTF("state:%d, is_client: %d, epoch: %d, is_enc: %d, ret:0x%x\n",
-        cnx->cnx_state, cnx->client_mode,  (int)epoch, is_enc, ret);
-
     return ret;
 }
 
@@ -1638,8 +1635,6 @@ int picoquic_tls_stream_process(picoquic_cnx_t* cnx)
 
         /* Update the current epoch */
         while (cnx->epoch_received[epoch] <= cnx->tls_stream.consumed_offset && epoch < 3) {
-            DBG_PRINTF("received[%d] = %d <= consumed = %d\n",
-                epoch, (int)cnx->epoch_received[epoch], (int)cnx->tls_stream.consumed_offset);
             epoch++;
         }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1279,9 +1279,8 @@ int picoquic_tlsinput_segment(picoquic_cnx_t* cnx, int epoch,
 
     if ((ret == 0 || ret == PTLS_ERROR_IN_PROGRESS) && roff < length) {
         inlen = length - roff;
-        ret = ptls_handle_message(ctx->tls, sendbuf, send_offset, epoch, bytes + roff, inlen, &ctx->handshake_properties);
-        DBG_PRINTF("State: %d, is_client: %d, epoch: %d, inlen: %d, buf.len = %d, ret: %x\n", 
-            cnx->cnx_state, cnx->client_mode, (int)epoch, inlen, sendbuf->off, ret);
+        ret = ptls_handle_message(ctx->tls, sendbuf, send_offset, epoch, bytes + roff, inlen,
+            &ctx->handshake_properties);
         roff += inlen;
         for (int i = 0; i < 5; i++) {
             cnx->epoch_offsets[i] += send_offset[i];
@@ -1710,17 +1709,22 @@ int picoquic_tls_stream_process(picoquic_cnx_t* cnx)
     } else if (ret == PTLS_ERROR_IN_PROGRESS && (cnx->cnx_state == picoquic_state_client_init || cnx->cnx_state == picoquic_state_client_init_sent || cnx->cnx_state == picoquic_state_client_init_resent)) {
         /* Extract and install the client 0-RTT key */
     } else if (ret == PTLS_ERROR_IN_PROGRESS && (cnx->cnx_state == picoquic_state_client_hrr_received)) {
-        picoquic_packet * next_retrans = cnx->retransmit_newest;
+
+        for (picoquic_packet_context_enum pc = 0;
+            pc < picoquic_nb_packet_context; pc++) {
+            picoquic_packet * next_retrans = cnx->pkt_ctx[pc].retransmit_newest;
+            /* Delete the packets queued for retransmission, but keep the 0-RTT packets */
+            while (next_retrans != NULL) {
+                picoquic_packet * next_next = next_retrans->next_packet;
+                /* TODO: special treatment for EOED packet */
+                if (next_retrans->ptype != picoquic_packet_0rtt_protected) {
+                    picoquic_dequeue_retransmit_packet(cnx, next_retrans, 1);
+                }
+                next_retrans = next_next;
+            }
+        }
         /* Need to reset the transport state of the connection */
         cnx->cnx_state = picoquic_state_client_init;
-        /* Delete the packets queued for retransmission, but keep the 0-RTT packets */
-        while (next_retrans != NULL) {
-            picoquic_packet * next_next = next_retrans->next_packet;
-            if (next_retrans->ptype != picoquic_packet_0rtt_protected) {
-                picoquic_dequeue_retransmit_packet(cnx, next_retrans, 1);
-            }
-            next_retrans = next_next;
-        }
 
         /* Reset the streams */
         picoquic_clear_stream(&cnx->tls_stream);

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -360,6 +360,7 @@ int parse_frame_test()
     const uint8_t extra_bytes[4] = { 0, 0, 0, 0 };
     uint64_t simulated_time = 0;
     struct sockaddr_in saddr;
+    picoquic_packet_context_enum pc = 0;
     picoquic_quic_t * qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL,
         NULL, NULL, NULL, NULL, simulated_time,
         &simulated_time, NULL, NULL, 0);
@@ -393,16 +394,18 @@ int parse_frame_test()
                     byte_max += sizeof(extra_bytes);
                 }
 
+                pc = picoquic_context_from_epoch(test_skip_list[i].epoch);
+
                 t_ret = picoquic_decode_frames(cnx, buffer, byte_max, test_skip_list[i].epoch, simulated_time);
 
                 if (t_ret != 0) {
                     DBG_PRINTF("Parse frame <%s> fails, ret = %d\n", test_skip_list[i].name, t_ret);
                     ret = t_ret;
                 }
-                else if ((cnx->ack_needed != 0 && test_skip_list[i].is_pure_ack != 0) ||
-                    (cnx->ack_needed == 0 && test_skip_list[i].is_pure_ack == 0)) {
-                    DBG_PRINTF("Parse frame <%s> fails, wrong pure ack, %d instead of %d\n",
-                        test_skip_list[i].name, (int)cnx->ack_needed, (int)test_skip_list[i].is_pure_ack);
+                else if ((cnx->pkt_ctx[pc].ack_needed != 0 && test_skip_list[i].is_pure_ack != 0) ||
+                    (cnx->pkt_ctx[pc].ack_needed == 0 && test_skip_list[i].is_pure_ack == 0)) {
+                    DBG_PRINTF("Parse frame <%s> fails, ack needed: %d, expected pure ack: %d\n",
+                        test_skip_list[i].name, (int)cnx->pkt_ctx[pc].ack_needed, (int)test_skip_list[i].is_pure_ack);
                     ret = -1;
                 }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1222,12 +1222,12 @@ int tls_api_q2_and_r2_stream_test()
 
 int tls_api_very_long_stream_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 1510000, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 3510000, NULL);
 }
 
 int tls_api_very_long_max_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 0, 0, 1510000, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 0, 0, 3510000, NULL);
 }
 
 int tls_api_very_long_with_err_test()
@@ -1859,10 +1859,6 @@ int zero_rtt_test_one(int use_badcrypt, int hardreset)
                     int was_active = 0;
 
                     ret = tls_api_one_sim_round(test_ctx, &simulated_time, &was_active);
-#if 0
-                    DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d), connection %d draining error (0x%x).\n",
-                        use_badcrypt, hardreset, i, ret);
-#endif
 
                     if (picoquic_is_cnx_backlog_empty(test_ctx->cnx_client) && picoquic_is_cnx_backlog_empty(test_ctx->cnx_server)) {
                         break;
@@ -2759,7 +2755,7 @@ int tls_different_params_test()
 
     test_parameters.initial_max_stream_id_bidir = 0;
 
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 1510000, &test_parameters);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 3510000, &test_parameters);
 }
 
 int set_certificate_and_key_test()


### PR DESCRIPTION
Implement the split into three packet number spaces, per draft 13. Fairly invasive.
Still need to implement other parts of draft-13, in particular ACK-ECN, retry cookies, and new transport parameters.