### PR TITLE
Send errors on initial packet if handshake not established

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -686,9 +686,16 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
-        TEST_METHOD(test_initial_close)
+        TEST_METHOD(initial_close)
         {
             int ret = initial_close_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
+        TEST_METHOD(initial_server_close)
+        {
+            int ret = initial_server_close_test();
 
             Assert::AreEqual(ret, 0);
         }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1859,7 +1859,8 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
     switch (cnx->cnx_state) {
     case picoquic_state_handshake_failure:
         /* TODO: check whether closing can be requested in "initial" mode */
-        if (cnx->crypto_context[2].aead_encrypt != NULL) {
+        if (cnx->crypto_context[2].aead_encrypt != NULL &&
+            cnx->pkt_ctx[picoquic_packet_context_handshake].first_sack_item.start_of_sack_range != (uint64_t)((int64_t)-1)) {
             pc = picoquic_packet_context_handshake;
             packet_type = picoquic_packet_handshake;
         }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -134,6 +134,7 @@ static const picoquic_test_def_t test_table[] = {
     { "retire_cnxid", retire_cnxid_test },
     { "server_busy", server_busy_test },
     { "initial_close", initial_close_test },
+    { "initial_server_close", initial_server_close_test },
     { "new_rotated_key", new_rotated_key_test },
     { "key_rotation", key_rotation_test },
     { "false_migration", false_migration_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -149,6 +149,7 @@ int ready_to_send_test();
 int split_stream_frame_test();
 int cubic_test();
 int cid_length_test();
+int initial_server_close_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4385,8 +4385,11 @@ int initial_close_test()
         }
 
         if (ret == 0) {
-            if (test_ctx->cnx_server != NULL &&
-                test_ctx->cnx_server->cnx_state != picoquic_state_disconnected) {
+            if (test_ctx->cnx_server != NULL) {
+                DBG_PRINTF("%s", "Server connection deleted, cannot verify error code.\n");
+            }
+            else if (test_ctx->cnx_server->cnx_state != picoquic_state_disconnected ||
+                test_ctx->cnx_server->remote_error != 0xDEAD) {
                 DBG_PRINTF("Server state: %d, remote error: %x\n", test_ctx->cnx_server->cnx_state, test_ctx->cnx_server->remote_error);
                 ret = -1;
             }
@@ -4408,6 +4411,75 @@ int initial_close_test()
 
     return ret;
 }
+
+/*
+ * Check what happens if the server detects an error in the client's initial
+ * message. Verify that the client receives the error code.
+ */
+
+int initial_server_close_test()
+{
+    uint64_t loss_mask = 0;
+    uint64_t simulated_time = 0;
+    int was_active = 0;
+    int nb_trials = 0;
+    int nb_inactive = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    int ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, 0, 0, 0);
+
+    /* Set the connection on the server side, but not on the client side */
+    while (ret == 0 && nb_trials < 32 ) {
+        nb_trials++;
+
+        ret = tls_api_one_sim_round(test_ctx, &simulated_time, 0, &was_active);
+
+        if (test_ctx->cnx_server != NULL && test_ctx->cnx_server->cnx_state == picoquic_state_server_almost_ready) {
+            break;
+        }
+    }
+
+    if (test_ctx->cnx_server == NULL || test_ctx->cnx_server->cnx_state != picoquic_state_server_almost_ready) {
+        DBG_PRINTF("Server state: %d\n", (test_ctx->cnx_server == NULL) ?
+            -1 : test_ctx->cnx_server->cnx_state);
+        ret = -1;
+    }
+
+    if (ret == 0) {
+        test_ctx->cnx_server->cnx_state = picoquic_state_handshake_failure;
+        test_ctx->cnx_server->local_error = 0xDEAD;
+        picoquic_reinsert_by_wake_time(test_ctx->qserver, test_ctx->cnx_server, simulated_time);
+    }
+
+
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+    }
+
+    if (ret == 0) {
+        if (test_ctx->cnx_server != NULL &&
+            test_ctx->cnx_server->cnx_state != picoquic_state_disconnected) {
+            DBG_PRINTF("Server state: %d, remote error: %x\n", test_ctx->cnx_server->cnx_state, test_ctx->cnx_server->remote_error);
+            ret = -1;
+        }
+        else if (test_ctx->cnx_client->cnx_state != picoquic_state_disconnected ||
+            test_ctx->cnx_client->remote_error != 0xDEAD) {
+            DBG_PRINTF("Client state: %d, local error: %x", test_ctx->cnx_client->cnx_state, test_ctx->cnx_client->local_error);
+            ret = -1;
+        }
+        else if (simulated_time > 50000ull) {
+            DBG_PRINTF("Simulated time: %llu", (unsigned long long)simulated_time);
+            ret = -1;
+        }
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
+}
+
 
 /*
  * Test that rotated keys are computed in a compatible way on client and server.

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4385,8 +4385,9 @@ int initial_close_test()
         }
 
         if (ret == 0) {
-            if (test_ctx->cnx_server != NULL) {
+            if (test_ctx->cnx_server == NULL) {
                 DBG_PRINTF("%s", "Server connection deleted, cannot verify error code.\n");
+                ret = -1;
             }
             else if (test_ctx->cnx_server->cnx_state != picoquic_state_disconnected ||
                 test_ctx->cnx_server->remote_error != 0xDEAD) {
@@ -4423,7 +4424,6 @@ int initial_server_close_test()
     uint64_t simulated_time = 0;
     int was_active = 0;
     int nb_trials = 0;
-    int nb_inactive = 0;
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
     int ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, 0, 0, 0);
 


### PR DESCRIPTION
Repro issue #485 in unit test, and then fix it.