### PR TITLE
Fix logging of retry packets and client side bug

### DIFF
--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -368,8 +368,10 @@ void picoquic_log_packet_header(FILE* F, uint64_t log_cnxid64, picoquic_packet_h
     default:
         /* Long packets. Log Vnum, both CID, Seq num, Payload length */
         fprintf(F, " Version %x,", ph->vn);
-        picoquic_log_prefix_initial_cid64(F, log_cnxid64);
 
+        fprintf(F, "\n");
+        picoquic_log_prefix_initial_cid64(F, log_cnxid64);
+        fprintf(F, "    ");
         picoquic_log_connection_id(F, &ph->dest_cnx_id);
         fprintf(F, ", ");
         picoquic_log_connection_id(F, &ph->srce_cnx_id);
@@ -440,6 +442,7 @@ void picoquic_log_retry_packet(FILE* F, uint64_t log_cnxid64,
         if (token_length > 0) {
             int printed_length = (token_length > 16) ? 16 : token_length; 
             picoquic_log_prefix_initial_cid64(F, log_cnxid64);
+            fprintf(F, "    Token: ");
             for (uint8_t i = 0; i < printed_length; i++) {
                 fprintf(F, "%02x", bytes[byte_index++]);
             }
@@ -1208,9 +1211,11 @@ void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* c
 
     ph.pn64 = sequence_number;
     ph.pn = (uint32_t)ph.pn64;
-    if (ph.pn_offset != 0) {
-        ph.offset = ph.pn_offset + 4; /* todo: should provide the actual length */
-        ph.payload_length -= 4;
+    if (ph.ptype != picoquic_packet_retry) {
+        if (ph.pn_offset != 0) {
+            ph.offset = ph.pn_offset + 4; /* todo: should provide the actual length */
+            ph.payload_length -= 4;
+        }
     }
     if (ph.ptype != picoquic_packet_version_negotiation) {
         if (ph.payload_length > checksum_length) {

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1105,13 +1105,13 @@ int picoquic_incoming_client_handshake(
 {
     int ret = 0;
 
-if (cnx->cnx_state == picoquic_state_server_init
-    || cnx->cnx_state == picoquic_state_server_handshake
-    || cnx->cnx_state == picoquic_state_server_almost_ready
-    || cnx->cnx_state == picoquic_state_server_false_start
-    || cnx->cnx_state == picoquic_state_ready) {
-    if (picoquic_compare_connection_id(&ph->srce_cnx_id, &cnx->path[0]->remote_cnxid) != 0) {
-        ret = PICOQUIC_ERROR_CNXID_CHECK;
+    if (cnx->cnx_state == picoquic_state_server_init
+        || cnx->cnx_state == picoquic_state_server_handshake
+        || cnx->cnx_state == picoquic_state_server_almost_ready
+        || cnx->cnx_state == picoquic_state_server_false_start
+        || cnx->cnx_state == picoquic_state_ready) {
+        if (picoquic_compare_connection_id(&ph->srce_cnx_id, &cnx->path[0]->remote_cnxid) != 0) {
+            ret = PICOQUIC_ERROR_CNXID_CHECK;
     }
     else {
         /* Accept the incoming frames */

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1473,13 +1473,14 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
 
                         if (packet_type == picoquic_packet_initial && 
                             (cnx->crypto_context[1].aead_encrypt == NULL ||
-                                cnx->cnx_state == picoquic_state_client_renegotiate)) {
+                                cnx->cnx_state == picoquic_state_client_renegotiate ||
+                                cnx->original_cnxid.id_len != 0)) {
                             /* Pad to minimum packet length. But don't do that if the
                              * initial packet will be coalesced with 0-RTT packet */
                             while (length < send_buffer_max - checksum_overhead) {
                                 bytes[length++] = 0;
                             }
-                        }
+                        } 
 
                         if (packet_type == picoquic_packet_0rtt_protected) {
                             cnx->nb_zero_rtt_sent++;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1520,6 +1520,7 @@ int tls_api_bad_server_reset_test()
 int tls_api_retry_test()
 {
     uint64_t simulated_time = 0;
+    const uint64_t target_time = 210000ull;
     uint64_t loss_mask = 0;
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
     int ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, 0, 0, 0);
@@ -1533,6 +1534,11 @@ int tls_api_retry_test()
 
     if (ret == 0) {
         ret = tls_api_attempt_to_close(test_ctx, &simulated_time);
+    }
+
+    if (ret == 0 && simulated_time > target_time) {
+        DBG_PRINTF("Retry test completes in %llu microsec, more than %llu\n", simulated_time, target_time);
+        ret = -1;
     }
 
     if (test_ctx != NULL) {


### PR DESCRIPTION
The logs of retry packets pointed to incorrect parsing of the header, which is now fixed.
There was also a client side bug, that caused the retried initial packets to not include padding.