### PR TITLE
Verify that all incoming cnx_id lengths are supported

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -777,6 +777,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(cid_length)
+        {
+            int ret = cid_length_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(stress)
         {
             int ret = stress_test();

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -420,7 +420,7 @@ void picoquic_log_negotiation_packet(FILE* F, uint64_t log_cnxid64,
 }
 
 void picoquic_log_retry_packet(FILE* F, uint64_t log_cnxid64,
-    uint8_t* bytes, size_t length, picoquic_packet_header* ph)
+    uint8_t* bytes, picoquic_packet_header* ph)
 {
     size_t byte_index = ph->offset;
     int token_length = 0;
@@ -1200,7 +1200,7 @@ void picoquic_log_decrypted_segment(void* F_log, int log_cnxid, picoquic_cnx_t* 
     }
     else if (ph->ptype == picoquic_packet_retry) {
         /* log version negotiation */
-        picoquic_log_retry_packet(F, log_cnxid64, bytes, length, ph);
+        picoquic_log_retry_packet(F, log_cnxid64, bytes, ph);
     }
     else if (ph->ptype != picoquic_packet_error) {
         /* log frames inside packet */

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -75,6 +75,7 @@ extern "C" {
 #define PICOQUIC_ERROR_MIGRATION_DISABLED (PICOQUIC_ERROR_CLASS + 34)
 #define PICOQUIC_ERROR_CANNOT_COMPUTE_KEY (PICOQUIC_ERROR_CLASS + 35)
 #define PICOQUIC_ERROR_CANNOT_SET_ACTIVE_STREAM (PICOQUIC_ERROR_CLASS + 36)
+#define PICOQUIC_ERROR_CANNOT_CHANGE_ACTIVE_CONTEXT (PICOQUIC_ERROR_CLASS + 37)
 
 /*
  * Protocol errors defined in the QUIC spec
@@ -366,6 +367,13 @@ void picoquic_set_default_padding(picoquic_quic_t* quic, uint32_t padding_multip
 
 /* Set default spin bit policy for the context */
 void picoquic_set_default_spinbit_policy(picoquic_quic_t * quic, picoquic_spinbit_version_enum default_spinbit_policy);
+
+/* Set default connection ID length for the context.
+ * All valid values are supported on the client.
+ * Using a null value on the server is not tested, may not work.
+ * Cannot be changed if there are active connections in the context.
+ * Value must be compatible with what the cnx_id_callback() expects on a server */
+int picoquic_set_default_connection_id_length(picoquic_quic_t* quic, uint8_t cid_length);
 
 /* Connection context creation and registration */
 picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1668,6 +1668,25 @@ void picoquic_set_cc_log(picoquic_quic_t * quic, char const * cc_log_dir)
     quic->cc_log_dir = cc_log_dir;
 }
 
+int picoquic_set_default_connection_id_length(picoquic_quic_t* quic, uint8_t cid_length)
+{
+    int ret = 0;
+
+    if (cid_length != quic->local_ctx_length) {
+        if (cid_length != 0 && (cid_length < 4 || cid_length > 18)) {
+            ret = PICOQUIC_ERROR_CNXID_CHECK;
+        }
+        else if (quic->cnx_list != NULL) {
+            ret = PICOQUIC_ERROR_CANNOT_CHANGE_ACTIVE_CONTEXT;
+        }
+        else {
+            quic->local_ctx_length = cid_length;
+        }
+    }
+
+    return ret;
+}
+
 void picoquic_set_callback(picoquic_cnx_t* cnx,
     picoquic_stream_data_cb_fn callback_fn, void* callback_ctx)
 {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -283,7 +283,7 @@ uint32_t picoquic_create_packet_header(
 {
     uint32_t length = 0;
     picoquic_connection_id_t dest_cnx_id =
-        ((packet_type == picoquic_packet_initial ||
+        (cnx->client_mode && (packet_type == picoquic_packet_initial ||
             packet_type == picoquic_packet_0rtt_protected)
             && picoquic_is_connection_id_null(*remote_cnxid)) ?
         cnx->initial_cnxid : *remote_cnxid;
@@ -388,7 +388,7 @@ uint32_t picoquic_predict_packet_header_length(
         header_length = 1 + /* version */ 4 + /* cnx_id prefix */ 1;
 
         /* add dest-id length */
-        if ((packet_type == picoquic_packet_initial ||
+        if (cnx->client_mode && (packet_type == picoquic_packet_initial ||
             packet_type == picoquic_packet_0rtt_protected)
             && picoquic_is_connection_id_null(cnx->path[0]->remote_cnxid)) {
             header_length += cnx->initial_cnxid.id_len;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -147,6 +147,7 @@ static const picoquic_test_def_t test_table[] = {
     { "rebiding_stress", rebinding_stress_test },
     { "ready_to_send", ready_to_send_test },
     { "cubic", cubic_test },
+    { "cid_length", cid_length_test },
     { "stress", stress_test },
     { "fuzz", fuzz_test },
     { "fuzz_initial", fuzz_initial_test}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -148,6 +148,7 @@ int many_short_loss_test();
 int ready_to_send_test();
 int split_stream_frame_test();
 int cubic_test();
+int cid_length_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This is a fix for issue #480. It adds a test for setting connections with a variety of cnx_id lengths, including zero. It also enforces stricter checks on the incoming destination cnx_id. With that change, picoquic clients can set the cnx_id length to any valid length, and picoquic servers can receive connections with any valid source cnx_id length.