### PR TITLE
only-check-token-on-first-initial

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -833,7 +833,8 @@ int picoquic_incoming_initial(
 
     /* Logic to test the retry token.
      * TODO: this should probably be implemented as a callback */
-    if ((*pcnx)->quic->flags&picoquic_context_check_token &&
+    if (((*pcnx)->quic->flags&picoquic_context_check_token) &&
+        (*pcnx)->cnx_state == picoquic_state_server_init &&
         ((*pcnx)->quic->flags&picoquic_context_server_busy) == 0) {
         uint8_t * base;
         size_t len;


### PR DESCRIPTION
This addresses an issue found in interop tests between lsquic and picoquic. Lsquic only copies the retry token in the first initial packet.