### PR TITLE
Check addresses of probes and responses

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -749,9 +749,9 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
-        TEST_METHOD(migration_stress)
+        TEST_METHOD(rebinding_stress)
         {
-            int ret = migration_stress_test();
+            int ret = rebinding_stress_test();
 
             Assert::AreEqual(ret, 0);
         }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1370,6 +1370,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header * ph
                     if (current_time > cnx->path[path_id]->alt_challenge_timeout) {
                         cnx->path[path_id]->alt_challenge_timeout = 0;
                         cnx->path[path_id]->alt_challenge_required = 1;
+                        cnx->path[path_id]->alt_challenge_repeat_count = 0;
                     }
                 }
                 else if (((cnx->path[path_id]->alt_peer_addr_len == 0 &&
@@ -1384,6 +1385,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header * ph
                     cnx->path[path_id]->alt_challenge = picoquic_public_random_64();
                     cnx->path[path_id]->alt_challenge_required = 1;
                     cnx->path[path_id]->alt_challenge_timeout = 0;
+                    cnx->path[path_id]->alt_challenge_repeat_count = 0;
                     /* Require a new challenge on the normal path */
                     new_challenge_required = 1;
                 }

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -487,9 +487,10 @@ typedef struct st_picoquic_path_t {
     int alt_local_addr_len;
     unsigned long alt_if_index_dest;
     /* Challenge used for the NAT rebinding tests */
+    uint64_t alt_challenge_response;
     uint64_t alt_challenge;
     uint64_t alt_challenge_timeout;
-    uint64_t alt_challenge_response;
+    uint8_t alt_challenge_repeat_count;
 
 #define PICOQUIC_CHALLENGE_REPEAT_MAX 4
     /* flags */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -141,6 +141,12 @@ static uint8_t picoquic_cleartext_draft_10_salt[] = {
     0xe0, 0x6d, 0x6c, 0x38
 };
 
+static uint8_t picoquic_cleartext_draft_17_salt[] = {
+     0xef, 0x4f, 0xb0, 0xab, 0xb4, 0x74, 0x70, 0xc4,
+     0x1b, 0xef, 0xcf, 0x80, 0x31, 0x33, 0x4f, 0xae,
+     0x48, 0x5e, 0x09, 0xa0
+};
+
 /* Support for draft 13! */
 const picoquic_version_parameters_t picoquic_supported_versions[] = {
     { PICOQUIC_INTERNAL_TEST_VERSION_2,
@@ -156,8 +162,8 @@ const picoquic_version_parameters_t picoquic_supported_versions[] = {
     { PICOQUIC_TENTH_INTEROP_VERSION,
         picoquic_version_header_17,
         picoquic_spinbit_basic,
-        sizeof(picoquic_cleartext_draft_10_salt),
-        picoquic_cleartext_draft_10_salt }
+        sizeof(picoquic_cleartext_draft_17_salt),
+        picoquic_cleartext_draft_17_salt }
 };
 
 const size_t picoquic_nb_supported_versions = sizeof(picoquic_supported_versions) / sizeof(picoquic_version_parameters_t);

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -768,14 +768,12 @@ int picoquic_setup_initial_secrets(
 
     /* Get the client secret */
     ret = ptls_hkdf_expand_label(cipher->hash, client_secret, cipher->hash->digest_size,
-        prk, PICOQUIC_LABEL_INITIAL_CLIENT, ptls_iovec_init(NULL, 0),
-        PICOQUIC_LABEL_QUIC_BASE);
+        prk, PICOQUIC_LABEL_INITIAL_CLIENT, ptls_iovec_init(NULL, 0), NULL);
 
     if (ret == 0) {
         /* Get the server secret */
         ret = ptls_hkdf_expand_label(cipher->hash, server_secret, cipher->hash->digest_size,
-            prk, PICOQUIC_LABEL_INITIAL_SERVER, ptls_iovec_init(NULL, 0),
-            PICOQUIC_LABEL_QUIC_BASE);
+            prk, PICOQUIC_LABEL_INITIAL_SERVER, ptls_iovec_init(NULL, 0), NULL);
     }
 
     return ret;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -143,7 +143,7 @@ static const picoquic_test_def_t test_table[] = {
     { "stream_id_max", stream_id_max_test },
     { "padding_test", padding_test },
     { "packet_trace", packet_trace_test },
-    { "migration_stress", migration_stress_test },
+    { "rebiding_stress", rebinding_stress_test },
     { "stress", stress_test },
     { "fuzz", fuzz_test },
     { "fuzz_initial", fuzz_initial_test}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -144,7 +144,7 @@ int stream_id_max_test();
 int stream_id_to_rank_test();
 int padding_test();
 int packet_trace_test();
-int migration_stress_test();
+int rebinding_stress_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3820,7 +3820,7 @@ int migration_test_loss()
  * The goal of the attack is to verify that the connection resists.
  */
 
-int migration_stress_test()
+int rebinding_stress_test()
 {
     int nb_trials = 0;
     const int max_trials = 10000;


### PR DESCRIPTION
This PR addresses issue #446 and implements the address checks required in draft-17. A challenge response is only accepted if it comes from exactly the same addresses to which the challenge was sent. Responses to NAT rebinding are similarly processed. The NAT rebinding stress test succeeds even in presence of a concerted attack rewriting the addresses of 1/2 the packets.