### PR TITLE
Move the logging calls inside the main code.

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -417,6 +417,13 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
             send_buffer + /* pn_offset */ pn_offset, pn_length);
     }
 
+    /* if needed, log the segment */
+    if (cnx->quic->F_log != NULL) {
+        picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
+            bytes, sequence_number, length, header_length,
+            send_buffer, send_length);
+    }
+
     return send_length;
 }
 
@@ -495,7 +502,6 @@ void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet *
         cnx->pkt_ctx[packet->pc].send_sequence++;
 
         switch (packet->ptype) {
-
         case picoquic_packet_version_negotiation:
             /* Packet is not encrypted */
             break;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -616,9 +616,7 @@ static int picoquic_set_key_from_secret(picoquic_cnx_t* cnx, ptls_cipher_suite_t
 
     if (is_enc != 0) {
         ret = picoquic_set_aead_from_secret(&ctx->aead_encrypt, cipher, is_enc, secret);
-        if (ret == 0) {
-            ret = picoquic_set_aead_from_secret(&ctx->aead_de_encrypt, cipher, 0, secret);
-        }
+        
         if (ret == 0) {
             ret = picoquic_set_pn_enc_from_secret(&ctx->pn_enc, cipher, is_enc, secret);
         }
@@ -783,11 +781,6 @@ void picoquic_crypto_context_free(picoquic_crypto_context_t * ctx)
     if (ctx->aead_decrypt != NULL) {
         ptls_aead_free((ptls_aead_context_t *)ctx->aead_decrypt);
         ctx->aead_decrypt = NULL;
-    }
-
-    if (ctx->aead_de_encrypt != NULL) {
-        ptls_aead_free((ptls_aead_context_t *)ctx->aead_de_encrypt);
-        ctx->aead_de_encrypt = NULL;
     }
 
     if (ctx->pn_enc != NULL) {

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -821,7 +821,7 @@ static int draft31_incoming_initial_test()
 
         /* Parse the header and decrypt the packet */
         ret = picoquic_parse_header_and_decrypt(qserver, draft13_test_input_packet, length, length,
-            (struct sockaddr *)&test_addr_c, current_time, &ph, &cnx, &consumed, 1);
+            (struct sockaddr *)&test_addr_c, current_time, &ph, &cnx, &consumed);
 
         if (ret != 0) {
             DBG_PRINTF("Cannot parse or decrypt incoming packet, ret = %x\n", ret);

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -423,7 +423,7 @@ int test_packet_decrypt_one(
         send_buffer, send_length, packet_length,
         addr_from,
         current_time, &received_ph, &server_cnx,
-        &consumed, 1);
+        &consumed);
 
     /* verify that decryption matches original value */
     if (decoding_return != expected_return) {


### PR DESCRIPTION
These changes address issue #253, logging would not work for coalesced packets.

The previous solution was to pick the outgoing or incoming packets inside the application, decrypt them, and then display the content. The problem is that with coalesced packets, the decryption of a segment may depend on a previous coalesced segment, and thus is not available until that segment has been properly processed. Also, this requires an extra decryption of all packets.

The new solution works "inside the stack", instead of outside, and has access to the clear text. It saves on decryption cycles, removes the need for the "de_encrypt" contexts, and works with coalesced packets.

There is still work to do make logging better, such as having policies to not log each and every packet at the server. Also, the demo app still includes quite a bit of logging code. That too could be moved inside the main code. But that can wait a bit. This check-in will enable interop testing for draft-13.