### PR TITLE
Rework handling of `RST_STREAM`

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -803,6 +803,17 @@ void picoquic_queue_stateless_reset(picoquic_cnx_t* cnx,
 
 picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length);
 
+#define STREAM_RESET_SENT(stream) ((stream->stream_flags & picoquic_stream_flag_reset_sent) != 0)
+#define STREAM_RESET_REQUESTED(stream) ((stream->stream_flags & picoquic_stream_flag_reset_requested) != 0)
+#define STREAM_SEND_RESET(stream) (STREAM_RESET_REQUESTED(stream) && !STREAM_RESET_SENT(stream))
+#define STREAM_STOP_SENDING_REQUESTED(stream) ((stream->stream_flags & picoquic_stream_flag_stop_sending_requested) != 0)
+#define STREAM_STOP_SENDING_SENT(stream) ((stream->stream_flags & picoquic_stream_flag_stop_sending_sent) != 0)
+#define STREAM_STOP_SENDING_RECEIVED(stream) ((stream->stream_flags & picoquic_stream_flag_stop_sending_received) != 0)
+#define STREAM_SEND_STOP_SENDING(stream) (STREAM_STOP_SENDING_REQUESTED(stream) && !STREAM_STOP_SENDING_SENT(stream))
+#define STREAM_FIN_NOTIFIED(stream) ((stream->stream_flags & picoquic_stream_flag_fin_notified) != 0)
+#define STREAM_FIN_SENT(stream) ((stream->stream_flags & picoquic_stream_flag_fin_sent) != 0)
+#define STREAM_SEND_FIN(stream) (STREAM_FIN_NOTIFIED(stream) && !STREAM_FIN_SENT(stream))
+
 #ifdef __cplusplus
 }
 #endif

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -59,7 +59,7 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
         /* Check parity */
         if (IS_CLIENT_STREAM_ID(stream_id) != cnx->client_mode) {
             ret = PICOQUIC_ERROR_INVALID_STREAM_ID;
-        } 
+        }
 
         if (ret == 0) {
             stream = picoquic_create_stream(cnx, stream_id);
@@ -82,6 +82,11 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
         } else {
             stream->stream_flags |= picoquic_stream_flag_fin_notified;
         }
+    }
+
+    /* If our side has sent RST_STREAM or received STOP_SENDING, we should not send anymore data. */
+    if (STREAM_RESET_SENT(stream) || STREAM_STOP_SENDING_RECEIVED(stream)) {
+        ret = -1;
     }
 
     if (ret == 0 && length > 0) {


### PR DESCRIPTION
When `RST_STREAM` is sent, the stream can still send `STOP_SENDING`.
The relevant check is now in `picoquic_add_to_stream` that ensures when
`RST_STREAM` was sent or `STOP_SENDING` was received, the stream does not send
anymore data.