### PR TITLE
Set `stop_sending_sent` even if we don't need to send it

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -674,6 +674,8 @@ int picoquic_prepare_stop_sending_frame(picoquic_stream_head* stream,
     if (bytes_max < min_length) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
     } else if (!stream->stop_sending_requested || stream->stop_sending_sent || stream->fin_received || stream->reset_received) {
+        /* set this, so we don't getting called again */
+        stream->stop_sending_sent = 1;
         /* no need to send a stop sending frame */
         *consumed = 0;
     } else {

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -674,7 +674,7 @@ int picoquic_prepare_stop_sending_frame(picoquic_stream_head* stream,
     if (bytes_max < min_length) {
         ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
     } else if (!stream->stop_sending_requested || stream->stop_sending_sent || stream->fin_received || stream->reset_received) {
-        /* set this, so we don't getting called again */
+        /* set this, so we will not be called again */
         stream->stop_sending_sent = 1;
         /* no need to send a stop sending frame */
         *consumed = 0;


### PR DESCRIPTION
The calling function checks if `stop_sending` was requested and it was
not sent yet. Together with the new `is_active` feature this can result
in an endless loop. `stop_sending_sent` is not set to 1, but `is_active`
stays at 1, the stream does not fill the send_buffer and
`picoquic_find_next_ready_stream` always returns the same stream.