### PR TITLE
Pacing tlp congestion

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1287,6 +1287,11 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
                 if (max_reorder_gap > old_path->max_reorder_gap) {
                     old_path->max_reorder_gap = max_reorder_gap;
                 }
+
+                if (cnx->congestion_alg != NULL ) {
+                    cnx->congestion_alg->alg_notify(old_path, picoquic_congestion_notification_spurious_repeat,
+                        0, 0, p->sequence_number, current_time);
+                }
             }
 
             cnx->nb_spurious++;

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -110,6 +110,11 @@ void picoquic_newreno_notify(picoquic_path_t* path_x,
                 picoquic_newreno_enter_recovery(path_x, notification, nr_state, current_time);
                 break;
             case picoquic_congestion_notification_spurious_repeat:
+                /* Immediately exit the previous recovery */
+                if (path_x->cwin < 2 * nr_state->ssthresh) {
+                    path_x->cwin = 2 * nr_state->ssthresh;
+                    nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;
+                }
                 break;
             case picoquic_congestion_notification_rtt_measurement:
                 /* TODO: consider using RTT increases as signal to get out of slow start */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -510,11 +510,19 @@ typedef struct st_picoquic_path_t {
     uint64_t bytes_in_transit;
     void* congestion_alg_state;
 
-    /* Pacing */
-    uint64_t packet_time_nano_sec;
-    uint64_t pacing_reminder_nano_sec;
-    uint64_t pacing_margin_micros;
-    uint64_t next_pacing_time;
+    /* 
+     * Pacing uses a set of per path variables:
+     * - pacing_evaluation_time: last time the path was evaluated.
+     * - pacing_bucket_nanosec: number of nanoseconds of transmission time that are allowed.
+     * - pacing_bucket_max: maximum value (capacity) of the leaky bucket.
+     * - pacing_packet_time_nanosec: number of nanoseconds required to send a full size packet.
+     * - pacing_packet_time_microsec: max of (packet_time_nano_sec/1024, 1) microsec.
+     */
+    uint64_t pacing_evaluation_time;
+    uint64_t pacing_bucket_nanosec;
+    uint64_t pacing_bucket_max;
+    uint64_t pacing_packet_time_nanosec;
+    uint64_t pacing_packet_time_microsec;
 
 } picoquic_path_t;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -734,10 +734,11 @@ int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, struct sockad
             path_x->congestion_alg_state = NULL;
 
             /* Initialize per path pacing state */
-            path_x->packet_time_nano_sec = 0;
-            path_x->pacing_reminder_nano_sec = 0;
-            path_x->pacing_margin_micros = 1000;
-            path_x->next_pacing_time = start_time;
+            path_x->pacing_evaluation_time = start_time;
+            path_x->pacing_bucket_nanosec = 16;
+            path_x->pacing_bucket_max = 16;
+            path_x->pacing_packet_time_nanosec = 1;
+            path_x->pacing_packet_time_microsec = 1;
 
             /* Initialize the MTU */
             path_x->send_mtu = (peer_addr == NULL || peer_addr->sa_family == AF_INET) ? PICOQUIC_INITIAL_MTU_IPV4 : PICOQUIC_INITIAL_MTU_IPV6;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -531,19 +531,31 @@ int picoquic_is_sending_authorized_by_pacing(picoquic_path_t * path_x, uint64_t 
 
 void picoquic_update_pacing_data(picoquic_path_t * path_x)
 {
-    uint64_t bucket_1024 = (((uint64_t)path_x->cwin)<<10)/ (8 * path_x->send_mtu);
-    uint64_t bucket = 2 + ((bucket_1024 + 1023) >> 10);
+    uint64_t rtt_nanosec = (path_x->smoothed_rtt << 10);
 
-    path_x->pacing_bucket_max = bucket;
-
-    path_x->pacing_packet_time_nanosec = ((path_x->smoothed_rtt << 10) * path_x->send_mtu) / path_x->cwin;
-
-    if (path_x->pacing_packet_time_nanosec <= 0) {
+    if (path_x->cwin < 8 * path_x->send_mtu) {
+        /* Small windows, should only relie on ACK clocking */
+        path_x->pacing_bucket_max = rtt_nanosec;
         path_x->pacing_packet_time_nanosec = 1;
         path_x->pacing_packet_time_microsec = 1;
+
     }
     else {
-        path_x->pacing_packet_time_microsec = (path_x->pacing_packet_time_nanosec + 1023) >> 10;
+
+        path_x->pacing_packet_time_nanosec = (rtt_nanosec * path_x->send_mtu) / path_x->cwin;
+
+        if (path_x->pacing_packet_time_nanosec <= 0) {
+            path_x->pacing_packet_time_nanosec = 1;
+            path_x->pacing_packet_time_microsec = 1;
+        }
+        else {
+            path_x->pacing_packet_time_microsec = (path_x->pacing_packet_time_nanosec + 1023) >> 10;
+        }
+
+        path_x->pacing_bucket_max = (rtt_nanosec / 4);
+        if (path_x->pacing_bucket_max < 2 * path_x->pacing_packet_time_nanosec) {
+            path_x->pacing_bucket_max = 2 * path_x->pacing_packet_time_nanosec;
+        }
     }
 }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1391,7 +1391,7 @@ int tls_api_one_scenario_test(test_api_stream_desc_t* scenario,
 
 int tls_api_oneway_stream_test()
 {
-    return tls_api_one_scenario_test(test_scenario_oneway, sizeof(test_scenario_oneway), 0, 0, 0, 0, 75000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_oneway, sizeof(test_scenario_oneway), 0, 0, 0, 0, 70000, NULL, NULL);
 }
 
 int tls_api_q_and_r_stream_test()

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1416,7 +1416,7 @@ int tls_api_very_long_max_test()
 
 int tls_api_very_long_with_err_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 5000000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 4000000, NULL, NULL);
 }
 
 int tls_api_very_long_congestion_test()

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1391,7 +1391,7 @@ int tls_api_one_scenario_test(test_api_stream_desc_t* scenario,
 
 int tls_api_oneway_stream_test()
 {
-    return tls_api_one_scenario_test(test_scenario_oneway, sizeof(test_scenario_oneway), 0, 0, 0, 0, 70000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_oneway, sizeof(test_scenario_oneway), 0, 0, 0, 0, 75000, NULL, NULL);
 }
 
 int tls_api_q_and_r_stream_test()
@@ -1406,22 +1406,22 @@ int tls_api_q2_and_r2_stream_test()
 
 int tls_api_very_long_stream_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 3510000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 0, 1000000, NULL, NULL);
 }
 
 int tls_api_very_long_max_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 0, 0, 3510000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 0, 0, 1000000, NULL, NULL);
 }
 
 int tls_api_very_long_with_err_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 11000000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0x30000, 128000, 0, 0, 5000000, NULL, NULL);
 }
 
 int tls_api_very_long_congestion_test()
 {
-    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 20000, 0, 7000000, NULL, NULL);
+    return tls_api_one_scenario_test(test_scenario_very_long, sizeof(test_scenario_very_long), 0, 128000, 20000, 0, 1500000, NULL, NULL);
 }
 
 int unidir_test()


### PR DESCRIPTION
Implement pacing, using a simple leaky bucket algorithm. Pacing does improve performance a lot. @bkchr: you should look at the reduction in execution time of several long tests.

Tried to implement the idea of only notifying the congestion algorithm when a loss is confirmed, but this caused a bunch of regressions. Instead, implemented the simpler solution of rolling back the congestion window decrease if a repetition is marked as spurious.

Tried to implement Tail Loss Probe, but this requires more work. The naive spec just causes spurious retransmission and performance regression.