### PR TITLE
Travis: add cppcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - echo $CC
   - echo $CXX
   - ${EXTRA} cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
-  - if [ "$CHECK" == "cppcheck" ]; then cppcheck --project=compile_commands.json; fi
+  - if [ "$CHECK" == "cppcheck" ]; then cppcheck --project=compile_commands.json --quiet; fi
   - ${EXTRA} make
   - ulimit -c unlimited -S
   - ./picoquic_ct -n && RESULT=$?

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
     - cmake-data
     - libssl-dev 
     - gdb
-    - cppcheck
 matrix:
     include:
         - name: Linux (gcc-8)
@@ -44,6 +43,7 @@ before_install:
 before_script:
   # First build external lib
   - ./ci/build_picotls.sh
+  - if [ "$CHECK" == "cppcheck" ]; then ./ci/build_cppcheck.sh; fi
   - sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
 script:
   # Now build picotls examples and test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
     - cmake-data
     - libssl-dev 
     - gdb
+    - cppcheck
 matrix:
     include:
         - name: Linux (gcc-8)
@@ -33,6 +34,11 @@ matrix:
               - CC=/usr/local/clang/libexec/ccc-analyzer
               - CXX=/usr/local/clang/libexec/c++-analyzer
               - EXTRA="scan-build"
+        - name: Linux (cppcheck)
+          os: linux
+          dist: xenial
+          env:
+              - CHECK="cppcheck"
 before_install:
   - cmake --version
 before_script:
@@ -43,7 +49,8 @@ script:
   # Now build picotls examples and test
   - echo $CC
   - echo $CXX
-  - ${EXTRA} cmake .
+  - ${EXTRA} cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+  - if [ "$CHECK" == "cppcheck" ]; then cppcheck --project=compile_commands.json; fi
   - ${EXTRA} make
   - ulimit -c unlimited -S
   - ./picoquic_ct -n && RESULT=$?

--- a/ci/build_cppcheck.sh
+++ b/ci/build_cppcheck.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+#build last cppcheck 1.84 (for Travis)
+
+cd ..
+git clone https://github.com/danmar/cppcheck.git
+cd cppcheck
+git checkout Cppcheck
+cmake .
+make -j$(nproc) all
+sudo make install
+cd ..

--- a/ci/build_cppcheck.sh
+++ b/ci/build_cppcheck.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
-#build last cppcheck 1.84 (for Travis)
+#build last cppcheck 1.86 (for Travis)
 
 cd ..
-git clone https://github.com/danmar/cppcheck.git
+git clone -b "1.86" --depth 1 https://github.com/danmar/cppcheck.git
 cd cppcheck
-git checkout Cppcheck
 cmake .
 make -j$(nproc) all
 sudo make install


### PR DESCRIPTION
add new job cppcheck (1.84)

found actually 2 "issue"
[picoquic/picosocks.c:541]: (error) failed to expand 'DBG_PRINTF', it is invalid to use a preprocessor directive as macro parameter
Look a issue with copy/paste (from vim ?) on commit 34243d67
[picoquic/picoquic/sender.c:252*]: (error) Address of local auto-variable assigned to a function parameter.
get 5 time this warning
