### PR TITLE
Compute next retransmit time in just one place

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1345,7 +1345,7 @@ static picoquic_packet_t* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larg
     /* Check whether this is a new acknowledgement */
     if (largest > pkt_ctx->highest_acknowledged || pkt_ctx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
         pkt_ctx->highest_acknowledged = largest;
-        pkt_ctx[pc].highest_acknowledged_time = current_time;
+        pkt_ctx->highest_acknowledged_time = current_time;
 
         if (ack_delay < PICOQUIC_ACK_DELAY_MAX) {
             /* if the ACK is reasonably recent, use it to update the RTT */

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1345,6 +1345,7 @@ static picoquic_packet_t* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larg
     /* Check whether this is a new acknowledgement */
     if (largest > pkt_ctx->highest_acknowledged || pkt_ctx->first_sack_item.start_of_sack_range == (uint64_t)((int64_t)-1)) {
         pkt_ctx->highest_acknowledged = largest;
+        pkt_ctx[pc].highest_acknowledged_time = current_time;
 
         if (ack_delay < PICOQUIC_ACK_DELAY_MAX) {
             /* if the ACK is reasonably recent, use it to update the RTT */
@@ -1952,7 +1953,7 @@ int picoquic_prepare_ack_frame_maybe_ecn(picoquic_cnx_t* cnx, uint64_t current_t
 
             /* Remember the ACK value and time */
             pkt_ctx->highest_ack_sent = pkt_ctx->first_sack_item.end_of_sack_range;
-            pkt_ctx->highest_ack_time = current_time;
+            pkt_ctx->highest_ack_sent_time = current_time;
 
             *consumed = byte_index;
         }
@@ -1993,7 +1994,7 @@ int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoquic_
     picoquic_packet_context_t * pkt_ctx = &cnx->pkt_ctx[pc];
 
     if (pkt_ctx->highest_ack_sent + 2 <= pkt_ctx->first_sack_item.end_of_sack_range ||
-        pkt_ctx->highest_ack_time + pkt_ctx->ack_delay_local <= current_time) {
+        pkt_ctx->highest_ack_sent_time + pkt_ctx->ack_delay_local <= current_time) {
         ret = pkt_ctx->ack_needed;
     }
 

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1620,6 +1620,9 @@ int picoquic_incoming_segment(
             (cnx == NULL) ? -1 : cnx->client_mode, ph.ptype, ph.epoch, ph.pc, (int)ph.pn, 
             length, ret);
         ret = -1;
+        if (cnx != NULL) {
+            picoquic_cnx_set_next_wake_time(cnx, current_time);
+        }
     } else if (ret == 1) {
         /* wonder what happened ! */
         DBG_PRINTF("Packet (%d) get ret=1, t: %d, e: %d, pc: %d, pn: %d, l: %d\n",

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1600,7 +1600,7 @@ int picoquic_incoming_segment(
             ret = picoquic_record_pn_received(cnx, ph.pc, ph.pn64, current_time);
         }
         if (cnx != NULL) {
-            picoquic_cnx_set_next_wake_time(cnx, current_time);
+            picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time);
         }
     } else if (ret == PICOQUIC_ERROR_DUPLICATE) {
         /* Bad packets are dropped silently, but duplicates should be acknowledged */
@@ -1621,7 +1621,7 @@ int picoquic_incoming_segment(
             length, ret);
         ret = -1;
         if (cnx != NULL) {
-            picoquic_cnx_set_next_wake_time(cnx, current_time);
+            picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time);
         }
     } else if (ret == 1) {
         /* wonder what happened ! */

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -88,7 +88,7 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -783,8 +783,6 @@ void picoquic_update_pacing_data(picoquic_path_t * path_x);
      * so ready connections are polled first */
 void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t next_time);
 
-void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time);
-
 /* Integer parsing macros */
 #define PICOPARSE_16(b) ((((uint16_t)(b)[0]) << 8) | (b)[1])
 #define PICOPARSE_24(b) ((((uint32_t)PICOPARSE_16(b)) << 16) | ((b)[2]))

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -918,7 +918,7 @@ void picoquic_log_time(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time,
 void picoquic_set_key_log_file(picoquic_quic_t *quic, FILE* F_keylog);
 
 /* handling of ACK logic */
-int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoquic_packet_context_enum pc);
+int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t * next_wake_time, picoquic_packet_context_enum pc);
 
 int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, 
     picoquic_packet_context_enum pc, uint64_t pn64);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -540,13 +540,14 @@ typedef struct st_picoquic_packet_context_t {
     picoquic_sack_item_t first_sack_item;
     uint64_t time_stamp_largest_received;
     uint64_t highest_ack_sent;
-    uint64_t highest_ack_time;
+    uint64_t highest_ack_sent_time;
     uint64_t ack_delay_local;
 
     uint64_t nb_retransmit;
     uint64_t latest_retransmit_time;
     uint64_t highest_acknowledged;
     uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
+    uint64_t highest_acknowledged_time; /* time at which the highest ack was received */
     picoquic_packet_t* retransmit_newest;
     picoquic_packet_t* retransmit_oldest;
     picoquic_packet_t* retransmitted_newest;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -835,7 +835,7 @@ uint32_t  picoquic_predict_packet_header_length(
     picoquic_packet_type_enum packet_type);
 
 void picoquic_update_payload_length(
-    uint8_t* bytes, size_t pnum_index, size_t header_length, size_t packet_length);
+    uint8_t* bytes, size_t pnum_index, size_t header_length, uint32_t packet_length);
 
 uint32_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode);
 

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -89,9 +89,11 @@ void picosplay_init_tree(picosplay_tree* tree, picosplay_comparator comp) {
 /* Return an empty tree, storing the picosplay_comparator. */
 picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
     picosplay_tree *new = malloc(sizeof(picosplay_tree));
-    new->comp = comp;
-    new->root = NULL;
-    new->size = 0;
+    if (new != NULL) {
+        new->comp = comp;
+        new->root = NULL;
+        new->size = 0;
+    }
     return new;
 }
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1360,7 +1360,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
                 cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range = 0;
                 cnx->pkt_ctx[pc].first_sack_item.next_sack = NULL;
                 cnx->pkt_ctx[pc].highest_ack_sent = 0;
-                cnx->pkt_ctx[pc].highest_ack_time = start_time;
+                cnx->pkt_ctx[pc].highest_ack_sent_time = start_time;
                 cnx->pkt_ctx[pc].time_stamp_largest_received = (uint64_t)((int64_t)-1);
                 cnx->pkt_ctx[pc].send_sequence = 0;
                 cnx->pkt_ctx[pc].nb_retransmit = 0;
@@ -1369,6 +1369,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
                 cnx->pkt_ctx[pc].retransmit_oldest = NULL;
                 cnx->pkt_ctx[pc].highest_acknowledged = cnx->pkt_ctx[pc].send_sequence - 1;
                 cnx->pkt_ctx[pc].latest_time_acknowledged = start_time;
+                cnx->pkt_ctx[pc].highest_acknowledged_time = start_time;
                 cnx->pkt_ctx[pc].ack_needed = 0;
                 cnx->pkt_ctx[pc].ack_delay_local = PICOQUIC_ACK_DELAY_MAX;
             }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1448,7 +1448,7 @@ int picoquic_start_client_cnx(picoquic_cnx_t * cnx)
 {
     int ret = picoquic_initialize_tls_stream(cnx);
 
-    picoquic_cnx_set_next_wake_time(cnx, picoquic_get_quic_time(cnx->quic));
+    picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
 
     return ret;
 }
@@ -1632,7 +1632,7 @@ int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t 
         cnx->first_misc_frame = misc_frame;
     }
 
-    picoquic_cnx_set_next_wake_time(cnx, picoquic_get_quic_time(cnx->quic));
+    picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
 
     return ret;
 }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -189,7 +189,7 @@ picoquic_packet_t* picoquic_create_packet()
 }
 
 void picoquic_update_payload_length(
-    uint8_t* bytes, size_t pnum_index, size_t header_length, size_t packet_length)
+    uint8_t* bytes, size_t pnum_index, size_t header_length, uint32_t packet_length)
 {
     if ((bytes[0] & 0x80) != 0 && header_length > 6 && packet_length > header_length && packet_length < 0x4000)
     {
@@ -407,7 +407,7 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     uint32_t send_length;
     uint32_t h_length;
     uint32_t pn_offset = 0;
-    size_t sample_offset = 0;
+    uint32_t sample_offset = 0;
     size_t sample_size = picoquic_pn_iv_size(pn_enc);
     uint32_t pn_length = 0;
     uint32_t aead_checksum_length = (uint32_t)picoquic_aead_get_checksum_length(aead_context);
@@ -532,7 +532,7 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x
 
 picoquic_packet_t* picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p, int should_free)
 {
-    size_t dequeued_length = p->length + p->checksum_overhead;
+    uint32_t dequeued_length = p->length + p->checksum_overhead;
     picoquic_packet_context_enum pc = p->pc;
 
     if (p->previous_packet == NULL) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1281,12 +1281,14 @@ void picoquic_cnx_set_next_wake_time(picoquic_cnx_t* cnx, uint64_t current_time)
     } else if (path_x->path_is_demoted == 0) {
         
         if (pacing != 0) {
-        next_time = path_x->next_pacing_time;
+            next_time = path_x->next_pacing_time;
         }
         else {
             if (cnx->path[0]->challenge_verified != 0) {
                 for (picoquic_packet_context_enum pc = 0; pc < picoquic_nb_packet_context; pc++) {
+#if 0
                     picoquic_packet_t* p = cnx->pkt_ctx[pc].retransmit_oldest;
+#endif
                     /* Consider delayed ACK */
                     if (cnx->pkt_ctx[pc].ack_needed) {
                         uint64_t ack_time = cnx->pkt_ctx[pc].highest_ack_sent_time + cnx->pkt_ctx[pc].ack_delay_local;

--- a/picoquic/ticket_store.c
+++ b/picoquic/ticket_store.c
@@ -34,7 +34,7 @@ picoquic_stored_ticket_t* picoquic_format_ticket(uint64_t time_valid_until,
     char* next_p = ((char*)stored) + sizeof(picoquic_stored_ticket_t);
 
     if (stored != NULL) {
-        memset(stored, 0, sizeof(picoquic_stored_ticket_t));
+        memset(stored, 0, ticket_size);
         stored->time_valid_until = time_valid_until;
         stored->sni = next_p;
         stored->sni_length = sni_length;
@@ -332,7 +332,7 @@ int picoquic_load_tickets(picoquic_stored_ticket_t** pp_first_ticket,
                         ret = PICOQUIC_ERROR_INVALID_FILE;
                     }
 
-                    if (ret == 0) {
+                    if (ret == 0 && next != NULL) {
                         if (next->time_valid_until < current_time) {
                             free(next);
                         }

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1523,8 +1523,12 @@ static int picoquic_add_to_tls_stream(picoquic_cnx_t* cnx, const uint8_t* data, 
                 *pprevious = stream_data;
             }
         }
-
+#if 0
         picoquic_cnx_set_next_wake_time(cnx, picoquic_get_quic_time(cnx->quic));
+#else
+        /* reset the connection at its new logical position */
+        picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
+#endif
     }
 
     return ret;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -982,6 +982,10 @@ static int tls_api_data_sending_loop(picoquic_test_tls_api_ctx_t* test_ctx,
             nb_inactive++;
         }
 
+        if (nb_inactive == 128) {
+            nb_inactive = 128;
+        }
+
         if (test_ctx->test_finished) {
             if (picoquic_is_cnx_backlog_empty(test_ctx->cnx_client) && picoquic_is_cnx_backlog_empty(test_ctx->cnx_server)) {
                 break;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3918,7 +3918,7 @@ int initial_close_test()
         if (ret == 0) {
             test_ctx->cnx_client->cnx_state = picoquic_state_handshake_failure;
             test_ctx->cnx_client->local_error = 0xDEAD;
-            picoquic_cnx_set_next_wake_time(test_ctx->cnx_client, simulated_time);
+            picoquic_reinsert_by_wake_time(test_ctx->qclient, test_ctx->cnx_client, simulated_time);
         }
     }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -982,10 +982,6 @@ static int tls_api_data_sending_loop(picoquic_test_tls_api_ctx_t* test_ctx,
             nb_inactive++;
         }
 
-        if (nb_inactive == 128) {
-            nb_inactive = 128;
-        }
-
         if (test_ctx->test_finished) {
             if (picoquic_is_cnx_backlog_empty(test_ctx->cnx_client) && picoquic_is_cnx_backlog_empty(test_ctx->cnx_server)) {
                 break;


### PR DESCRIPTION
Move most of the "compute wake time" logic inside the packet sending logic, so as to avoid code duplication. 

This removes the separate procedure used to compute the "next wake time". That procedure needed to replicate the logic used when sending packets, and this turns out to be very hard to maintain, as seen for example in issues #88 , #201 and #288, plus a variety of quick fixes added after tests.

The fix is not perfect, since there is still some guesswork for the management of probes and paths, but it should be a vast improvement. Also, the code becomes smaller.

