### PR TITLE
Separate structures for each spin variant

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -271,7 +271,7 @@ int picoquic_parse_packet_header(
                  ph->key_phase = bytes[0] >> 6;
                  ph->has_spin_bit = 1;
                  ph->spin = (bytes[0] >> 2) & 1;
-                 ph->spin_vec = bytes[0] & 0x03 ;
+                 ph->spin_opt = bytes[0] & 0x03 ;
 
                  ph->pn_offset = ph->offset;
                  ph->pn = 0;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2973,7 +2973,7 @@ int spin_bit_test()
         int nb_trials = 0;
         int nb_inactive = 0;
         int max_trials = 100000;
-        int current_spin = test_ctx->cnx_client->path[0]->current_spin;
+        int current_spin = test_ctx->cnx_client->path[0]->spin_data.s_sqr.current_spin;
 
         test_ctx->c_to_s_link->loss_mask = &loss_mask;
         test_ctx->s_to_c_link->loss_mask = &loss_mask;
@@ -2990,9 +2990,9 @@ int spin_bit_test()
                 break;
             }
 
-            if (test_ctx->cnx_client->path[0]->current_spin != current_spin) {
+            if (test_ctx->cnx_client->path[0]->spin_data.s_sqr.current_spin != current_spin) {
                 spin_count++;
-                current_spin = test_ctx->cnx_client->path[0]->current_spin;
+                current_spin = test_ctx->cnx_client->path[0]->spin_data.s_sqr.current_spin;
             }
 
             if (was_active) {


### PR DESCRIPTION
Also, remove assumptions about "vec" in header parsing, and update the SQR counting of losses so the main code does not have to take a dependency on SQR.