### PR TITLE
Use read tls epoch api

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,14 @@ builds, the tests are run through a command line program.
 As explained in the Wiki, Picoquic is actively tested against other implementations
 during the QUIC Interop days. See https://github.com/private-octopus/picoquic/wiki/QUIC-milestones-and-interop-testing.
 
-The implementations are progressing with the spec. The next step, with draft 09,
-brings support for TLS 1.3 draft 23, hopefully very close to final TLS 1.3 version.
+The current version is aligned with draft 13. Most big features are now tested, including
+the revised interface between QUIC and TLS, but we still have to fully develop and 
+test connection migration. At this stage we only support NAT rebinding.
 
-There are a few big features coming after that: packet number encryption, 
-NAT rebinding, connection migration, and variable length connection ID. Hopefully
-we will be able to start testing that during the next IETF meeting in March.
-
-In parallel, we plan to do an implementation
+In parallel, we still plan to do an implementation
 of DNS over QUIC (https://datatracker.ietf.org/doc/draft-huitema-quic-dnsoquic/).
 
-We are also starting to spend time bettering the implementation. Until now 
+We are spending time bettering the implementation. Until now 
 the focus has been on correctness rather than performance. We will keep correctness,
 but we will improve performance, especially in light of practical experience with 
 applications. Suggestions are wellcome.
@@ -68,8 +65,8 @@ applications. Suggestions are wellcome.
 
 Picoquic is developed in C, and can be built under Windows or Linux. Building the
 project requires first managing the dependencies, Picotls (https://github.com/h2o/picotls)
-and OpenSSL. Please note that you will need a recent version of Picotls -- the tests
-on Windows depend on commits from Aug 7, 2018.
+and OpenSSL. Please note that you will need a recent version of Picotls -- the TLS API
+depends on commits from Aug 14, 2018.
 
 ## Picoquic on Windows
 

--- a/ci/build_picotls.sh
+++ b/ci/build_picotls.sh
@@ -4,7 +4,7 @@
 # Build at a known-good commit
 # Must select a commit date (can copy-paste from git log)
 COMMIT_ID=a760bd5812441d3ef44fd34ae3c5aaab2016712d
-COMMIT_DATE="Tue Aug 7 09:01:25 2018 -0700"
+COMMIT_DATE="Tue Aug 14 10:13:45 2018 +0900"
 
 cd ..
 git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags --shallow-since="$COMMIT_DATE" https://github.com/h2o/picotls

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -483,13 +483,9 @@ typedef struct st_picoquic_cnx_t {
     void* tls_ctx;
     struct st_ptls_buffer_t* tls_sendbuf;
     uint16_t psk_cipher_suite_id;
-    int tls_stream_closed[PICOQUIC_NUMBER_OF_EPOCHS];
+
     picoquic_stream_head tls_stream[PICOQUIC_NUMBER_OF_EPOCHS]; /* Separate input/output from each epoch */
     picoquic_crypto_context_t crypto_context[PICOQUIC_NUMBER_OF_EPOCHS]; /* Encryption and decryption objects */
-#if 0
-    size_t epoch_offsets[PICOQUIC_NUMBER_OF_EPOCH_OFFSETS]; /* documents the offset for the sending side of the tls_stream */
-    size_t epoch_received[PICOQUIC_NUMBER_OF_EPOCH_OFFSETS]; /* documents the offset for the sending side of the tls_stream */
-#endif
 
     /* Liveness detection */
     uint64_t latest_progress_time; /* last local time at which the connection progressed */

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -101,7 +101,7 @@ void debug_printf(const char* fmt, ...)
     }
 }
 
-void debug_dump(void * x, int len)
+void debug_dump(const void * x, int len)
 {
     if (debug_suspended == 0) {
         FILE * F = debug_out ? debug_out : stderr;

--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -43,7 +43,7 @@ void debug_printf_push_stream(FILE* f);
 void debug_printf_pop_stream(void);
 void debug_printf_suspend(void);
 void debug_printf_resume(void);
-void debug_dump(void * x, int len);
+void debug_dump(const void * x, int len);
 
 extern const picoquic_connection_id_t picoquic_null_connection_id;
 uint32_t picoquic_format_connection_id(uint8_t* bytes, size_t bytes_max, picoquic_connection_id_t cnx_id);


### PR DESCRIPTION
This replaces the "epoch closed" heuristic by a much cleaner call to the new "ptls_get_read-epoch" API provided by Picoquic, but requires using the a version of TLS after 8/14/2018.