### PR TITLE
Random tester

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - cmake .
   - make
   - ulimit -c unlimited -S
-  - ./picoquic_ct -x fuzz && RESULT=$?
+  - ./picoquic_ct -n && RESULT=$?
   # Early out if the program exited successfully
   - if [[ ${RESULT} == 0 ]]; then exit 0; fi;
   - for i in $(find ./ -maxdepth 1 -name 'core*' -print); do gdb $(pwd)/picoquic_ct core* -ex "thread apply all bt" -ex "set pagination 0" -batch; done;

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -37,6 +37,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
 	    }
 
+        TEST_METHOD(random_tester)
+        {
+            int ret = random_tester_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(splay)
         {
             int ret = splay_test();

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -446,10 +446,10 @@ size_t picoquic_log_stream_frame(FILE* F, uint8_t* bytes, size_t bytes_max)
     int fin;
     int ret = 0;
 
-    debug_printf_suspend();
+    int suspended = debug_printf_reset(1);
     ret = picoquic_parse_stream_header(bytes, bytes_max,
         &stream_id, &offset, &data_length, &fin, &byte_index);
-    debug_printf_resume();
+    (void)debug_printf_reset(suspended);
 
     if (ret != 0)
         return bytes_max;
@@ -474,12 +474,12 @@ size_t picoquic_log_ack_frame(FILE* F, uint64_t cnx_id64, uint8_t* bytes, size_t
     uint64_t ack_delay;
     uint64_t ecnx3[3];
 
-    debug_printf_suspend();
+    int suspended = debug_printf_reset(1);
 
     int ret = picoquic_parse_ack_header(bytes, bytes_max, &num_block, (is_ecn)? ecnx3:NULL,
         &largest, &ack_delay, &byte_index, 0);
 
-    debug_printf_resume();
+    (void)debug_printf_reset(suspended);
 
     if (ret != 0)
         return bytes_max;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1344,7 +1344,7 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, 
 
     picoquic_finalize_and_protect_packet(cnx, packet,
         ret, length, header_length, checksum_overhead,
-        send_length, send_buffer, send_buffer_max, path_x, current_time);
+        send_length, send_buffer, (uint32_t)send_buffer_max, path_x, current_time);
 
     if (length > 0) {
         /* Accounting of zero rtt packets sent */
@@ -1640,7 +1640,7 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
     } else {
         picoquic_finalize_and_protect_packet(cnx, packet,
             ret, length, header_length, checksum_overhead,
-            send_length, send_buffer, send_buffer_max, path_x, current_time);
+            send_length, send_buffer, (uint32_t)send_buffer_max, path_x, current_time);
 
         if (cnx->cnx_state != picoquic_state_draining) {
             picoquic_cnx_set_next_wake_time(cnx, current_time);
@@ -1797,7 +1797,7 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
 
     picoquic_finalize_and_protect_packet(cnx, packet,
         ret, length, header_length, checksum_overhead,
-        send_length, send_buffer, send_buffer_max, path_x, current_time);
+        send_length, send_buffer, (uint32_t)send_buffer_max, path_x, current_time);
 
     picoquic_cnx_set_next_wake_time(cnx, current_time);
 
@@ -2009,7 +2009,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
 
     picoquic_finalize_and_protect_packet(cnx, packet,
         ret, length, header_length, checksum_overhead,
-        send_length, send_buffer, send_buffer_max, path_x, current_time);
+        send_length, send_buffer, (uint32_t)send_buffer_max, path_x, current_time);
 
     return ret;
 }

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -202,6 +202,7 @@ uint64_t picoquic_crypto_uniform_random(picoquic_quic_t* quic, uint64_t rnd_max)
 
 static uint64_t public_random_seed[16] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
 static int public_random_index = 0;
+static const uint64_t public_random_multiplier = 1181783497276652981ull;
 
 uint64_t picoquic_public_random_64(void)
 {
@@ -211,7 +212,7 @@ uint64_t picoquic_public_random_64(void)
     s1 ^= s1 >> 11; // b
     s1 ^= s0 ^ (s0 >> 30); // c
     public_random_seed[public_random_index] = s1;
-    return s1 * (uint64_t)1181783497276652981;
+    return s1 * public_random_multiplier;
 }
 
 void picoquic_public_random_seed(picoquic_quic_t* quic)

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -146,6 +146,13 @@ void debug_printf_resume(void)
     debug_suspended = 0;
 }
 
+int debug_printf_reset(int suspended)
+{
+    int ret = debug_suspended;
+    debug_suspended = suspended;
+    return ret;
+}
+
 uint8_t picoquic_create_packet_header_cnxid_lengths(uint8_t dest_len, uint8_t srce_len)
 {
     uint8_t ret;

--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -43,6 +43,7 @@ void debug_printf_push_stream(FILE* f);
 void debug_printf_pop_stream(void);
 void debug_printf_suspend(void);
 void debug_printf_resume(void);
+int debug_printf_reset(int suspended);
 void debug_dump(const void * x, int len);
 
 extern const picoquic_connection_id_t picoquic_null_connection_id;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -177,6 +177,7 @@ int usage(char const * argv0)
     fprintf(stderr, "  -x test        Do not run the specified test.\n");
     fprintf(stderr, "  -s nnn         Run stress for nnn minutes.\n");
     fprintf(stderr, "  -f nnn         Run fuzz for nnn minutes.\n");
+    fprintf(stderr, "  -n             Disable debug prints.\n");
     fprintf(stderr, "  -h             Print this help message\n");
 
     return -1;
@@ -206,6 +207,7 @@ int main(int argc, char** argv)
     int opt;
     int do_fuzz = 0;
     int do_stress = 0;
+    int disable_debug = 0;
 
     if (test_status == NULL)
     {
@@ -214,7 +216,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        while (ret == 0 && (opt = getopt(argc, argv, "f:s:x:h")) != -1) {
+        while (ret == 0 && (opt = getopt(argc, argv, "f:s:x:nh")) != -1) {
             switch (opt) {
             case 'x': {
                 int test_number = get_test_number(optarg);
@@ -245,6 +247,9 @@ int main(int argc, char** argv)
                     ret = usage(argv[0]);
                 }
                 break;
+            case 'n':
+                disable_debug = 1;
+                break;
             case 'h':
                 usage(argv[0]);
                 exit(0);
@@ -253,6 +258,10 @@ int main(int argc, char** argv)
                 ret = usage(argv[0]);
                 break;
             }
+        }
+
+        if (disable_debug) {
+            debug_printf_suspend();
         }
 
         if (ret == 0 && stress_minutes > 0) {

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -126,6 +126,7 @@ static const picoquic_test_def_t test_table[] = {
     { "pn_vector", cleartext_pn_vector_test },
     { "zero_rtt_spurious", zero_rtt_spurious_test },
     { "zero_rtt_retry", zero_rtt_retry_test },
+    { "random_tester", random_tester_test},
     { "stress", stress_test },
     { "fuzz", fuzz_test }
 };

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -120,6 +120,7 @@ int splay_test();
 int TlsStreamFrameTest();
 int draft13_vector_test();
 int fuzz_test();
+int random_tester_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -335,7 +335,7 @@ int skip_frame_test()
             DBG_PRINTF("Skip packet <%d> fails, ret = %d\n", i, ret);
         } else {
             /* do the actual fuzz test */
-            debug_printf_suspend();
+            int suspended = debug_printf_reset(1);
             for (size_t j = 0; j < 100; j++) {
                 skip_test_fuzz_packet(fuzz_buffer, buffer, bytes_max, &random_context);
                 if (skip_test_packet(fuzz_buffer, bytes_max) != 0) {
@@ -343,7 +343,7 @@ int skip_frame_test()
                 }
                 fuzz_count++;
             }
-            debug_printf_resume();
+            (void)debug_printf_reset(suspended);
         }
     }
 

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -223,7 +223,7 @@ uint64_t picoquic_test_uniform_random(uint64_t * random_context, uint64_t rnd_ma
     uint64_t rnd_min = ((uint64_t)((int64_t)-1)) % rnd_max;
 
     do {
-        rnd = picoquic_public_random_64();
+        rnd = picoquic_test_random(random_context);
     } while (rnd < rnd_min);
 
     return rnd % rnd_max;

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -331,6 +331,7 @@ int transport_param_fuzz_test(int mode, uint32_t version, uint32_t proposed_vers
     uint8_t buffer[256];
     size_t decoded;
     uint8_t fuzz_byte = 1;
+    int suspended = debug_printf_reset(1);
 
     memset(&quic_ctx, 0, sizeof(quic_ctx));
     memset(&test_cnx, 0, sizeof(picoquic_cnx_t));
@@ -340,8 +341,6 @@ int transport_param_fuzz_test(int mode, uint32_t version, uint32_t proposed_vers
     if (target_length < 8 || target_length > sizeof(buffer)) {
         return -1;
     }
-
-    debug_printf_suspend();
 
     /* initialize the connection object to the test parameters */
     memcpy(&test_cnx.local_parameters, param, sizeof(picoquic_tp_t));
@@ -386,7 +385,7 @@ int transport_param_fuzz_test(int mode, uint32_t version, uint32_t proposed_vers
         }
     }
 
-    debug_printf_resume();
+    (void)debug_printf_reset(suspended);
 
     return ret;
 }
@@ -498,6 +497,7 @@ static int transport_param_log_fuzz_test(int client_mode, uint8_t* target, size_
     int ret = 0;
     uint8_t buffer[256];
     uint8_t fuzz_byte = 1;
+    int suspended = debug_printf_reset(1);
 
 
     /* test for valid arguments */
@@ -505,7 +505,6 @@ static int transport_param_log_fuzz_test(int client_mode, uint8_t* target, size_
         return -1;
     }
 
-    debug_printf_suspend();
 
     /* repeat multiple times */
     for (size_t l = 0; l < 8; l++) {
@@ -547,7 +546,7 @@ static int transport_param_log_fuzz_test(int client_mode, uint8_t* target, size_
         }
     }
 
-    debug_printf_resume();
+    (void) debug_printf_reset(suspended);
 
     return ret;
 }


### PR DESCRIPTION
The random generator for test was incorrectly using the "picoquic_public_random" function, which does not guarantee that the sequence of random numbers is repeatable. In addition, the public random generator was incorrectly initialized on 32 bit machines, leading to different values generated with clang and gcc.