### PR TITLE
Use `last_incoming_packet_time` as next wake for sending data

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -63,7 +63,7 @@ int picoquic_parse_packet_header(
             ph->vn = PICOPARSE_32(bytes + 1);
             /* Obtain the connection ID lengths from the byte following the version */
             picoquic_parse_packet_header_cnxid_lengths(bytes[5], &l_dest_id, &l_srce_id);
-            /* Required length: 
+            /* Required length:
              * (packet type(1) + version number(4) + cid_lengths(1) = 6,
              * cid lengths,
              * sequence number (4) */
@@ -77,7 +77,7 @@ int picoquic_parse_packet_header(
                 ph->offset += picoquic_parse_connection_id(bytes + ph->offset, l_srce_id, &ph->srce_cnx_id);
 
                 /* Not applicable for long packets. */
-                
+
                 if (ph->vn == 0) {
                     /* VN = zero identifies a version negotiation packet */
                     ph->ptype = picoquic_packet_version_negotiation;
@@ -102,8 +102,8 @@ int picoquic_parse_packet_header(
                 else {
                     char context_by_addr = 0;
                     uint64_t payload_length = 0;
-                    uint64_t pn_length_clear = 0;  
-                    uint32_t var_length = 0; 
+                    uint64_t pn_length_clear = 0;
+                    uint32_t var_length = 0;
 
                     ph->version_index = picoquic_get_version_index(ph->vn);
 
@@ -200,7 +200,7 @@ int picoquic_parse_packet_header(
                             ph->pl_val = ph->payload_length;
                         }
                     }
-                    
+
                     if (ph->ptype != picoquic_packet_error)
                     {
                         ph->pl_val = (uint16_t)payload_length;
@@ -270,7 +270,7 @@ int picoquic_parse_packet_header(
              ph->offset = length;
              ph->payload_length = 0;
          }
-      
+
          if (*pcnx != NULL) {
              ph->epoch = 3;
              ph->version_index = (*pcnx)->version_index;
@@ -337,7 +337,7 @@ uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t 
 }
 
 /*
- * Remove header protection 
+ * Remove header protection
  */
 int picoquic_remove_header_protection(picoquic_cnx_t* cnx,
     uint8_t* bytes, picoquic_packet_header* ph)
@@ -501,7 +501,7 @@ size_t picoquic_remove_packet_protection(picoquic_cnx_t* cnx,
             decoded = ph->payload_length + 1;
         }
     }
-    
+
     /* by conventions, values larger than input indicate error */
     return decoded;
 }
@@ -606,7 +606,7 @@ int picoquic_parse_header_and_decrypt(
 /*
  * Processing of a version renegotiation packet.
  *
- * From the specification: When the client receives a Version Negotiation packet 
+ * From the specification: When the client receives a Version Negotiation packet
  * from the server, it should select an acceptable protocol version. If the server
  * lists an acceptable version, the client selects that version and reattempts to
  * create a connection using that version. Though the contents of a packet might
@@ -669,7 +669,7 @@ int picoquic_prepare_version_negotiation(
         /* Copy the incoming connection ID */
         byte_index += picoquic_format_connection_id(bytes + byte_index, PICOQUIC_MAX_PACKET_SIZE - byte_index, ph->srce_cnx_id);
         byte_index += picoquic_format_connection_id(bytes + byte_index, PICOQUIC_MAX_PACKET_SIZE - byte_index, ph->dest_cnx_id);
-        
+
         /* Set the payload to the list of versions */
         for (size_t i = 0; i < picoquic_nb_supported_versions; i++) {
             picoformat_32(bytes + byte_index, picoquic_supported_versions[i].version);
@@ -700,7 +700,7 @@ int picoquic_prepare_version_negotiation(
 }
 
 /*
- * Process an unexpected connection ID. This could be an old packet from a 
+ * Process an unexpected connection ID. This could be an old packet from a
  * previous connection. If the packet type correspond to an encrypted value,
  * the server can respond with a public reset.
  *
@@ -716,7 +716,7 @@ void picoquic_process_unexpected_cnxid(
     unsigned long if_index_to,
     picoquic_packet_header* ph)
 {
-    if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE && 
+    if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE &&
         ph->ptype == picoquic_packet_1rtt_protected) {
         picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(quic);
         if (sp != NULL) {
@@ -954,15 +954,15 @@ int picoquic_incoming_initial(
 /*
  * Processing of a server retry
  *
- * The packet number and connection ID fields echo the corresponding fields from the 
+ * The packet number and connection ID fields echo the corresponding fields from the
  * triggering client packet. This allows a client to verify that the server received its packet.
  *
  * A Server Stateless Retry packet is never explicitly acknowledged in an ACK frame by a client.
  * Receiving another Client Initial packet implicitly acknowledges a Server Stateless Retry packet.
  *
- * After receiving a Server Stateless Retry packet, the client uses a new Client Initial packet 
+ * After receiving a Server Stateless Retry packet, the client uses a new Client Initial packet
  * containing the next token. In effect, the next cryptographic
- * handshake message is sent on a new connection. 
+ * handshake message is sent on a new connection.
  */
 
 int picoquic_incoming_retry(
@@ -1183,7 +1183,7 @@ int picoquic_incoming_0rtt(
         picoquic_compare_connection_id(&ph->dest_cnx_id, &cnx->path[0]->local_cnxid) == 0) ||
         picoquic_compare_connection_id(&ph->srce_cnx_id, &cnx->path[0]->remote_cnxid) != 0) {
         ret = PICOQUIC_ERROR_CNXID_CHECK;
-    } else if (cnx->cnx_state == picoquic_state_server_almost_ready || 
+    } else if (cnx->cnx_state == picoquic_state_server_almost_ready ||
         cnx->cnx_state == picoquic_state_server_false_start ||
         cnx->cnx_state == picoquic_state_ready) {
         if (ph->vn != picoquic_supported_versions[cnx->version_index].version) {
@@ -1499,7 +1499,7 @@ int picoquic_incoming_encrypted(
 
                 picoquic_spin_function_table[cnx->spin_policy].spinbit_incoming(cnx, path_x, ph);
                 /* Accept the incoming frames */
-                ret = picoquic_decode_frames(cnx, cnx->path[path_id], 
+                ret = picoquic_decode_frames(cnx, cnx->path[path_id],
                     bytes + ph->offset, ph->payload_length, ph->epoch, addr_from, addr_to, current_time);
             }
 
@@ -1673,15 +1673,15 @@ int picoquic_incoming_segment(
         }
         ret = -1;
     } else if (ret == PICOQUIC_ERROR_AEAD_CHECK || ret == PICOQUIC_ERROR_INITIAL_TOO_SHORT ||
-        ret == PICOQUIC_ERROR_UNEXPECTED_PACKET || ret == PICOQUIC_ERROR_FNV1A_CHECK || 
-        ret == PICOQUIC_ERROR_CNXID_CHECK || 
+        ret == PICOQUIC_ERROR_UNEXPECTED_PACKET || ret == PICOQUIC_ERROR_FNV1A_CHECK ||
+        ret == PICOQUIC_ERROR_CNXID_CHECK ||
         ret == PICOQUIC_ERROR_RETRY || ret == PICOQUIC_ERROR_DETECTED ||
         ret == PICOQUIC_ERROR_CONNECTION_DELETED ||
         ret == PICOQUIC_ERROR_CNXID_SEGMENT) {
         /* Bad packets are dropped silently */
 
         DBG_PRINTF("Packet (%d) dropped, t: %d, e: %d, pc: %d, pn: %d, l: %d, ret : %x\n",
-            (cnx == NULL) ? -1 : cnx->client_mode, ph.ptype, ph.epoch, ph.pc, (int)ph.pn, 
+            (cnx == NULL) ? -1 : cnx->client_mode, ph.ptype, ph.epoch, ph.pc, (int)ph.pn,
             length, ret);
         ret = -1;
         if (cnx != NULL) {
@@ -1715,11 +1715,12 @@ int picoquic_incoming_packet(
     int ret = 0;
     picoquic_connection_id_t previous_destid = picoquic_null_connection_id;
 
+    quic->last_incoming_packet_time = current_time;
 
     while (consumed_index < packet_length) {
         uint32_t consumed = 0;
 
-        ret = picoquic_incoming_segment(quic, bytes + consumed_index, 
+        ret = picoquic_incoming_segment(quic, bytes + consumed_index,
             packet_length - consumed_index, packet_length,
             &consumed, addr_from, addr_to, if_index_to, current_time, &previous_destid);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -181,7 +181,7 @@ typedef struct st_picoquic_spinbit_def_t {
 
 extern picoquic_spinbit_def_t picoquic_spin_function_table[];
 
-/* 
+/*
  * Codes used for representing the various types of packet encodings.
  */
 typedef enum {
@@ -201,7 +201,7 @@ extern const size_t picoquic_nb_supported_versions;
 int picoquic_get_version_index(uint32_t proposed_version);
 
 /*
-     * Definition of the session ticket store that can be associated with a 
+     * Definition of the session ticket store that can be associated with a
      * client context.
      */
 typedef struct st_picoquic_stored_ticket_t {
@@ -279,6 +279,7 @@ typedef struct st_picoquic_quic_t {
     uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE];
     uint8_t retry_seed[PICOQUIC_RETRY_SECRET_SIZE];
     uint64_t* p_simulated_time;
+    uint64_t last_incoming_packet_time;
     char const* ticket_file_name;
     picoquic_stored_ticket_t* p_first_ticket;
     uint32_t mtu_max;
@@ -403,14 +404,14 @@ typedef struct st_picoquic_misc_frame_header_t {
  * that path. When a path is deleted, the corresponding ID is removed from the table.
  *
  * On the server side, paths are activated after receiving the first packet on that path.
- * The server will then schedule allocate a non-zero challenge value for the path, 
+ * The server will then schedule allocate a non-zero challenge value for the path,
  * consume a connection ID advertised by the client, and allocate it as remote
  * connection ID for the path. (TODO: what if no new connection ID is available?).
  *
  * On the client side, challenges are initially sent without creating a path context,
  * by "half-consuming" a connection ID sent by the peer. Challenges can be repeated
  * up to 3 times before the probe is declared lost. The first response from the
- * peer will arrive on an unitialized path. The client will check whether the 
+ * peer will arrive on an unitialized path. The client will check whether the
  * challenge value correspond to a probe, and allocate the corresponding connection
  * ID to the path.
  *
@@ -476,7 +477,7 @@ typedef struct st_picoquic_path_t {
     unsigned int current_spin : 1;
 
     /* number of retransmissions observed on path */
-    uint64_t retrans_count;  
+    uint64_t retrans_count;
 
     /* Time measurement */
     uint64_t max_ack_delay;
@@ -497,7 +498,7 @@ typedef struct st_picoquic_path_t {
     uint64_t bytes_in_transit;
     void* congestion_alg_state;
 
-    /* 
+    /*
      * Pacing uses a set of per path variables:
      * - pacing_evaluation_time: last time the path was evaluated.
      * - pacing_bucket_nanosec: number of nanoseconds of transmission time that are allowed.
@@ -573,7 +574,7 @@ typedef struct st_picoquic_cnxid_stash_t {
 typedef struct st_picoquic_probe_t {
     struct st_picoquic_probe_t * next_probe;
     uint64_t sequence;
-    picoquic_connection_id_t remote_cnxid; 
+    picoquic_connection_id_t remote_cnxid;
     uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE];
     /* Addresses with which the probe was sent */
     struct sockaddr_storage peer_addr;
@@ -591,7 +592,7 @@ typedef struct st_picoquic_probe_t {
     unsigned int challenge_failed : 1;
 } picoquic_probe_t;
 
-/* 
+/*
  * Per connection context.
  */
 typedef struct st_picoquic_cnx_t {
@@ -935,7 +936,7 @@ void picoquic_cc_dump(picoquic_cnx_t * cnx, uint64_t current_time);
 /* handling of ACK logic */
 int picoquic_is_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, uint64_t * next_wake_time, picoquic_packet_context_enum pc);
 
-int picoquic_is_pn_already_received(picoquic_cnx_t* cnx, 
+int picoquic_is_pn_already_received(picoquic_cnx_t* cnx,
     picoquic_packet_context_enum pc, uint64_t pn64);
 int picoquic_record_pn_received(picoquic_cnx_t* cnx,
     picoquic_packet_context_enum pc, uint64_t pn64, uint64_t current_microsec);
@@ -1003,7 +1004,7 @@ int picoquic_prepare_misc_frame(picoquic_misc_frame_header_t* misc_frame, uint8_
 
 /* send/receive */
 
-int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, uint8_t* bytes, size_t bytes_max, 
+int picoquic_decode_frames(picoquic_cnx_t* cnx, picoquic_path_t * path_x, uint8_t* bytes, size_t bytes_max,
     int epoch, struct sockaddr* addr_from, struct sockaddr* addr_to, uint64_t current_time);
 
 int picoquic_skip_frame(uint8_t* bytes, size_t bytes_max, size_t* consumed, int* pure_ack);


### PR DESCRIPTION
Given the following structure of calling picoquic:

1. Get current time()
2. Check socket and forward data to picoquic using current time from 1.
3. Check stream structures for data to send and forward to picoquic
4. Get list of connections based on next wake time with max_time set to time from 1.

The current implementation would require a new round, for the connection to send data, as `add_to_stream`/`mark_as_active` were using a time that was higher than the time from 1.

My solution now is to save the time of the last incoming packet, to use it as next wake up time. So, after step 3, the connection already can send data in step 4 and we don't need another round.