### PR TITLE
Demo client only migrates when handshake fully completed

### DIFF
--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -1143,7 +1143,8 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
 
                     client_ready_loop++;
 
-                    if (force_migration && migration_started == 0 && cnx_client->cnxid_stash_first != NULL) {
+                    if (force_migration && migration_started == 0 && cnx_client->cnxid_stash_first != NULL
+                        && picoquic_get_cnx_state(cnx_client) == picoquic_state_ready) {
                         int mig_ret = quic_client_migrate(cnx_client, &fd,
                             (struct sockaddr *)&server_address, force_migration, F_log);
 


### PR DESCRIPTION
Fully completed specifically means that the server has acknowledged at least one of the client's 1-RTT packets. That only happens if the server has received the handshake finished message from the client, and installed the 1-RTT receive key.