### PR TITLE
Fuzz test

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -604,5 +604,12 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+
+        TEST_METHOD(fuzz)
+        {
+            int ret = fuzz_test();
+
+            Assert::AreEqual(ret, 0);
+        }
     };
 }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -180,8 +180,10 @@ int picoquic_parse_packet_header(
                             ph->ptype = picoquic_packet_error;
                         }
                     } else {
-                        var_length = (uint32_t)picoquic_varint_decode(bytes + ph->offset,
-                            length - ph->offset, &payload_length);
+                        if (ph->offset < length) {
+                            var_length = (uint32_t)picoquic_varint_decode(bytes + ph->offset,
+                                length - ph->offset, &payload_length);
+                        }
 
                         if (var_length <= 0 || ph->offset + var_length + pn_length_clear + payload_length > length ||
                             ph->version_index < 0) {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -199,6 +199,9 @@ typedef struct _picoquic_packet {
     uint32_t offset;
     picoquic_packet_type_enum ptype;
     picoquic_packet_context_enum pc;
+    unsigned int is_evaluated : 1;
+    unsigned int is_pure_ack : 1;
+    unsigned int contains_crypto : 1;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquic_packet;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -272,6 +272,13 @@ typedef void (*picoquic_stream_data_cb_fn)(picoquic_cnx_t* cnx,
 typedef void (*cnx_id_cb_fn)(picoquic_connection_id_t cnx_id_local,
     picoquic_connection_id_t cnx_id_remote, void* cnx_id_cb_data, picoquic_connection_id_t * cnx_id_returned);
 
+/* The fuzzer function is used to inject error in packets randomly.
+ * It is called just prior to sending a packet, and can randomly
+ * change the content or length of the packet.
+ */
+typedef uint32_t(*picoquic_fuzz_fn)(void * fuzz_ctx, picoquic_cnx_t* cnx, uint8_t * bytes, size_t bytes_max, size_t length);
+void picoquic_set_fuzz(picoquic_quic_t* quic, picoquic_fuzz_fn fuzz_fn, void * fuzz_ctx);
+
 /* Will be called to verify that the given data corresponds to the given signature.
  * This callback and the `verify_ctx` will be set by the `verify_certificate_cb_fn`.
  * If `data` and `sign` are empty buffers, an error occurred and `verify_ctx` should be freed.

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -211,6 +211,9 @@ typedef struct st_picoquic_quic_t {
     picoquic_free_verify_certificate_ctx free_verify_certificate_callback_fn;
     void* verify_certificate_ctx;
     uint8_t local_ctx_length;
+
+    picoquic_fuzz_fn fuzz_fn;
+    void* fuzz_ctx;
 } picoquic_quic_t;
 
 picoquic_packet_context_enum picoquic_context_from_epoch(int epoch);
@@ -679,13 +682,13 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     picoquic_packet_type_enum ptype,
     uint8_t * bytes, uint64_t sequence_number,
     uint32_t length, uint32_t header_length,
-    uint8_t* send_buffer,
+    uint8_t* send_buffer, uint32_t send_buffer_max,
     void * aead_context, void* pn_enc);
 
 void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet * packet, int ret,
     uint32_t length, uint32_t header_length, uint32_t checksum_overhead,
-    size_t * send_length, uint8_t * send_buffer, picoquic_path_t * path_x,
-    uint64_t current_time);
+    size_t * send_length, uint8_t * send_buffer, uint32_t send_buffer_max,
+    picoquic_path_t * path_x, uint64_t current_time);
 
 int picoquic_parse_header_and_decrypt(
     picoquic_quic_t* quic,

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1057,6 +1057,12 @@ uint64_t picoquic_get_quic_time(picoquic_quic_t* quic)
     return now;
 }
 
+void picoquic_set_fuzz(picoquic_quic_t * quic, picoquic_fuzz_fn fuzz_fn, void * fuzz_ctx)
+{
+    quic->fuzz_fn = fuzz_fn;
+    quic->fuzz_ctx = fuzz_ctx;
+}
+
 
 
 void picoquic_set_callback(picoquic_cnx_t* cnx,

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -503,7 +503,7 @@ int test_packet_encrypt_one(
         /* Create a packet with specified parameters */
         picoquic_finalize_and_protect_packet(cnx_client, packet,
             ret, length, header_length, checksum_overhead,
-            &send_length, send_buffer, path_x, current_time);
+            &send_length, send_buffer, PICOQUIC_MAX_PACKET_SIZE, path_x, current_time);
 
         expected_header.ptype = packet->ptype;
         expected_header.offset = packet->offset;

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -119,6 +119,7 @@ int stress_test();
 int splay_test();
 int TlsStreamFrameTest();
 int draft13_vector_test();
+int fuzz_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -861,11 +861,12 @@ static void stress_delete_client_context(int client_index, picoquic_stress_ctx_t
     }
 }
 
-int stress_test()
+static int stress_or_fuzz_test(picoquic_fuzz_fn fuzz_fn, void * fuzz_ctx)
 {
     int ret = 0;
     picoquic_stress_ctx_t stress_ctx;
     double run_time_seconds = 0;
+    double target_seconds = 0;
     double wall_time_seconds = 0;
     uint64_t wall_time_start = picoquic_current_time();
     uint64_t wall_time_max = wall_time_start + picoquic_stress_test_duration;
@@ -895,6 +896,9 @@ int stress_test()
         else {
             for (int i = 0; ret == 0 && i < stress_ctx.nb_clients; i++) {
                 ret = stress_create_client_context(i, &stress_ctx);
+                if (ret == 0 && fuzz_fn != NULL) {
+                    picoquic_set_fuzz(stress_ctx.c_ctx[i]->qclient, fuzz_fn, fuzz_ctx);
+                }
             }
         }
     }
@@ -946,9 +950,81 @@ int stress_test()
 
     /* Report */
     run_time_seconds = ((double)stress_ctx.simulated_time) / 1000000.0;
+    target_seconds = ((double)picoquic_stress_test_duration) / 1000000.0;
     wall_time_seconds = ((double)(picoquic_current_time() - wall_time_start)) / 1000000.0;
-    DBG_PRINTF("Stress complete after simulating %3f s. in %3f s., returns %d\n",
-        run_time_seconds, wall_time_seconds, ret);
+
+    if (stress_ctx.simulated_time < picoquic_stress_test_duration) {
+        DBG_PRINTF("Stress incomplete after simulating %3fs instead of %3fs in %3f s., returns %d\n",
+            run_time_seconds, target_seconds, wall_time_seconds, ret);
+        ret = -1;
+    }
+    else {
+        DBG_PRINTF("Stress complete after simulating %3f s. in %3f s., returns %d\n",
+            run_time_seconds, wall_time_seconds, ret);
+    }
+
+    return ret;
+}
+
+int stress_test()
+{
+    return stress_or_fuzz_test(NULL, NULL);
+}
+
+/*
+ * Basic fuzz test just tries to flip some bits in random packets
+ */
+
+typedef struct st_basic_fuzzer_ctx_t {
+    uint64_t random_context;
+    picoquic_state_enum highest_state_fuzzed;
+} basic_fuzzer_ctx_t;
+
+static uint32_t basic_fuzzer(void * fuzz_ctx, picoquic_cnx_t* cnx, uint8_t * bytes, size_t bytes_max, size_t length)
+{
+    basic_fuzzer_ctx_t * ctx = (basic_fuzzer_ctx_t *)fuzz_ctx;
+    uint64_t fuzz_pilot = picoquic_test_random(&ctx->random_context);
+    int should_fuzz = 0;
+    uint32_t fuzz_index = 0;
+
+    if (cnx->cnx_state > ctx->highest_state_fuzzed) {
+        should_fuzz = 1;
+        ctx->highest_state_fuzzed = cnx->cnx_state;
+    } else {
+        /* if already fuzzed this state, fuzz one packet in 16 */
+        should_fuzz = ((fuzz_pilot & 0xF) == 0xD);
+        fuzz_pilot >>= 4;
+    }
+
+    if (should_fuzz) {
+        /* Once in 64, fuzz by changing the length */
+        if (bytes_max > length + 16  && (fuzz_pilot & 0x3F) == 0x2B) {
+            fuzz_pilot >>= 6;
+            length = 16 + (uint32_t)((fuzz_pilot&0xFFFF) % length);
+            fuzz_pilot >>= 16;
+        }
+        /* Find the position that shall be fuzzed */
+        fuzz_index = (uint32_t)((fuzz_pilot & 0xFFFF) % length);
+        fuzz_pilot >>= 16;
+        while (fuzz_pilot != 0 && fuzz_index < length) {
+            /* flip one byte */
+            bytes[fuzz_index++] = (uint8_t)(fuzz_pilot & 0xFF);
+            fuzz_pilot >>= 8;
+        }
+    }
+
+    return length;
+}
+
+int fuzz_test()
+{
+    basic_fuzzer_ctx_t fuzz_ctx;
+    int ret = 0;
+
+    fuzz_ctx.highest_state_fuzzed = 0;
+    fuzz_ctx.random_context = 0xDEADBEEFBABACAFEull;
+
+    ret = stress_or_fuzz_test(basic_fuzzer, &fuzz_ctx);
 
     return ret;
 }


### PR DESCRIPTION
Add an API to the QUIC context for programming a "fuzz" callback, that fill be called just before a packet is encrypted and sent. This allows testing arbitrary fuzzing logics.
Create a "fuzz" variant of the stress test that uses a basic fuzzer. Make it accessible through the normal test program, e.g. "picoquic_ct -f 5" to run the test on 5 simulated minutes.
Fix bugs discovered when running the fuzz test for 5 minutes, including three hot loops conditions and one crash.