### PR TITLE
Remove not working IPv4 DONT FRAG attempt on Linux

### DIFF
--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -496,6 +496,7 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
         }
 #endif
 
+#if 0
 #if defined(IP_PMTUDISC_DO) || defined(IP_DONTFRAG)
         if (addr_from->sa_family == AF_INET && length > PICOQUIC_INITIAL_MTU_IPV4) {
 #ifdef CMSG_ALIGN
@@ -524,6 +525,32 @@ int picoquic_sendmsg(SOCKET_TYPE fd,
                 control_length += CMSG_SPACE(sizeof(int));
             }
         }
+#endif
+#else
+#if defined(IP_DONTFRAG)
+        if (addr_from->sa_family == AF_INET && length > PICOQUIC_INITIAL_MTU_IP$
+#ifdef CMSG_ALIGN
+            struct cmsghdr * cmsg_2 = (struct cmsghdr *)((unsigned char *)cmsg $
+            {
+#else
+            struct cmsghdr * cmsg_2 = CMSG_NXTHDR((&msg), cmsg);
+            if (cmsg_2 == NULL) {
+                DBG_PRINTF("Cannot obtain second CMSG (control_length: %d)\n", $
+            }
+            else {
+#endif
+                /* On BSD systems, just use IP_DONTFRAG */
+                int val = 1;
+                cmsg_2->cmsg_level = IPPROTO_IP;
+                cmsg_2->cmsg_type = IP_DONTFRAG;
+                cmsg_2->cmsg_len = CMSG_LEN(sizeof(int));
+                memcpy(CMSG_DATA(cmsg_2), &val, sizeof(int));
+                control_length += CMSG_SPACE(sizeof(int));
+            }
+        }
+#endif
+
+
 #endif
 
     }


### PR DESCRIPTION
Trying to use the equivalent of:
```
s = setsockopt(sockfd, IPPROTO_IP, IP_MTU_DISCOVER, &on, sizeof(on));
```
on individual packets through the "sendmsg" API on Linux causes EINVAL errors. It works for IPv6, and it works for IPv4 on WIndows and BSD, but not on Linux.

A possible fix is to set the option for the whole socket on Linux, but that would prevent working on some networks.