### PR TITLE
header changes per QUIC PR 1498 + fix warnings

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -220,7 +220,7 @@ picoquic_stream_head* picoquic_find_or_create_stream(picoquic_cnx_t* cnx, uint64
 
     if (stream == NULL) {
         /* Verify the stream ID control conditions */
-        int      expect_client_stream = cnx->client_mode ^ is_remote;
+        unsigned int expect_client_stream = cnx->client_mode ^ is_remote;
         uint64_t max_stream = IS_BIDIR_STREAM_ID(stream_id) ? cnx->max_stream_id_bidir_local : cnx->max_stream_id_unidir_local;
 
         if (IS_CLIENT_STREAM_ID(stream_id) != expect_client_stream || stream_id > max_stream) {

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -971,7 +971,7 @@ void picoquic_log_frames(FILE* F, uint64_t cnx_id64, uint8_t* bytes, size_t leng
             /* Not implemented yet! */
             uint64_t frame_id64;
             if (picoquic_varint_decode(bytes, length - byte_index, &frame_id64) > 0) {
-                fprintf(F, "    Unknown frame, type: %"PRIst"\n", frame_id64);
+                fprintf(F, "    Unknown frame, type: %llu\n", (unsigned long long)frame_id64);
             } else {
                 fprintf(F, "    Truncated frame type\n");
             }

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -305,8 +305,8 @@ typedef struct _picoquic_stream_head {
     picoquic_sack_item_t first_sack_item;
 } picoquic_stream_head;
 
-#define IS_CLIENT_STREAM_ID(id) (((id) & 1) == 0)
-#define IS_BIDIR_STREAM_ID(id)  (((id) & 2) == 0)
+#define IS_CLIENT_STREAM_ID(id) (unsigned int)(((id) & 1) == 0)
+#define IS_BIDIR_STREAM_ID(id)  (unsigned int)(((id) & 2) == 0)
 
 /*
      * Frame queue. This is used for miscellaneous packets, such as the PONG

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1775,7 +1775,7 @@ int picoquic_set_tls_root_certificates(picoquic_quic_t* quic, ptls_iovec_t* cert
     ptls_context_t* ctx = (ptls_context_t*)quic->tls_master_ctx;
     ptls_openssl_verify_certificate_t* verify_ctx = (ptls_openssl_verify_certificate_t*)ctx->verify_certificate;
 
-    for (int i = 0; i < count; ++i) {
+    for (size_t i = 0; i < count; ++i) {
         X509* cert = d2i_X509(NULL, (const uint8_t**)&certs[i].base, certs[i].len);
 
         if (cert == NULL) {

--- a/picoquictest/intformattest.c
+++ b/picoquictest/intformattest.c
@@ -253,7 +253,8 @@ int varint_test()
                 } else if (length == 0) {
                     continue;
                 } else if (n64 != test->decoded) {
-                    fprintf(stderr, "Varint: unexpected value %"PRIst" [expected %"PRIst"]", n64, test->decoded);
+                    fprintf(stderr, "Varint: unexpected value %llu [expected %llu]", 
+                        (unsigned long long)n64, (unsigned long long)test->decoded);
                     test_ret = -1;
                 } else if (test->is_canonical != 0) {
                     uint8_t encoding[8];

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -56,6 +56,7 @@ static uint8_t pinitial10[] = {
     TEST_CNXID_LEN_BYTE,
     TEST_CNXID_INI_BYTES,
     TEST_CNXID_REM_BYTES,
+    0x00,
     0x44, 00,
     0xDE, 0xAD, 0xBE, 0xEF
 };
@@ -65,8 +66,8 @@ static picoquic_packet_header hinitial10 = {
     TEST_CNXID_REM_VAL,
     0xDEADBEEF,
     0x50435130,
-    20,
-    20,
+    21,
+    21,
     picoquic_packet_initial,
     0xFFFFFFFF00000000ull,
     0, 
@@ -87,6 +88,7 @@ static uint8_t pinitial10_l[] = {
     TEST_CNXID_LOCAL_BYTE,
     TEST_CNXID_INI_BYTES,
     TEST_CNXID_LOCAL_BYTES,
+    0,
     0x44, 00,
     0xDE, 0xAD, 0xBE, 0xEF
 };
@@ -96,8 +98,8 @@ static picoquic_packet_header hinitial10_l = {
     TEST_CNXID_LOCAL_VAL,
     0xDEADBEEF,
     0x50435130,
-    24,
-    24,
+    25,
+    25,
     picoquic_packet_initial,
     0xFFFFFFFF00000000ull,
     0,


### PR DESCRIPTION
PR 1498 simplifies encoding of the Initial and Retry packet headers. The code changes also include fixes for compilation warnings caused by recent PR.