### PR TITLE
Kludge max stream data parameter for draft-13 compat

### DIFF
--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -569,6 +569,12 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                 }
             }
     }
+    /* TODO: remove this horrific kludge */
+    if (cnx->remote_parameters.initial_max_stream_data_bidi_remote == 0)
+    {
+        cnx->remote_parameters.initial_max_stream_data_bidi_remote =
+            cnx->remote_parameters.initial_max_stream_data_bidi_local;
+    }
 
     /* Only the idle timeout parameters is mandatory for both client and server. */
 

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -203,7 +203,10 @@ static int transport_param_compare(picoquic_tp_t* param, picoquic_tp_t* ref) {
     if (param->initial_max_stream_data_bidi_local != ref->initial_max_stream_data_bidi_local) {
         ret = -1;
     }
-    else if (param->initial_max_stream_data_bidi_remote != ref->initial_max_stream_data_bidi_remote) {
+    else if (param->initial_max_stream_data_bidi_remote != ref->initial_max_stream_data_bidi_remote &&
+        (ref->initial_max_stream_data_bidi_remote != 0 ||
+            param->initial_max_stream_data_bidi_remote != ref->initial_max_stream_data_bidi_local)) {
+        /* TODO: remove the horrific kludge above when we align on draft 14 */
         ret = -1;
     }
     else if (param->initial_max_stream_data_uni != ref->initial_max_stream_data_uni) {


### PR DESCRIPTION
This is a fix for issue #273. The root cause is that I implemented the spec from the current editor draft, but the separation of the single max_stream_data parameter into 3 parameters will only be checked in in draft 14.