### PR TITLE
Retransmit 0RTT packets if they contain crypto-HS data. 

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -401,9 +401,16 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
-        TEST_METHOD(test_zero_rtt)
+        TEST_METHOD(zero_rtt)
         {
             int ret = zero_rtt_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
+        TEST_METHOD(zero_rtt_loss)
+        {
+            int ret = zero_rtt_loss_test();
 
             Assert::AreEqual(ret, 0);
         }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -93,6 +93,7 @@ static const picoquic_test_def_t test_table[] = {
     { "ticket_store", ticket_store_test },
     { "session_resume", session_resume_test },
     { "zero_rtt", zero_rtt_test },
+    { "zero_rtt_loss", zero_rtt_loss_test },
     { "stop_sending", stop_sending_test },
     { "unidir", unidir_test },
     { "mtu_discovery", mtu_discovery_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -81,6 +81,7 @@ int socket_test();
 int ticket_store_test();
 int session_resume_test();
 int zero_rtt_test();
+int zero_rtt_loss_test();
 int stop_sending_test();
 int unidir_test();
 int mtu_discovery_test();


### PR DESCRIPTION
Add test that reproduce the EOED loss issue. this fixes issue #231.