### PR TITLE
Ensure spin on one eight of connections

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1494,7 +1494,7 @@ int picoquic_incoming_encrypted(
             if (ret == 0) {
                 picoquic_path_t * path_x = cnx->path[path_id];
 
-                picoquic_spin_function_table[picoquic_supported_versions[cnx->version_index].spinbit_version].spinbit_incoming(cnx, path_x, ph);
+                picoquic_spin_function_table[cnx->spin_policy].spinbit_incoming(cnx, path_x, ph);
                 /* Accept the incoming frames */
                 ret = picoquic_decode_frames(cnx, cnx->path[path_id], 
                     bytes + ph->offset, ph->payload_length, ph->epoch, addr_from, addr_to, current_time);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -157,6 +157,12 @@ typedef enum {
     picoquic_nb_packet_context = 3
 } picoquic_packet_context_enum;
 
+typedef enum {
+    picoquic_spinbit_basic = 0, /* default spin bit behavior, as specified in spin bit draft */
+    picoquic_spinbit_random = 1, /* alternative spin bit behavior, randomized for each packet */
+    picoquic_spinbit_null = 2 /* null behavior, randomized per path */
+} picoquic_spinbit_version_enum;
+
 /*
  * Provisional definition of the connection ID.
  */
@@ -357,6 +363,9 @@ void picoquic_set_client_authentication(picoquic_quic_t* quic, int client_authen
 /* Set default padding policy for the context */
 void picoquic_set_default_padding(picoquic_quic_t* quic, uint32_t padding_multiple, uint32_t padding_minsize);
 
+/* Set default spin bit policy for the context */
+void picoquic_set_default_spinbit_policy(picoquic_quic_t * quic, picoquic_spinbit_version_enum default_spinbit_policy);
+
 /* Connection context creation and registration */
 picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
     picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
@@ -391,6 +400,8 @@ picoquic_state_enum picoquic_get_cnx_state(picoquic_cnx_t* cnx);
 
 void picoquic_cnx_set_padding_policy(picoquic_cnx_t * cnx, uint32_t padding_multiple, uint32_t padding_minsize);
 void picoquic_cnx_get_padding_policy(picoquic_cnx_t * cnx, uint32_t * padding_multiple, uint32_t * padding_minsize);
+/* Set spin bit policy for the connection */
+void picoquic_cnx_set_spinbit_policy(picoquic_cnx_t * cnx, picoquic_spinbit_version_enum spinbit_policy);
 
 int picoquic_tls_is_psk_handshake(picoquic_cnx_t* cnx);
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -262,7 +262,7 @@ uint32_t picoquic_create_packet_header(
         uint8_t K = (cnx->key_phase_enc) ? 0x04 : 0;
         const uint8_t C = 0x43; /* default packet length to 4 bytes; set the QUIC bit */
         length = 0;
-        bytes[length++] = (K | C | picoquic_spin_function_table[picoquic_supported_versions[cnx->version_index].spinbit_version].spinbit_outgoing(cnx));
+        bytes[length++] = (K | C | picoquic_spin_function_table[cnx->spin_policy].spinbit_outgoing(cnx));
         length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, dest_cnx_id);
 
         *pn_offset = length;

--- a/picoquic/spinbit.c
+++ b/picoquic/spinbit.c
@@ -31,12 +31,12 @@
  */
 void picoquic_spinbit_basic_incoming(picoquic_cnx_t * cnx, picoquic_path_t * path_x, picoquic_packet_header * ph)
 {
-    path_x->spin_data.s_basic.current_spin = ph->spin ^ cnx->client_mode;
+    path_x->current_spin = ph->spin ^ cnx->client_mode;
 }
 
 uint8_t picoquic_spinbit_basic_outgoing(picoquic_cnx_t * cnx)
 {
-    uint8_t spin_bit = (uint8_t)((cnx->path[0]->spin_data.s_basic.current_spin) << 5);
+    uint8_t spin_bit = (uint8_t)((cnx->path[0]->current_spin) << 5);
 
     return spin_bit;
 }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3129,6 +3129,9 @@ int spin_bit_test()
     if (ret == 0) {
         test_ctx->client_use_nat = 1;
 
+        /* force spinbit policy to basic, then start */
+        test_ctx->cnx_client->spin_policy = picoquic_spinbit_basic;
+
         ret = picoquic_start_client_cnx(test_ctx->cnx_client);
         if (ret != 0)
         {
@@ -3148,6 +3151,9 @@ int spin_bit_test()
 
     /* Prepare to send data */
     if (ret == 0) {
+        /* force the server spin bit policy to basic, then init the scenario */
+        test_ctx->cnx_server->spin_policy = picoquic_spinbit_basic;
+
         ret = test_api_init_send_recv_scenario(test_ctx, test_scenario_very_long, sizeof(test_scenario_very_long));
 
         if (ret != 0)
@@ -3164,7 +3170,7 @@ int spin_bit_test()
         int nb_trials = 0;
         int nb_inactive = 0;
         int max_trials = 100000;
-        int current_spin = test_ctx->cnx_client->path[0]->spin_data.s_basic.current_spin;
+        int current_spin = test_ctx->cnx_client->path[0]->current_spin;
 
         test_ctx->c_to_s_link->loss_mask = &loss_mask;
         test_ctx->s_to_c_link->loss_mask = &loss_mask;
@@ -3181,9 +3187,9 @@ int spin_bit_test()
                 break;
             }
 
-            if (test_ctx->cnx_client->path[0]->spin_data.s_basic.current_spin != current_spin) {
+            if (test_ctx->cnx_client->path[0]->current_spin != current_spin) {
                 spin_count++;
-                current_spin = test_ctx->cnx_client->path[0]->spin_data.s_basic.current_spin;
+                current_spin = test_ctx->cnx_client->path[0]->current_spin;
             }
 
             if (was_active) {


### PR DESCRIPTION
Also, allow setting of preferred spin bit policy per quic context, and per connection.