### PR TITLE
Remove usage of relative paths (../xxx.h) in headers and test configuration

### DIFF
--- a/UnitTest1/UnitTest1.vcxproj
+++ b/UnitTest1/UnitTest1.vcxproj
@@ -94,6 +94,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -108,6 +109,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -124,6 +126,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -142,6 +145,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -21,7 +21,7 @@
 
 #include "stdafx.h"
 #include "CppUnitTest.h"
-#include "../picoquictest/picoquictest.h"
+#include "picoquictest/picoquictest.h"
 
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -307,3 +307,53 @@ int picoquic_store_addr(struct sockaddr_storage * stored_addr, const struct sock
 
     return len;
 }
+
+/* Return a directory path based on solution dir and file name */
+#ifdef _WINDOWS
+#define PICOQUIC_FILE_SEPARATOR '\\'
+#ifdef _WINDOWS64
+#define PICOQUIC_DEFAULT_SOLUTION_DIR "..\\..\\"
+#else
+#define PICOQUIC_DEFAULT_SOLUTION_DIR "..\\"
+#endif
+#else
+#define PICOQUIC_DEFAULT_SOLUTION_DIR "./"
+#define PICOQUIC_FILE_SEPARATOR '/'
+#endif
+
+int picoquic_get_input_path(char * target_file_path, size_t file_path_max, const char * solution_path, const char * file_name) 
+{
+    int ret = 0;
+    size_t solution_path_length;
+    size_t file_name_length;
+    size_t separator_length = 0;
+    if (solution_path == NULL) {
+        solution_path = PICOQUIC_DEFAULT_SOLUTION_DIR;
+    }
+
+    solution_path_length = strlen(solution_path);
+    file_name_length = strlen(file_name);
+    if (solution_path_length == 0 || solution_path[solution_path_length - 1] != PICOQUIC_FILE_SEPARATOR) {
+        separator_length = 1;
+    }
+
+    if (solution_path_length + separator_length + file_name_length + 1 > file_path_max) {
+        target_file_path[0] = 0;
+        ret = -1;
+    }
+    else {
+        size_t byte_index = 0;
+        memcpy(&target_file_path[byte_index], solution_path, solution_path_length);
+        byte_index += solution_path_length;
+
+        if (separator_length) {
+            target_file_path[byte_index++] = PICOQUIC_FILE_SEPARATOR;
+        }
+        memcpy(&target_file_path[byte_index], file_name, file_name_length);
+        byte_index += file_name_length;
+
+        target_file_path[byte_index] = 0;
+    }
+
+    return ret;
+}

--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -60,6 +60,8 @@ void picoquic_parse_packet_header_cnxid_lengths(uint8_t l_byte, uint8_t *dest_le
 int picoquic_compare_addr(const struct sockaddr * expected, const struct sockaddr * actual);
 int picoquic_store_addr(struct sockaddr_storage * stored_addr, const struct sockaddr * addr);
 
+int picoquic_get_input_path(char * target_file_path, size_t file_path_max, const char * solution_path, const char * file_name);
+
 #ifndef MAX
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -19,11 +19,11 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #ifdef _WINDOWS
-#include "../picoquicfirst/getopt.h"
+#include "picoquicfirst/getopt.h"
 #endif
-#include "../picoquic/picoquic.h"
-#include "../picoquic/util.h"
-#include "../picoquictest/picoquictest.h"
+#include "picoquic/picoquic.h"
+#include "picoquic/util.h"
+#include "picoquictest/picoquictest.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -191,11 +191,12 @@ int usage(char const * argv0)
         fprintf(stderr, "\n");
     }
     fprintf(stderr, "Options: \n");
-    fprintf(stderr, "  -x test        Do not run the specified test.\n");
-    fprintf(stderr, "  -s nnn         Run stress for nnn minutes.\n");
-    fprintf(stderr, "  -f nnn         Run fuzz for nnn minutes.\n");
-    fprintf(stderr, "  -n             Disable debug prints.\n");
-    fprintf(stderr, "  -h             Print this help message\n");
+    fprintf(stderr, "  -x test           Do not run the specified test.\n");
+    fprintf(stderr, "  -s nnn            Run stress for nnn minutes.\n");
+    fprintf(stderr, "  -f nnn            Run fuzz for nnn minutes.\n");
+    fprintf(stderr, "  -n                Disable debug prints.\n");
+    fprintf(stderr, "  -h                Print this help message\n");
+    fprintf(stderr, "  -S solution_dir   Set the path to the source files to find the default files\n");
 
     return -1;
 }
@@ -233,7 +234,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        while (ret == 0 && (opt = getopt(argc, argv, "f:s:x:nh")) != -1) {
+        while (ret == 0 && (opt = getopt(argc, argv, "f:s:S:x:nh")) != -1) {
             switch (opt) {
             case 'x': {
                 int test_number = get_test_number(optarg);
@@ -263,6 +264,9 @@ int main(int argc, char** argv)
                     fprintf(stderr, "Incorrect stress minutes: %s\n", optarg);
                     ret = usage(argv[0]);
                 }
+                break;
+            case 'S':
+                picoquic_test_set_solution_dir(optarg);
                 break;
             case 'n':
                 disable_debug = 1;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -19,11 +19,11 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #ifdef _WINDOWS
-#include "picoquicfirst/getopt.h"
+#include "getopt.h"
 #endif
-#include "picoquic/picoquic.h"
-#include "picoquic/util.h"
-#include "picoquictest/picoquictest.h"
+#include "picoquic.h"
+#include "util.h"
+#include "picoquictest.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/picoquic_t/picoquic_t.vcxproj
+++ b/picoquic_t/picoquic_t.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picoquictest;$(SolutionDir)\picoquicfirst;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,7 +104,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picoquictest;$(SolutionDir)\picoquicfirst;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -121,7 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picoquictest;$(SolutionDir)\picoquicfirst;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -140,7 +140,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picoquictest;$(SolutionDir)\picoquicfirst;</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/picoquic_t/picoquic_t.vcxproj
+++ b/picoquic_t/picoquic_t.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,7 +104,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -121,6 +121,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -139,6 +140,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -104,10 +104,10 @@ static const char* ticket_store_filename = "demo_ticket_store.bin";
 
 static const char* bad_request_message = "<html><head><title>Bad Request</title></head><body>Bad request. Why don't you try \"GET /doc-456789.html\"?</body></html>";
 
-#include "../picoquic/picoquic.h"
-#include "../picoquic/picoquic_internal.h"
-#include "../picoquic/picosocks.h"
-#include "../picoquic/util.h"
+#include "picoquic/picoquic.h"
+#include "picoquic/picoquic_internal.h"
+#include "picoquic/picosocks.h"
+#include "picoquic/util.h"
 
 void print_address(struct sockaddr* address, char* label, picoquic_connection_id_t cnx_id)
 {
@@ -149,16 +149,24 @@ static void picoquic_set_key_log_file_from_env(picoquic_quic_t* quic)
     const char* keylog_filename;
     FILE* F = NULL;
 
+#ifdef _WINDOWS
+    size_t len;
+    errno_t err = _dupenv_s(&keylog_filename, &len, "SSLKEYLOGFILE");
+
+    if (err == 0) {
+        err = fopen_s(&F, keylog_filename, "a");
+
+        free(keylog_filename);
+
+        if (err != 0 || F == NULL) {
+            return;
+        }
+    }
+#else
     keylog_filename = getenv("SSLKEYLOGFILE");
     if (keylog_filename == NULL) {
         return;
     }
-#ifdef _WINDOWS
-    errno_t err = fopen_s(&F, keylog_filename, "a");
-    if (err != 0 || F == NULL) {
-        return;
-    }
-#else
     F = fopen(keylog_filename, "a");
     if (F == NULL) {
         return;

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -88,8 +88,8 @@
 #define WSA_LAST_ERROR(x) ((long)(x))
 #endif
 
-#define SERVER_KEY_FILE = "certs/cert.pem";
-#define SERVER_KEY_FILE = "certs/key.pem";
+#define SERVER_CERT_FILE = "certs/cert.pem"
+#define SERVER_KEY_FILE = "certs/key.pem"
 
 #endif
 

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -104,10 +104,10 @@ static const char* ticket_store_filename = "demo_ticket_store.bin";
 
 static const char* bad_request_message = "<html><head><title>Bad Request</title></head><body>Bad request. Why don't you try \"GET /doc-456789.html\"?</body></html>";
 
-#include "picoquic/picoquic.h"
-#include "picoquic/picoquic_internal.h"
-#include "picoquic/picosocks.h"
-#include "picoquic/util.h"
+#include "picoquic.h"
+#include "picoquic_internal.h"
+#include "picosocks.h"
+#include "util.h"
 
 void print_address(struct sockaddr* address, char* label, picoquic_connection_id_t cnx_id)
 {

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -88,8 +88,8 @@
 #define WSA_LAST_ERROR(x) ((long)(x))
 #endif
 
-#define SERVER_CERT_FILE = "certs/cert.pem"
-#define SERVER_KEY_FILE = "certs/key.pem"
+#define SERVER_CERT_FILE "certs/cert.pem"
+#define SERVER_KEY_FILE "certs/key.pem"
 
 #endif
 

--- a/picoquicfirst/picoquicfirst.vcxproj
+++ b/picoquicfirst/picoquicfirst.vcxproj
@@ -89,6 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -102,6 +103,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -117,6 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -134,6 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/picoquicfirst/picoquicfirst.vcxproj
+++ b/picoquicfirst/picoquicfirst.vcxproj
@@ -89,7 +89,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -103,7 +103,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -119,7 +119,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,7 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/picoquictest/ack_of_ack_test.c
+++ b/picoquictest/ack_of_ack_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <stdlib.h>
 
 /*

--- a/picoquictest/ack_of_ack_test.c
+++ b/picoquictest/ack_of_ack_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <stdlib.h>
 
 /*

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -20,11 +20,11 @@
 */
 
 #ifdef _WINDOWS
-#include "../picoquic/wincompat.h"
+#include "picoquic/wincompat.h"
 #endif
-#include "../picoquic/picoquic_internal.h"
-#include "../picoquic/tls_api.h"
-#include "../picoquic/util.h"
+#include "picoquic/picoquic_internal.h"
+#include "picoquic/tls_api.h"
+#include "picoquic/util.h"
 #include "picotls.h"
 #include "picotls/openssl.h"
 #include "picotls/minicrypto.h"

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -20,11 +20,11 @@
 */
 
 #ifdef _WINDOWS
-#include "picoquic/wincompat.h"
+#include "wincompat.h"
 #endif
-#include "picoquic/picoquic_internal.h"
-#include "picoquic/tls_api.h"
-#include "picoquic/util.h"
+#include "picoquic_internal.h"
+#include "tls_api.h"
+#include "util.h"
 #include "picotls.h"
 #include "picotls/openssl.h"
 #include "picotls/minicrypto.h"

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -86,14 +86,37 @@ int cleartext_aead_test()
     struct sockaddr_in test_addr_c, test_addr_s;
     picoquic_cnx_t* cnx_client = NULL;
     picoquic_cnx_t* cnx_server = NULL;
-    picoquic_quic_t* qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
-        NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    picoquic_quic_t* qserver = picoquic_create(8,
-        PICOQUIC_TEST_SERVER_CERT, PICOQUIC_TEST_SERVER_KEY, PICOQUIC_TEST_CERT_STORE,
-        "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (qclient == NULL || qserver == NULL) {
-        DBG_PRINTF("%s", "Could not create Quic contexts.\n");
-        ret = -1;
+    picoquic_quic_t* qclient = NULL;
+    picoquic_quic_t* qserver = NULL;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+    char test_server_cert_store_file[512];
+
+    ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT);
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY);
+    }
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_cert_store_file, sizeof(test_server_cert_store_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_CERT_STORE);
+    }
+
+    if (ret != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert, key or store file names.\n");
+    }
+    else {
+
+        qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
+            NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        qserver = picoquic_create(8,
+            test_server_cert_file, test_server_key_file, test_server_cert_store_file,
+            "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+
+        if (qclient == NULL || qserver == NULL) {
+            DBG_PRINTF("%s", "Could not create Quic contexts.\n");
+            ret = -1;
+        }
     }
 
     if (ret == 0) {
@@ -414,22 +437,29 @@ int cleartext_pn_enc_test()
     struct sockaddr_in test_addr_c, test_addr_s;
     picoquic_cnx_t* cnx_client = NULL;
     picoquic_cnx_t* cnx_server = NULL;
-    picoquic_quic_t* qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
-        NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    picoquic_quic_t* qserver = picoquic_create(8,
-#ifdef _WINDOWS
-#ifdef _WINDOWS64
-        "..\\..\\certs\\cert.pem", "..\\..\\certs\\key.pem",
-#else
-        "..\\certs\\cert.pem", "..\\certs\\key.pem",
-#endif
-#else
-        "certs/cert.pem", "certs/key.pem",
-#endif
-        NULL, "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (qclient == NULL || qserver == NULL) {
-        DBG_PRINTF("%s", "Could not create Quic contexts.\n");
-        ret = -1;
+    picoquic_quic_t* qclient = NULL;
+    picoquic_quic_t* qserver = NULL;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+
+    ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT);
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY);
+    }
+
+    if (ret != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert or key file names.\n");
+    }
+    else {
+        qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
+            NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        qserver = picoquic_create(8, test_server_cert_file, test_server_key_file,
+            NULL, "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        if (qclient == NULL || qserver == NULL) {
+            DBG_PRINTF("%s", "Could not create Quic contexts.\n");
+            ret = -1;
+        }
     }
 
     if (ret == 0) {
@@ -522,20 +552,26 @@ int cleartext_pn_vector_test()
     struct sockaddr_in test_addr_s;
     picoquic_connection_id_t initial_cnxid;
     picoquic_cnx_t* cnx_server = NULL;
-    picoquic_quic_t* qserver = picoquic_create(8,
-#ifdef _WINDOWS
-#ifdef _WINDOWS64
-        "..\\..\\certs\\cert.pem", "..\\..\\certs\\key.pem",
-#else
-        "..\\certs\\cert.pem", "..\\certs\\key.pem",
-#endif
-#else
-        "certs/cert.pem", "certs/key.pem",
-#endif
-        NULL, "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (qserver == NULL) {
-        DBG_PRINTF("%s", "Could not create Quic contexts.\n");
-        ret = -1;
+    picoquic_quic_t* qserver = NULL;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+
+    ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT);
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY);
+    }
+
+    if (ret != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert or key file names.\n");
+    }
+    else {
+        qserver = picoquic_create(8, test_server_cert_file, test_server_key_file,
+            NULL, "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        if (qserver == NULL) {
+            DBG_PRINTF("%s", "Could not create Quic contexts.\n");
+            ret = -1;
+        }
     }
 
     if (ret == 0 && picoquic_parse_connection_id(cid, sizeof(cid), &initial_cnxid) != sizeof(cid)) {

--- a/picoquictest/cnx_creation_test.c
+++ b/picoquictest/cnx_creation_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <stdlib.h>
 #ifdef _WINDOWS
 #include <malloc.h>

--- a/picoquictest/cnx_creation_test.c
+++ b/picoquictest/cnx_creation_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <stdlib.h>
 #ifdef _WINDOWS
 #include <malloc.h>

--- a/picoquictest/float16test.c
+++ b/picoquictest/float16test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 
 /*
 * Float16 format required for encoding the time deltas in current QUIC draft.

--- a/picoquictest/float16test.c
+++ b/picoquictest/float16test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 
 /*
 * Float16 format required for encoding the time deltas in current QUIC draft.

--- a/picoquictest/fnv1atest.c
+++ b/picoquictest/fnv1atest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/fnv1a.h"
+#include "fnv1a.h"
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/picoquictest/fnv1atest.c
+++ b/picoquictest/fnv1atest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/fnv1a.h"
+#include "picoquic/fnv1a.h"
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/picoquictest/hashtest.c
+++ b/picoquictest/hashtest.c
@@ -23,7 +23,7 @@
 #ifdef _WINDOWS
 #include <malloc.h>
 #endif
-#include "picoquic/picohash.h"
+#include "picohash.h"
 
 struct hashtestkey {
     uint64_t x;

--- a/picoquictest/hashtest.c
+++ b/picoquictest/hashtest.c
@@ -23,7 +23,7 @@
 #ifdef _WINDOWS
 #include <malloc.h>
 #endif
-#include "../picoquic/picohash.h"
+#include "picoquic/picohash.h"
 
 struct hashtestkey {
     uint64_t x;

--- a/picoquictest/intformattest.c
+++ b/picoquictest/intformattest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <string.h>
 
 static const uint64_t test_number[] = {

--- a/picoquictest/intformattest.c
+++ b/picoquictest/intformattest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <string.h>
 
 static const uint64_t test_number[] = {

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -21,8 +21,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include "../picoquic/tls_api.h"
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/tls_api.h"
+#include "picoquic/picoquic_internal.h"
 #include "picoquictest_internal.h"
 
 /* test vectors and corresponding structure */

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -21,8 +21,8 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include "picoquic/tls_api.h"
-#include "picoquic/picoquic_internal.h"
+#include "tls_api.h"
+#include "picoquic_internal.h"
 #include "picoquictest_internal.h"
 
 /* test vectors and corresponding structure */

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -578,14 +578,35 @@ int packet_enc_dec_test()
     struct sockaddr_in test_addr_c;
     picoquic_cnx_t* cnx_client = NULL;
     picoquic_cnx_t* cnx_server = NULL;
-    picoquic_quic_t* qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
-        NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    picoquic_quic_t* qserver = picoquic_create(8,
-        PICOQUIC_TEST_SERVER_CERT, PICOQUIC_TEST_SERVER_KEY, PICOQUIC_TEST_CERT_STORE, 
-        "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
-    if (qclient == NULL || qserver == NULL) {
-        DBG_PRINTF("%s", "Could not create Quic contexts.\n");
-        ret = -1;
+    picoquic_quic_t* qclient = NULL;
+    picoquic_quic_t* qserver = NULL;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+    char test_server_cert_store_file[512];
+
+    ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT);
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY);
+    }
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_cert_store_file, sizeof(test_server_cert_store_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_CERT_STORE);
+    }
+
+    if (ret != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert, key or store file names.\n");
+    }
+    else {
+        qclient = picoquic_create(8, NULL, NULL, NULL, NULL, NULL, NULL,
+            NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        qserver = picoquic_create(8,
+            test_server_cert_file, test_server_key_file, test_server_cert_store_file,
+            "test", NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, 0);
+        if (qclient == NULL || qserver == NULL) {
+            DBG_PRINTF("%s", "Could not create Quic contexts.\n");
+            ret = -1;
+        }
     }
 
     if (ret == 0) {

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -29,6 +29,9 @@ extern "C" {
 /* From picoquic/util.h */
 void debug_printf_suspend();
 
+/* Setting the solution dir when not executing from default location */
+void picoquic_test_set_solution_dir(char const * solution_dir);
+
 /* Control variables for the duration of the stress test */
 
 extern uint64_t picoquic_stress_test_duration; /* In microseconds; defaults to 2 minutes */

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -78,7 +78,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -91,7 +91,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -106,7 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,7 +123,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -78,7 +78,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -91,7 +91,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -106,7 +106,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(OPENSSLDIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -123,7 +123,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir);$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -22,7 +22,7 @@
 #ifndef PICOQUICTEST_INTERNAL_H
 #define PICOQUICTEST_INTERNAL_H
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -22,7 +22,7 @@
 #ifndef PICOQUICTEST_INTERNAL_H
 #define PICOQUICTEST_INTERNAL_H
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -35,23 +35,19 @@ extern "C" {
 #define PICOQUIC_TEST_ALPN "picoquic-test"
 
 #ifdef _WINDOWS
-#ifdef _WINDOWS64
-#define PICOQUIC_TEST_SERVER_CERT "..\\..\\certs\\cert.pem"
-#define PICOQUIC_TEST_SERVER_BAD_CERT "..\\..\\certs\\badcert.pem"
-#define PICOQUIC_TEST_SERVER_KEY "..\\..\\certs\\key.pem"
-#define PICOQUIC_TEST_CERT_STORE "..\\..\\certs\\test-ca.crt"
+#define PICOQUIC_TEST_FILE_SERVER_CERT "certs\\cert.pem"
+#define PICOQUIC_TEST_FILE_SERVER_BAD_CERT "certs\\badcert.pem"
+#define PICOQUIC_TEST_FILE_SERVER_KEY "certs\\key.pem"
+#define PICOQUIC_TEST_FILE_CERT_STORE "certs\\test-ca.crt"
 #else
-#define PICOQUIC_TEST_SERVER_CERT "..\\certs\\cert.pem"
-#define PICOQUIC_TEST_SERVER_BAD_CERT "..\\certs\\badcert.pem"
-#define PICOQUIC_TEST_SERVER_KEY "..\\certs\\key.pem"
-#define PICOQUIC_TEST_CERT_STORE "..\\certs\\test-ca.crt"
+#define PICOQUIC_TEST_FILE_SERVER_CERT "certs/cert.pem"
+#define PICOQUIC_TEST_FILE_SERVER_BAD_CERT "certs/badcert.pem"
+#define PICOQUIC_TEST_FILE_SERVER_KEY "certs/key.pem"
+#define PICOQUIC_TEST_FILE_CERT_STORE "certs/test-ca.crt"
 #endif
-#else
-#define PICOQUIC_TEST_SERVER_CERT "certs/cert.pem"
-#define PICOQUIC_TEST_SERVER_BAD_CERT "certs/badcert.pem"
-#define PICOQUIC_TEST_SERVER_KEY "certs/key.pem"
-#define PICOQUIC_TEST_CERT_STORE "certs/test-ca.crt"
-#endif
+
+ /* To set the solution directory for tests */
+extern char const * picoquic_test_solution_dir;
 
 /* Really basic network simulator, only simulates a simple link using a
  * packet structure.

--- a/picoquictest/pn2pn64test.c
+++ b/picoquictest/pn2pn64test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <stdlib.h>
 
 struct _pn2pn64test_entry {

--- a/picoquictest/pn2pn64test.c
+++ b/picoquictest/pn2pn64test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <stdlib.h>
 
 struct _pn2pn64test_entry {

--- a/picoquictest/sacktest.c
+++ b/picoquictest/sacktest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/picoquictest/sacktest.c
+++ b/picoquictest/sacktest.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/picoquictest/sim_link.c
+++ b/picoquictest/sim_link.c
@@ -29,7 +29,7 @@
  * Get packet out of link at time T + L + Queue.
  */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include "picoquictest_internal.h"
 #include <stdlib.h>
 

--- a/picoquictest/sim_link.c
+++ b/picoquictest/sim_link.c
@@ -29,7 +29,7 @@
  * Get packet out of link at time T + L + Queue.
  */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include "picoquictest_internal.h"
 #include <stdlib.h>
 

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/tls_api.h"
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/tls_api.h"
+#include "picoquic/picoquic_internal.h"
 #include "picoquictest_internal.h"
 #include <stdlib.h>
 #include <string.h>

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -459,13 +459,9 @@ static char const* log_fuzz_test_file = "log_fuzz_test.txt";
 static char const* log_packet_test_file = "log_fuzz_test.txt";
 
 #ifdef _WINDOWS
-#ifndef _WINDOWS64
-static char const* log_test_ref = "..\\picoquictest\\log_test_ref.txt";
+#define LOG_TEST_REF "picoquictest\\log_test_ref.txt"
 #else
-static char const* log_test_ref = "..\\..\\picoquictest\\log_test_ref.txt";
-#endif
-#else
-static char const* log_test_ref = "picoquictest/log_test_ref.txt";
+#define LOG_TEST_REF "picoquictest/log_test_ref.txt"
 #endif
 
 static int compare_lines(char const* b1, char const* b2)
@@ -587,7 +583,16 @@ int logger_test()
     F = NULL;
 
     if (ret == 0) {
-        ret = picoquic_test_compare_files(log_test_file, log_test_ref);
+        char log_test_ref[512];
+
+        ret = picoquic_get_input_path(log_test_ref, sizeof(log_test_ref), picoquic_test_solution_dir, LOG_TEST_REF);
+
+        if (ret != 0) {
+            DBG_PRINTF("%s", "Cannot set the log ref file name.\n");
+        }
+        else {
+            ret = picoquic_test_compare_files(log_test_file, log_test_ref);
+        }
     }
 
     /* Create a set of randomized packets. Verify that they can be logged without 

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/tls_api.h"
-#include "picoquic/picoquic_internal.h"
+#include "tls_api.h"
+#include "picoquic_internal.h"
 #include "picoquictest_internal.h"
 #include <stdlib.h>
 #include <string.h>

--- a/picoquictest/socket_test.c
+++ b/picoquictest/socket_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picosocks.h"
-#include "../picoquic/util.h"
+#include "picoquic/picosocks.h"
+#include "picoquic/util.h"
 
 static int socket_ping_pong(SOCKET_TYPE fd, struct sockaddr* server_addr, int server_address_length,
     picoquic_server_sockets_t* server_sockets)

--- a/picoquictest/socket_test.c
+++ b/picoquictest/socket_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picosocks.h"
-#include "picoquic/util.h"
+#include "picosocks.h"
+#include "util.h"
 
 static int socket_ping_pong(SOCKET_TYPE fd, struct sockaddr* server_addr, int server_address_length,
     picoquic_server_sockets_t* server_sockets)

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -24,8 +24,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "../picoquic/util.h"
-#include "../picoquic/picosplay.h"
+#include "picoquic/util.h"
+#include "picoquic/picosplay.h"
 
 static int compare_int(void *l, void *r) {
     return *((int*)l) - *((int*)r);

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -24,8 +24,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "picoquic/util.h"
-#include "picoquic/picosplay.h"
+#include "util.h"
+#include "picosplay.h"
 
 static int compare_int(void *l, void *r) {
     return *((int*)l) - *((int*)r);

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 
 /*
  * Testing Arrival of Frame for Stream Zero

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 
 /*
  * Testing Arrival of Frame for Stream Zero

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
-#include "../picoquic/tls_api.h"
+#include "picoquic/picoquic_internal.h"
+#include "picoquic/tls_api.h"
 #include "picoquictest_internal.h"
 #ifdef _WINDOWS
 #include "..\picoquic\wincompat.h"

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
-#include "picoquic/tls_api.h"
+#include "picoquic_internal.h"
+#include "tls_api.h"
 #include "picoquictest_internal.h"
 #ifdef _WINDOWS
 #include "..\picoquic\wincompat.h"

--- a/picoquictest/ticket_store_test.c
+++ b/picoquictest/ticket_store_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
+#include "picoquic/picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/picoquictest/ticket_store_test.c
+++ b/picoquictest/ticket_store_test.c
@@ -19,7 +19,7 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
+#include "picoquic_internal.h"
 #include <stdlib.h>
 #include <string.h>
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "../picoquic/picoquic_internal.h"
-#include "../picoquic/tls_api.h"
+#include "picoquic/picoquic_internal.h"
+#include "picoquic/tls_api.h"
 #include "picoquictest_internal.h"
 #ifdef _WINDOWS
 #include "..\picoquic\wincompat.h"

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -19,8 +19,8 @@
 * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include "picoquic/picoquic_internal.h"
-#include "picoquic/tls_api.h"
+#include "picoquic_internal.h"
+#include "tls_api.h"
 #include "picoquictest_internal.h"
 #ifdef _WINDOWS
 #include "..\picoquic\wincompat.h"

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1266,7 +1266,6 @@ int tls_api_one_scenario_init(
     uint32_t proposed_version,
     picoquic_tp_t * client_params, picoquic_tp_t * server_params)
 {
-    uint64_t loss_mask = 0;
     int ret = tls_api_init_ctx(p_test_ctx,
         (proposed_version == 0) ? PICOQUIC_INTERNAL_TEST_VERSION_1 : proposed_version,
         PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, simulated_time, NULL, 0, 1, 0);

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -22,9 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "picoquic/picoquic_internal.h"
-#include "picoquic/util.h"
-#include "picoquic/tls_api.h"
+#include "picoquic_internal.h"
+#include "util.h"
+#include "tls_api.h"
 #include "picoquictest_internal.h"
 
 /* The transport parameter tests operate by comparing the decoding of test vectors

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -463,23 +463,45 @@ int transport_param_set_contexts(picoquic_quic_t ** quic_ctx, picoquic_cnx_t ** 
     picoquic_connection_id_t initial_cnx_id = { { 1, 2, 3, 4, 5, 6, 7, 8, 0, 0, 0, 0, 0, 0, 0, 0 }, 8 };
     picoquic_connection_id_t remote_cnx_id = { { 0, 1, 2, 3, 4, 5, 6, 7,  0, 0, 0, 0, 0, 0, 0, 0 }, 8 };
     struct sockaddr_in addr;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+    char test_server_cert_store_file[512];
 
-    memset(&addr, 0, sizeof(struct sockaddr_in));
-    addr.sin_family = AF_INET;
-
+    *quic_ctx = NULL;
     *test_cnx = NULL;
-    *quic_ctx = picoquic_create(8,
-        PICOQUIC_TEST_SERVER_CERT, PICOQUIC_TEST_SERVER_KEY, PICOQUIC_TEST_CERT_STORE,
-        PICOQUIC_TEST_ALPN, NULL, NULL, NULL, NULL, NULL,
-        *p_simulated_time, p_simulated_time, NULL, NULL, 1);
 
-    if (*quic_ctx != NULL) {
-        *test_cnx = picoquic_create_cnx(*quic_ctx, initial_cnx_id, remote_cnx_id,
-            (struct sockaddr*) &addr, 0, 0, "sni", "alpn", (mode==0)?1:0);
+    ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT);
+
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY);
     }
 
-    if (*quic_ctx == NULL || *test_cnx == NULL) {
-        ret = -1;
+    if (ret == 0) {
+        ret = picoquic_get_input_path(test_server_cert_store_file, sizeof(test_server_cert_store_file), picoquic_test_solution_dir, PICOQUIC_TEST_FILE_CERT_STORE);
+    }
+
+    if (ret != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert, key or store file names.\n");
+    }
+    else {
+
+        memset(&addr, 0, sizeof(struct sockaddr_in));
+        addr.sin_family = AF_INET;
+
+        *quic_ctx = picoquic_create(8,
+            test_server_cert_file, test_server_key_file, test_server_cert_store_file,
+            PICOQUIC_TEST_ALPN, NULL, NULL, NULL, NULL, NULL,
+            *p_simulated_time, p_simulated_time, NULL, NULL, 1);
+
+
+        if (*quic_ctx != NULL) {
+            *test_cnx = picoquic_create_cnx(*quic_ctx, initial_cnx_id, remote_cnx_id,
+                (struct sockaddr*) &addr, 0, 0, "sni", "alpn", (mode == 0) ? 1 : 0);
+        }
+
+        if (*quic_ctx == NULL || *test_cnx == NULL) {
+            ret = -1;
+        }
     }
 
     return ret;
@@ -839,13 +861,9 @@ static char const* log_tp_test_file = "log_tp_test.txt";
 static char const* log_tp_fuzz_file = "log_tp_fuzz_test.txt";
 
 #ifdef _WINDOWS
-#ifndef _WINDOWS64
-static char const* log_tp_test_ref = "..\\picoquictest\\log_tp_test_ref.txt";
+#define LOG_TP_TEST_REF "picoquictest\\log_tp_test_ref.txt"
 #else
-static char const* log_tp_test_ref = "..\\..\\picoquictest\\log_tp_test_ref.txt";
-#endif
-#else
-static char const* log_tp_test_ref = "picoquictest/log_tp_test_ref.txt";
+#define LOG_TP_TEST_REF "picoquictest/log_tp_test_ref.txt"
 #endif
 
 void picoquic_log_transport_extension_content(FILE* F, int log_cnxid, uint64_t cnx_id_64,
@@ -952,7 +970,15 @@ int transport_param_log_test()
 
     if (ret == 0)
     {
-        ret = picoquic_test_compare_files(log_tp_test_file, log_tp_test_ref);
+        char log_tp_test_ref[512];
+
+        ret = picoquic_get_input_path(log_tp_test_ref, sizeof(log_tp_test_ref), picoquic_test_solution_dir, LOG_TP_TEST_REF);
+
+        if (ret != 0) {
+            DBG_PRINTF("%s", "Cannot set the log TP ref file name.\n");
+        } else {
+            ret = picoquic_test_compare_files(log_tp_test_file, log_tp_test_ref);
+        }
     }
 
     if (ret == 0)

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -22,9 +22,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../picoquic/picoquic_internal.h"
-#include "../picoquic/util.h"
-#include "../picoquic/tls_api.h"
+#include "picoquic/picoquic_internal.h"
+#include "picoquic/util.h"
+#include "picoquic/tls_api.h"
 #include "picoquictest_internal.h"
 
 /* The transport parameter tests operate by comparing the decoding of test vectors


### PR DESCRIPTION
Addressing some of the comments in issue #310, use of relative paths in include files.