### PR TITLE
Add key rotation vector test plus log

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -490,6 +490,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(key_rotation_vector)
+        {
+            int ret = key_rotation_vector_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+        
         TEST_METHOD(draft13_vector)
         {
             int ret = draft13_vector_test();

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -99,6 +99,7 @@ uint8_t * picoquic_get_app_secret(picoquic_cnx_t* cnx, int is_enc);
 size_t picoquic_get_app_secret_size(picoquic_cnx_t* cnx);
 int picoquic_compute_new_rotated_keys(picoquic_cnx_t * cnx);
 void picoquic_apply_rotated_keys(picoquic_cnx_t * cnx, int is_enc);
+int picoquic_rotate_app_secret(ptls_cipher_suite_t * cipher, uint8_t * secret);
 
 void picoquic_crypto_context_free(picoquic_crypto_context_t * ctx);
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -142,6 +142,7 @@ static const picoquic_test_def_t test_table[] = {
     { "key_rotation", key_rotation_test },
     { "false_migration", false_migration_test },
     { "nat_handshake", nat_handshake_test },
+    { "key_rotation_vector", key_rotation_vector_test },
     { "stress", stress_test },
     { "fuzz", fuzz_test },
     { "fuzz_initial", fuzz_initial_test}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -140,6 +140,7 @@ int new_rotated_key_test();
 int key_rotation_test();
 int false_migration_test();
 int nat_handshake_test();
+int key_rotation_vector_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added log of rotated secrets, and also of AEAD IV.
Also, added test vectors for secret rotation. 