### PR TITLE
CI for Windows: integration with AppVeyor

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -30,6 +30,11 @@ namespace UnitTest1
 	TEST_CLASS(UnitTest1)
 	{
 	public:
+        TEST_CLASS_INITIALIZE(setup) {
+            // avoid large debug spew that slows down the console.
+            debug_printf_suspend();
+        }
+
 	    TEST_METHOD(test_picohash)
 	    {
             int ret = picohash_test();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,13 @@ environment:
     - platform: x64
       configuration: Release
       OPENSSL64DIR: C:\OpenSSL-v11-Win64
+matrix:
+  allow_failures:
+    # For some reason linking picoquicdemo.lib fails with
+    # cifra.lib(chash.obj) : error LNK2001: unresolved external symbol __CheckForDebuggerJustMyCode [C:\projects\picoquic\picoquicfirst\picoquicfirst.vcxproj]
+    - platform: x64
+      configuration: Debug
+      OPENSSL64DIR: C:\OpenSSL-v11-Win64
 
 build:
   parallel: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+version: build{build}
+image: Visual Studio 2017
+
+environment:
+  matrix:
+    - platform: x86
+      configuration: Debug
+      OPENSSLDIR: C:\OpenSSL-v11-Win32
+    - platform: x64
+      configuration: Debug
+      OPENSSL64DIR: C:\OpenSSL-v11-Win64
+    - platform: x86
+      configuration: Release
+      OPENSSLDIR: C:\OpenSSL-v11-Win32
+    - platform: x64
+      configuration: Release
+      OPENSSL64DIR: C:\OpenSSL-v11-Win64
+
+build:
+  parallel: true
+  project: picoquic.sln
+
+before_build:
+  - ps: ci\build_picotls.ps1
+
+test_script:
+ - ps: if ($Env:Platform -eq "x64") { cd x64 }
+ - ps: cd "$Env:Configuration"
+ - ps: vstest.console /logger:Appveyor UnitTest1.dll
+ # Alternative to UnitTest1 (apparently running the same tests):
+ - ps: .\picoquic_t -n
+
+deploy: off
+
+#on_finish:
+#  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/ci/build_picotls.ps1
+++ b/ci/build_picotls.ps1
@@ -1,0 +1,24 @@
+# Build at a known-good commit
+# Must select a commit date (can copy-paste from git log)
+$COMMIT_ID="62c7d6c43d68bc411cd3edf41d537ccae9178999"
+$COMMIT_DATE="Wed Aug 22 11:16:13 2018 +0900"
+
+# Match expectations of picotlsvs project.
+foreach ($dir in "$Env:OPENSSLDIR","$Env:OPENSSL64DIR") {
+    if ($dir) {
+        cp "$dir\lib\libcrypto.lib" "$dir"
+        cp C:\OpenSSL-Win32\include\openssl\applink.c "$dir\include\openssl"
+    }
+}
+
+pushd ..
+git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags --shallow-since="$COMMIT_DATE" https://github.com/h2o/picotls 2>&1 | %{ "$_" }
+cd picotls
+git apply ..\picoquic\ci\picotls-win32.patch
+git checkout -q "$COMMIT_ID"
+#git submodule init
+#git submodule update
+
+msbuild "/p:Configuration=$Env:Configuration" "/p:Platform=$Env:Platform" /m picotlsvs\picotlsvs.sln
+
+popd

--- a/ci/picotls-win32.patch
+++ b/ci/picotls-win32.patch
@@ -1,0 +1,11 @@
+--- a/lib/openssl.c
++++ b/lib/openssl.c
+@@ -43,7 +43,7 @@
+ #include "picotls/openssl.h"
+ 
+ #ifdef _WINDOWS
+-#include <ms\applink.c>
++#include <openssl/applink.c>
+ #endif
+ 
+ #if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -123,7 +123,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -26,6 +26,9 @@
 extern "C" {
 #endif
 
+/* From picoquic/util.h */
+void debug_printf_suspend();
+
 /* Control variables for the duration of the stress test */
 
 extern uint64_t picoquic_stress_test_duration; /* In microseconds; defaults to 2 minutes */


### PR DESCRIPTION
Linux builds are already covered by Travis, but there was no CI for Windows. This PR tries to rectify that. See individual commits for details. Example passing build: https://ci.appveyor.com/project/Lekensteyn/picoquic/build/build23

To enable AppVeyor, you need to login at https://ci.appveyor.com/ with your Github account and enable this repo. After that, go to https://ci.appveyor.com/project/private-octopus/picoquic/settings and check *Skip branches without appveyor.yml* (optional, but recommended).

At first I tried to integrate with CMake which has better support for discovering OpenSSL automatically, but since the number of Windows developers using CMake probably approach 0, I decided to use the existing VS project (where the number of users is at least 1).