### PR TITLE
Hunt leaks

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1516,6 +1516,9 @@ uint8_t* picoquic_decode_ack_frame_maybe_ecn(picoquic_cnx_t* cnx, uint8_t* bytes
         cnx->remote_parameters.ack_delay_exponent) != 0) {
         bytes = NULL;
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, first_byte);
+    } else if (largest >= cnx->pkt_ctx[pc].send_sequence) {
+        bytes = NULL;
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION, first_byte);
     } else {
         bytes += consumed;
 

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -102,7 +102,7 @@ int picoquic_parse_packet_header(
                 }
                 else {
                     char context_by_addr = 0;
-                    uint64_t payload_length;
+                    uint64_t payload_length = 0;
                     uint64_t pn_length_clear = 0;  
                     uint32_t var_length = 0; 
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -188,9 +188,9 @@ typedef enum {
  * The checksum length is the difference between encrypted and unencrypted.
  */
 
-typedef struct _picoquic_packet {
-    struct _picoquic_packet* previous_packet;
-    struct _picoquic_packet* next_packet;
+typedef struct st_picoquic_packet_t {
+    struct st_picoquic_packet_t* previous_packet;
+    struct st_picoquic_packet_t* next_packet;
     struct st_picoquic_path_t * send_path;
     uint64_t sequence_number;
     uint64_t send_time;
@@ -204,7 +204,7 @@ typedef struct _picoquic_packet {
     unsigned int contains_crypto : 1;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
-} picoquic_packet;
+} picoquic_packet_t;
 
 typedef struct st_picoquic_quic_t picoquic_quic_t;
 typedef struct st_picoquic_cnx_t picoquic_cnx_t;
@@ -408,7 +408,7 @@ int picoquic_incoming_packet(
     int if_index_to,
     uint64_t current_time);
 
-picoquic_packet* picoquic_create_packet();
+picoquic_packet_t* picoquic_create_packet();
 
 int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -472,6 +472,16 @@ int picoquic_get_local_error(picoquic_cnx_t* cnx);
 /* Returns the remote error of the given connection context. */
 int picoquic_get_remote_error(picoquic_cnx_t* cnx);
 
+/*
+ * The OpenSSL resources are allocated on first use, and not released until the end of the
+ * process.The only problem is when use memory leak tracers such as valgrind.The OpenSSL
+ * allocations will create a large number of issues, which may hide the actual leaks that
+ * should be fixed.To alleviate that, the application may use the global SSL destructor
+ * just prior to exiting.However, once the destructor is called, trying to reinitialize
+ * OpenSSL will likely cause the program to crash.
+ */
+void picoquic_openssl_final_destructor();
+
 #ifdef __cplusplus
 }
 #endif

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -472,16 +472,6 @@ int picoquic_get_local_error(picoquic_cnx_t* cnx);
 /* Returns the remote error of the given connection context. */
 int picoquic_get_remote_error(picoquic_cnx_t* cnx);
 
-/*
- * The OpenSSL resources are allocated on first use, and not released until the end of the
- * process.The only problem is when use memory leak tracers such as valgrind.The OpenSSL
- * allocations will create a large number of issues, which may hide the actual leaks that
- * should be fixed.To alleviate that, the application may use the global SSL destructor
- * just prior to exiting.However, once the destructor is called, trying to reinitialize
- * OpenSSL will likely cause the program to crash.
- */
-void picoquic_openssl_final_destructor();
-
 #ifdef __cplusplus
 }
 #endif

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -413,10 +413,10 @@ typedef struct st_picoquic_packet_context_t {
     uint64_t latest_retransmit_time;
     uint64_t highest_acknowledged;
     uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
-    picoquic_packet* retransmit_newest;
-    picoquic_packet* retransmit_oldest;
-    picoquic_packet* retransmitted_newest;
-    picoquic_packet* retransmitted_oldest;
+    picoquic_packet_t* retransmit_newest;
+    picoquic_packet_t* retransmit_oldest;
+    picoquic_packet_t* retransmitted_newest;
+    picoquic_packet_t* retransmitted_oldest;
 
     unsigned int ack_needed : 1;
 } picoquic_packet_context_t;
@@ -552,8 +552,8 @@ void picoquic_queue_stateless_packet(picoquic_quic_t* quic, picoquic_stateless_p
 int picoquic_register_cnx_id(picoquic_quic_t* quic, picoquic_cnx_t* cnx, picoquic_connection_id_t cnx_id);
 
 /* handling of retransmission queue */
-void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free);
-void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet* p);
+void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p, int should_free);
+void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p);
 
 /* Reset connection after receiving version negotiation */
 int picoquic_reset_cnx_version(picoquic_cnx_t* cnx, uint8_t* bytes, size_t length, uint64_t current_time);
@@ -685,7 +685,7 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     uint8_t* send_buffer, uint32_t send_buffer_max,
     void * aead_context, void* pn_enc);
 
-void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet * packet, int ret,
+void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret,
     uint32_t length, uint32_t header_length, uint32_t checksum_overhead,
     size_t * send_length, uint8_t * send_buffer, uint32_t send_buffer_max,
     picoquic_path_t * path_x, uint64_t current_time);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -552,8 +552,8 @@ void picoquic_queue_stateless_packet(picoquic_quic_t* quic, picoquic_stateless_p
 int picoquic_register_cnx_id(picoquic_quic_t* quic, picoquic_cnx_t* cnx, picoquic_connection_id_t cnx_id);
 
 /* handling of retransmission queue */
-void picoquic_enqueue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p);
 void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free);
+void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet* p);
 
 /* Reset connection after receiving version negotiation */
 int picoquic_reset_cnx_version(picoquic_cnx_t* cnx, uint8_t* bytes, size_t length, uint64_t current_time);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1284,6 +1284,14 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
     picoquic_misc_frame_header_t* misc_frame;
 
     if (cnx != NULL) {
+        if (cnx->cnx_state < picoquic_state_disconnected) {
+            /* Give the application a chance to clean up its state */
+            cnx->cnx_state = picoquic_state_disconnected;
+            if (cnx->callback_fn) {
+                (cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+            }
+        }
+
         if (cnx->alpn != NULL) {
             free((void*)cnx->alpn);
             cnx->alpn = NULL;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1128,68 +1128,6 @@ void picoquic_clear_stream(picoquic_stream_head* stream)
     }
 }
 
-void picoquic_enqueue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p)
-{
-    picoquic_packet_context_enum pc = p->pc;
-    if (cnx->pkt_ctx[pc].retransmit_oldest == NULL) {
-        p->previous_packet = NULL;
-        cnx->pkt_ctx[pc].retransmit_newest = p;
-    } else {
-        cnx->pkt_ctx[pc].retransmit_oldest->next_packet = p;
-        p->previous_packet = cnx->pkt_ctx[pc].retransmit_oldest;
-    }
-    p->next_packet = NULL;
-    cnx->pkt_ctx[pc].retransmit_oldest = p;
-
-    /* Account for bytes in transit, for congestion control */
-    cnx->path[0]->bytes_in_transit += p->length;
-}
-
-void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free)
-{
-    size_t dequeued_length = p->length + p->checksum_overhead;
-    picoquic_packet_context_enum pc = p->pc;
-
-    if (p->previous_packet == NULL) {
-        cnx->pkt_ctx[pc].retransmit_newest = p->next_packet;
-    }
-    else {
-        p->previous_packet->next_packet = p->next_packet;
-    }
-
-    if (p->next_packet == NULL) {
-        cnx->pkt_ctx[pc].retransmit_oldest = p->previous_packet;
-    }
-    else {
-        p->next_packet->previous_packet = p->previous_packet;
-    }
-
-    /* Account for bytes in transit, for congestion control */
-
-    if (p->send_path->bytes_in_transit > dequeued_length) {
-        p->send_path->bytes_in_transit -= dequeued_length;
-    }
-    else {
-        p->send_path->bytes_in_transit = 0;
-    }
-        
-    if (should_free) {
-        free(p);
-    } else {
-        p->next_packet = NULL;
-
-        /* add this packet to the retransmitted list */
-        if (cnx->pkt_ctx[pc].retransmitted_oldest == NULL) {
-            cnx->pkt_ctx[pc].retransmitted_newest = p;
-            p->previous_packet = NULL;
-        } else {
-            cnx->pkt_ctx[pc].retransmitted_oldest->next_packet = p;
-            p->previous_packet = cnx->pkt_ctx[pc].retransmitted_oldest;
-            cnx->pkt_ctx[pc].retransmitted_oldest = p;
-        }
-    }
-}
-
 void picoquic_reset_packet_context(picoquic_cnx_t* cnx,
     picoquic_packet_context_enum pc)
 {
@@ -1201,25 +1139,16 @@ void picoquic_reset_packet_context(picoquic_cnx_t* cnx,
     }
     
     while (pkt_ctx->retransmitted_newest != NULL) {
-        picoquic_packet* p = pkt_ctx->retransmitted_newest;
-        pkt_ctx->retransmitted_newest = p->next_packet;
-        free(p);
+        picoquic_dequeue_retransmitted_packet(cnx, pkt_ctx->retransmitted_newest);
     }
 
     pkt_ctx->retransmitted_oldest = NULL;
 
-#if 1
-    /* BUG #225: this crashes in some tests not related to this PR. */
-    /* Reset the sack lists*/
     while (pkt_ctx->first_sack_item.next_sack != NULL) {
         picoquic_sack_item_t * next = pkt_ctx->first_sack_item.next_sack;
         pkt_ctx->first_sack_item.next_sack = next->next_sack;
         free(next);
     }
-#else
-    /* BUG: see above */
-    pkt_ctx->first_sack_item.next_sack = NULL;
-#endif
 
     pkt_ctx->first_sack_item.start_of_sack_range = (uint64_t)((int64_t)-1);
     pkt_ctx->first_sack_item.end_of_sack_range = 0;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -177,12 +177,12 @@ int picoquic_stop_sending(picoquic_cnx_t* cnx,
  * Packet management
  */
 
-picoquic_packet* picoquic_create_packet()
+picoquic_packet_t* picoquic_create_packet()
 {
-    picoquic_packet* packet = (picoquic_packet*)malloc(sizeof(picoquic_packet));
+    picoquic_packet_t* packet = (picoquic_packet_t*)malloc(sizeof(picoquic_packet_t));
 
     if (packet != NULL) {
-        memset(packet, 0, sizeof(picoquic_packet));
+        memset(packet, 0, sizeof(picoquic_packet_t));
     }
 
     return packet;
@@ -484,7 +484,7 @@ void picoquic_update_pacing_after_send(picoquic_path_t * send_path, uint64_t cur
  * Final steps in packet transmission: queue for retransmission, etc
  */
 
-void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     size_t length, uint64_t current_time)
 {
     picoquic_packet_context_enum pc = packet->pc;
@@ -507,7 +507,7 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x
     picoquic_update_pacing_after_send(path_x, current_time);
 }
 
-void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p, int should_free)
+void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p, int should_free)
 {
     size_t dequeued_length = p->length + p->checksum_overhead;
     picoquic_packet_context_enum pc = p->pc;
@@ -553,6 +553,7 @@ void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p,
         /* add this packet to the retransmitted list */
         if (cnx->pkt_ctx[pc].retransmitted_oldest == NULL) {
             cnx->pkt_ctx[pc].retransmitted_newest = p;
+            cnx->pkt_ctx[pc].retransmitted_oldest = p;
             p->previous_packet = NULL;
         }
         else {
@@ -563,12 +564,19 @@ void picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet* p,
     }
 }
 
-void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet* p)
+void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p)
 {
     picoquic_packet_context_enum pc = p->pc;
 
     if (p->previous_packet == NULL) {
         cnx->pkt_ctx[pc].retransmitted_newest = p->next_packet;
+    }
+    else {
+        p->previous_packet->next_packet = p->next_packet;
+    }
+
+    if (p->next_packet == NULL) {
+        cnx->pkt_ctx[pc].retransmitted_oldest = p->previous_packet;
     }
     else {
 #ifdef _DEBUG
@@ -580,13 +588,6 @@ void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet*
             DBG_PRINTF("Inconsistent chain of packets, pc = %d\n", pc);
         }
 #endif
-        p->previous_packet->next_packet = p->next_packet;
-    }
-
-    if (p->next_packet == NULL) {
-        cnx->pkt_ctx[pc].retransmitted_oldest = p->previous_packet;
-    }
-    else {
         p->next_packet->previous_packet = p->previous_packet;
     }
 
@@ -598,7 +599,7 @@ void picoquic_dequeue_retransmitted_packet(picoquic_cnx_t* cnx, picoquic_packet*
  * Final steps of encoding and protecting the packet before sending
  */
 
-void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet * packet, int ret, 
+void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret, 
     uint32_t length, uint32_t header_length, uint32_t checksum_overhead,
     size_t * send_length, uint8_t * send_buffer, uint32_t send_buffer_max, 
     picoquic_path_t * path_x, uint64_t current_time)
@@ -671,7 +672,7 @@ void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet *
  */
 
 static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
-    picoquic_packet* p, uint64_t current_time, int* timer_based)
+    picoquic_packet_t* p, uint64_t current_time, int* timer_based)
 {
     picoquic_packet_context_enum pc = p->pc;
     int64_t delta_seq = cnx->pkt_ctx[pc].highest_acknowledged - p->sequence_number;
@@ -726,9 +727,9 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
 int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
     picoquic_packet_context_enum pc,
     picoquic_path_t * path_x, uint64_t current_time,
-    picoquic_packet* packet, size_t send_buffer_max, int* is_cleartext_mode, uint32_t* header_length)
+    picoquic_packet_t* packet, size_t send_buffer_max, int* is_cleartext_mode, uint32_t* header_length)
 {
-    picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+    picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
     uint32_t length = 0;
 
     /* TODO: while packets are pure ACK, drop them from retransmit queue */
@@ -736,7 +737,7 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
         int should_retransmit = 0;
         int timer_based_retransmit = 0;
         uint64_t lost_packet_number = p->sequence_number;
-        picoquic_packet* p_next = p->next_packet;
+        picoquic_packet_t* p_next = p->next_packet;
         uint8_t * new_bytes = packet->bytes;
         int ret = 0;
 
@@ -943,7 +944,7 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx)
     for (picoquic_packet_context_enum pc = 0;
         backlog_empty == 1 && pc < picoquic_nb_packet_context; pc++)
     {
-        picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+        picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
 
         while (p != NULL && backlog_empty == 1) {
             /* check if this is an ACK only packet */
@@ -1068,7 +1069,7 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
     {
 
         for (picoquic_packet_context_enum pc = 0; blocked == 0 && pc < picoquic_nb_packet_context; pc++) {
-            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+            picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
 
             if ((pc_ready_flag & (1 << pc)) == 0) {
                 continue;
@@ -1117,7 +1118,7 @@ static void picoquic_cnx_set_next_wake_time_init(picoquic_cnx_t* cnx, uint64_t c
         }
         else {
             for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
-                picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+                picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
 
                 if ((pc_ready_flag & (1 << pc)) == 0) {
                     continue;
@@ -1192,7 +1193,7 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
     }
     else {
         for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
-            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+            picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
 
             if (p != NULL && ret == 0 && picoquic_retransmit_needed_by_packet(cnx, p, current_time, /* &ph,*/ &timer_based)) {
                 blocked = 0;
@@ -1225,7 +1226,7 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
         next_time = path_x->next_pacing_time;
     } else {
         for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
-            picoquic_packet* p = cnx->pkt_ctx[pc].retransmit_oldest;
+            picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
             /* Consider delayed ACK */
             if (cnx->pkt_ctx[pc].ack_needed) {
                 uint64_t ack_time = cnx->pkt_ctx[pc].highest_ack_time + cnx->pkt_ctx[pc].ack_delay_local;
@@ -1279,7 +1280,7 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
 /* Prepare the next packet to 0-RTT packet to send in the client initial
  * state, when 0-RTT is available
  */
-int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -1383,7 +1384,7 @@ picoquic_packet_type_enum picoquic_packet_type_from_epoch(int epoch)
 
 /* Prepare a required repetition or ack  in a previous context */
 uint32_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
-    picoquic_path_t * path_x, picoquic_packet* packet, size_t send_buffer_max, uint64_t current_time, uint32_t * header_length)
+    picoquic_path_t * path_x, picoquic_packet_t* packet, size_t send_buffer_max, uint64_t current_time, uint32_t * header_length)
 {
     int is_cleartext_mode = (pc == picoquic_packet_context_initial) ? 1 : 0;
     uint32_t length = 0;
@@ -1431,7 +1432,7 @@ uint32_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packe
 }
 
 /* Prepare the next packet to send when in one of the client initial states */
-int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -1649,7 +1650,7 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
 }
 
 /* Prepare the next packet to send when in one the server initial states */
-int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -1803,7 +1804,7 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
 }
 
 /* Prepare the next packet to send when in one the closing states */
-int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -2013,7 +2014,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
 }
 
 /*  Prepare the next packet to send when in one the ready states */
-int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -2249,7 +2250,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x,
 }
 
 /* Prepare next packet to send, or nothing.. */
-int picoquic_prepare_segment(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet* packet,
+int picoquic_prepare_segment(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length)
 {
     int ret = 0;
@@ -2319,7 +2320,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
 {
     int ret = 0;
     picoquic_path_t * path_x = cnx->path[0];
-    picoquic_packet * packet = NULL;
+    picoquic_packet_t * packet = NULL;
 
     *send_length = 0;
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -99,6 +99,10 @@ static void picoquic_release_openssl()
     if (openssl_is_init > 0) {
         openssl_is_init--;
         if (openssl_is_init == 0) {
+#if !defined(OPENSSL_NO_ENGINE)
+            /* Release all compiled-in ENGINEs */
+            ENGINE_cleanup();
+#endif
             EVP_cleanup();
         }
     }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -333,8 +333,6 @@ int main(int argc, char** argv)
         }
 
         free(test_status);
-
-        picoquic_openssl_final_destructor();
     }
     return (ret);
 }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -333,6 +333,8 @@ int main(int argc, char** argv)
         }
 
         free(test_status);
+
+        picoquic_openssl_final_destructor();
     }
     return (ret);
 }

--- a/picoquictest/cnx_creation_test.c
+++ b/picoquictest/cnx_creation_test.c
@@ -197,7 +197,7 @@ int cnxcreation_test()
     }
 
     /* delete QUIC context. */
-    if (ret == 0) {
+    if (quic != NULL) {
         picoquic_free(quic);
     }
 

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -483,7 +483,7 @@ int test_packet_encrypt_one(
     picoquic_path_t * path_x = cnx_client->path[0];
     uint64_t current_time = 0;
     picoquic_packet_header expected_header;
-    picoquic_packet * packet = (picoquic_packet *) malloc(sizeof(picoquic_packet));
+    picoquic_packet_t * packet = (picoquic_packet_t *) malloc(sizeof(picoquic_packet_t));
     picoquic_packet_context_enum pc = 0;
 
     if (packet == NULL) {
@@ -491,7 +491,7 @@ int test_packet_encrypt_one(
         ret = -1;
     }
     else {
-        memset(packet, 0, sizeof(picoquic_packet));
+        memset(packet, 0, sizeof(picoquic_packet_t));
         memset(packet->bytes, 0xbb, length);
         header_length = picoquic_predict_packet_header_length(cnx_client, ptype);
         packet->ptype = ptype;

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -399,6 +399,8 @@ int parse_frame_test()
 
                 pc = picoquic_context_from_epoch(test_skip_list[i].epoch);
 
+                cnx->pkt_ctx[0].send_sequence = 0x0102030406;
+
                 t_ret = picoquic_decode_frames(cnx, buffer, byte_max, test_skip_list[i].epoch, simulated_time);
 
                 if (t_ret != 0) {


### PR DESCRIPTION
Debugged the memory leaks experienced in the stress and fuzz tests. There were two big packet leaks, and then a couple of small leaks tied to context management. There is still a residual leak, but we went from leaking 2.8MB in a stress session to leaking 140KB.

There are two causes for the residual leak. One is the initialization of OpenSSL global variables. I tried fixing using procedures like "OpenSSL_cleanup", using ref-counting to do it once for many QUIC contexts. But something is broken, because if one tries to re-open OpenSSL again in the same process, there is a crash.

The other cause is the management of the "verify certificate" call back. The current code is a bit messy, as the knowledge of the Picotls function based on OpenSSL has polluted the common path. It need sto be rewritten, but that is another PR.