### PR TITLE
demo: do not crash if server context could not be created

### DIFF
--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -402,10 +402,10 @@ int quic_server(const char* server_name, int server_port,
                 picoquic_set_cookie_mode(qserver, 1);
             }
             qserver->mtu_max = mtu_max;
-        }
 
-        /* TODO: add log level, to reduce size in "normal" cases */
-        PICOQUIC_SET_LOG(qserver, stdout);
+            /* TODO: add log level, to reduce size in "normal" cases */
+            PICOQUIC_SET_LOG(qserver, stdout);
+        }
     }
 
     /* Wait for packets */


### PR DESCRIPTION
Trying to run the demo server from a different working directory where the `certs` dir is missing resulted in a crash.