### PR TITLE
Adding time value in stateless packets logs

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -679,15 +679,12 @@ int picoquic_prepare_version_negotiation(
         memcpy(&sp->addr_local, addr_to,
             (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
         sp->if_index_local = if_index_to;
+        sp->cnxid_log64 = picoquic_val64_connection_id(ph->dest_cnx_id);
 
         if (quic->F_log != NULL) {
             picoquic_log_outgoing_segment(quic->F_log, 1, NULL,
                 bytes, 0, (uint32_t)sp->length,
                 bytes, (uint32_t)sp->length);
-
-            picoquic_log_packet_address(quic->F_log,
-                picoquic_val64_connection_id(ph->dest_cnx_id),
-                NULL, addr_to, 0, sp->length, 0);
         }
 
         picoquic_queue_stateless_packet(quic, sp);
@@ -744,15 +741,11 @@ void picoquic_process_unexpected_cnxid(
             memcpy(&sp->addr_local, addr_to,
                 (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
             sp->if_index_local = if_index_to;
+            sp->cnxid_log64 = picoquic_val64_connection_id(ph->dest_cnx_id);
 
             if (quic->F_log != NULL) {
-                uint64_t log_cnxid64 = picoquic_val64_connection_id(ph->dest_cnx_id);
-
                 fprintf(quic->F_log, "%llu: Unexpected connection ID, sending stateless reset.\n",
-                    (unsigned long long)log_cnxid64);
-
-                picoquic_log_packet_address(quic->F_log, log_cnxid64,
-                    NULL, addr_to, 0, sp->length, 0);
+                    (unsigned long long)sp->cnxid_log64);
             }
 
 
@@ -810,15 +803,12 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
         memcpy(&sp->addr_local, addr_to,
             (addr_to->sa_family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6));
         sp->if_index_local = if_index_to;
+        sp->cnxid_log64 = picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx));
 
         if (cnx->quic->F_log != NULL) {
             picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
                 bytes, 0, (uint32_t)sp->length,
                 bytes, (uint32_t)sp->length);
-
-            picoquic_log_packet_address(cnx->quic->F_log,
-                picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)),
-                cnx, addr_to, 0, sp->length, 0);
         }
 
         picoquic_queue_stateless_packet(cnx->quic, sp);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -181,6 +181,7 @@ typedef struct st_picoquic_stateless_packet_t {
     struct sockaddr_storage addr_local;
     unsigned long if_index_local;
     size_t length;
+    uint64_t cnxid_log64;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquic_stateless_packet_t;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -369,6 +369,11 @@ picoquic_stateless_packet_t* picoquic_dequeue_stateless_packet(picoquic_quic_t* 
     if (sp != NULL) {
         quic->pending_stateless_packet = sp->next_packet;
         sp->next_packet = NULL;
+
+        if (quic->F_log != NULL) {
+            picoquic_log_packet_address(quic->F_log, sp->cnxid_log64,
+                NULL, (struct sockaddr*)&sp->addr_to, 0, sp->length, picoquic_get_quic_time(quic));
+        }
     }
 
     return sp;


### PR DESCRIPTION
Fixing issue #377 