### PR TITLE
Add an option for key logging (draft -14)

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -847,6 +847,8 @@ void picoquic_log_time(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time,
 
 #define PICOQUIC_SET_LOG(quic, F) (quic)->F_log = (void*)(F)
 
+void picoquic_set_key_log_file(picoquic_quic_t *quic, FILE* F_keylog);
+
 /* handling of ACK logic */
 int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoquic_packet_context_enum pc);
 


### PR DESCRIPTION
The log_labels logic is based on setup_traffic_protection in picotls.c.
Enables QUIC decryption with Wireshark v2.9.0rc0-1850-g2fd42045f5.

The file handle will be leaked on exit, since this is a debug feature I
am not too worried about that.
___
This was tested on Linux where setting environment variables is rather easy. I can also replace it with a command-line argument if you prefer that. Do you think something like this would be nice to have?

(This feature was requested by @alagoutte)