### PR TITLE
Fix prepare stream frame

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1074,8 +1074,8 @@ int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* str
                 if (stream->stream_id != 0) {
                     cnx->data_sent += length;
                 }
-                *consumed = byte_index;
             }
+            *consumed = byte_index;
 
             if (ret == 0 && STREAM_FIN_NOTIFIED(stream) && stream->send_queue == 0) {
                 /* Set the fin bit */

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1025,11 +1025,8 @@ int picoquic_prepare_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head* str
                 length = (size_t)(stream->maxdata_remote - stream->sent_offset);
             }
 
-            /* Abide by flow control restrictions, stream 0 is exempt */
-            if (stream->stream_id != 0) {
-                if (length > (cnx->maxdata_remote - cnx->data_sent)) {
-                    length = (size_t)(cnx->maxdata_remote - cnx->data_sent);
-                }
+            if (length > (cnx->maxdata_remote - cnx->data_sent)) {
+                length = (size_t)(cnx->maxdata_remote - cnx->data_sent);
             }
 
             if (length >= space) {


### PR DESCRIPTION
Hey,
I encountered some bugs, while porting your latest changes to rust.

The first one was that a packet was padded and the stream was sending data with a length of `0`. It happened that the padding data was interpreted as stream data, because no length was set!

Another bug I discovered while doing that was the `consumed` argument for `picoquic_prepare_stream_frame`. The argument was `4`, because some function before set it and so, the data was still send. However, `consumed` should be set by each call of `prepare_stream_frame`.