### PR TITLE
Add test that addresses are documented during call setup

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -819,6 +819,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(document_addresses)
+        {
+            int ret = document_addresses_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(stress)
         {
             int ret = stress_test();

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -465,6 +465,10 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx);
 void picoquic_set_callback(picoquic_cnx_t* cnx,
     picoquic_stream_data_cb_fn callback_fn, void* callback_ctx);
 
+picoquic_stream_data_cb_fn picoquic_get_default_callback_function(picoquic_quic_t * quic);
+
+picoquic_stream_data_cb_fn picoquic_get_default_callback_context(picoquic_quic_t * quic);
+
 picoquic_stream_data_cb_fn picoquic_get_callback_function(picoquic_cnx_t * cnx);
 
 void * picoquic_get_callback_context(picoquic_cnx_t* cnx);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -465,6 +465,8 @@ int picoquic_is_cnx_backlog_empty(picoquic_cnx_t* cnx);
 void picoquic_set_callback(picoquic_cnx_t* cnx,
     picoquic_stream_data_cb_fn callback_fn, void* callback_ctx);
 
+picoquic_stream_data_cb_fn picoquic_get_callback_function(picoquic_cnx_t * cnx);
+
 void * picoquic_get_callback_context(picoquic_cnx_t* cnx);
 
 /* Send extra frames */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1724,6 +1724,16 @@ void picoquic_set_callback(picoquic_cnx_t* cnx,
     cnx->callback_ctx = callback_ctx;
 }
 
+picoquic_stream_data_cb_fn picoquic_get_default_callback_function(picoquic_quic_t* quic)
+{
+    return quic->default_callback_fn;
+}
+
+picoquic_stream_data_cb_fn picoquic_get_default_callback_context(picoquic_quic_t* quic)
+{
+    return quic->default_callback_ctx;
+}
+
 picoquic_stream_data_cb_fn picoquic_get_callback_function(picoquic_cnx_t * cnx)
 {
     return cnx->callback_fn;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1724,6 +1724,11 @@ void picoquic_set_callback(picoquic_cnx_t* cnx,
     cnx->callback_ctx = callback_ctx;
 }
 
+picoquic_stream_data_cb_fn picoquic_get_callback_function(picoquic_cnx_t * cnx)
+{
+    return cnx->callback_fn;
+}
+
 void * picoquic_get_callback_context(picoquic_cnx_t * cnx)
 {
     return cnx->callback_ctx;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -153,6 +153,7 @@ static const picoquic_test_def_t test_table[] = {
     { "long_rtt", long_rtt_test },
     { "cid_length", cid_length_test },
     { "optimistic_ack", optimistic_ack_test },
+    { "document_addresses", document_addresses_test },
     { "stress", stress_test },
     { "fuzz", fuzz_test },
     { "fuzz_initial", fuzz_initial_test},

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -163,6 +163,7 @@ int h09_server_test();
 int generic_server_test();
 int tls_retry_token_test();
 int optimistic_ack_test();
+int document_addresses_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -5707,3 +5707,147 @@ int optimistic_ack_test()
 
     return ret;
 }
+
+/*
+ * test that local and remote addresses are properly documented during the
+ * call setup process.
+ */
+
+typedef struct st_tls_api_address_are_documented_t {
+    /* addresses returned by almost ready callback */
+    int nb_almost_ready;
+    int local_addr_almost_ready_len;
+    int remote_addr_almost_ready_len;
+    struct sockaddr_storage local_addr_almost_ready;
+    struct sockaddr_storage remote_addr_almost_ready;
+    /* addresses returned by ready callback */
+    int nb_ready;
+    int local_addr_ready_len;
+    int remote_addr_ready_len;
+    struct sockaddr_storage local_addr_ready;
+    struct sockaddr_storage remote_addr_ready;
+    /* Pointer to the underlying callback */
+    picoquic_stream_data_cb_fn callback_fn;
+    void * callback_ctx;
+} tls_api_address_are_documented_t;
+
+static int test_local_address_callback(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+{
+    int ret;
+
+    tls_api_address_are_documented_t* cb_ctx = (tls_api_address_are_documented_t*)callback_ctx;
+
+    if (fin_or_event == picoquic_callback_almost_ready) {
+        cb_ctx->nb_almost_ready++;
+        if (cb_ctx->nb_almost_ready == 1) {
+            cb_ctx->local_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->local_addr_almost_ready,
+                (struct sockaddr *)&cnx->path[0]->local_addr);
+            cb_ctx->remote_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_almost_ready,
+                (struct sockaddr *)&cnx->path[0]->peer_addr);
+        }
+    }
+    else if (fin_or_event == picoquic_callback_ready) {
+        cb_ctx->nb_ready++;
+        if (cb_ctx->nb_ready == 1) {
+            cb_ctx->local_addr_ready_len = picoquic_store_addr(&cb_ctx->local_addr_ready,
+                (struct sockaddr *)&cnx->path[0]->local_addr);
+            cb_ctx->remote_addr_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_ready,
+                (struct sockaddr *)&cnx->path[0]->peer_addr);
+        }
+    };
+
+    if (cb_ctx->callback_fn != NULL) {
+        ret = (cb_ctx->callback_fn)(cnx, stream_id, bytes, length, fin_or_event, cb_ctx->callback_ctx);
+    }
+
+    return ret;
+}
+
+int document_addresses_test()
+{
+    uint64_t simulated_time = 0; 
+    tls_api_address_are_documented_t address_callback_ctx;
+
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    int ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 1, 0);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = -1;
+    }
+    if (ret == 0) {
+        /* Set the call back to intercept the almost ready and ready transitions */
+        memset(&address_callback_ctx, 0, sizeof(tls_api_address_are_documented_t));
+        address_callback_ctx.callback_fn = picoquic_get_callback_function(test_ctx->cnx_client);
+        address_callback_ctx.callback_ctx = picoquic_get_callback_context(test_ctx->cnx_client);
+        picoquic_set_callback(test_ctx->cnx_client, test_local_address_callback, &address_callback_ctx);
+
+        ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
+            test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 20000, 3600000);
+    }
+
+    /* Verify that the addresses and calls are what we expect */
+    if (ret == 0 && address_callback_ctx.nb_almost_ready != 1) {
+        DBG_PRINTF("Expected 1 almost ready callback, got %d\n", address_callback_ctx.nb_ready);
+        ret = -1;
+    }
+
+    if (ret == 0 && address_callback_ctx.local_addr_almost_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected almost ready local address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->client_addr,
+        (struct sockaddr*)&address_callback_ctx.local_addr_almost_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && address_callback_ctx.remote_addr_almost_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected almost ready remote address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->server_addr,
+        (struct sockaddr*)&address_callback_ctx.remote_addr_almost_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && address_callback_ctx.nb_ready != 1) {
+        DBG_PRINTF("Expected 1 ready callback, got %d\n", address_callback_ctx.nb_ready);
+        ret = -1;
+    }
+
+    if (ret == 0 && address_callback_ctx.local_addr_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected ready local address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->client_addr,
+        (struct sockaddr*)&address_callback_ctx.local_addr_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && address_callback_ctx.remote_addr_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected ready remote address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->server_addr,
+        (struct sockaddr*)&address_callback_ctx.remote_addr_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
+    }
+
+    /* Free the resource */
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
+}

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -5736,30 +5736,120 @@ static int test_local_address_callback(picoquic_cnx_t* cnx,
     picoquic_call_back_event_t fin_or_event, void* callback_ctx)
 {
     int ret;
+    int local_addr_len, remote_addr_len;
+    struct sockaddr * local_addr;
+    struct sockaddr * remote_addr;
 
     tls_api_address_are_documented_t* cb_ctx = (tls_api_address_are_documented_t*)callback_ctx;
 
     if (fin_or_event == picoquic_callback_almost_ready) {
+        picoquic_get_peer_addr(cnx, &remote_addr, &remote_addr_len);
+        picoquic_get_local_addr(cnx, &local_addr, &local_addr_len);
         cb_ctx->nb_almost_ready++;
         if (cb_ctx->nb_almost_ready == 1) {
-            cb_ctx->local_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->local_addr_almost_ready,
-                (struct sockaddr *)&cnx->path[0]->local_addr);
-            cb_ctx->remote_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_almost_ready,
-                (struct sockaddr *)&cnx->path[0]->peer_addr);
+            if (local_addr_len > 0 && local_addr != NULL) {
+                cb_ctx->local_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->local_addr_almost_ready,
+                    local_addr);
+            }
+            if (remote_addr_len > 0 && remote_addr != NULL) {
+                cb_ctx->remote_addr_almost_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_almost_ready,
+                    remote_addr);
+            }
         }
     }
     else if (fin_or_event == picoquic_callback_ready) {
+        picoquic_get_peer_addr(cnx, &remote_addr, &remote_addr_len);
+        picoquic_get_local_addr(cnx, &local_addr, &local_addr_len);
         cb_ctx->nb_ready++;
         if (cb_ctx->nb_ready == 1) {
-            cb_ctx->local_addr_ready_len = picoquic_store_addr(&cb_ctx->local_addr_ready,
-                (struct sockaddr *)&cnx->path[0]->local_addr);
-            cb_ctx->remote_addr_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_ready,
-                (struct sockaddr *)&cnx->path[0]->peer_addr);
+            if (local_addr_len > 0 && local_addr != NULL) {
+                cb_ctx->local_addr_ready_len = picoquic_store_addr(&cb_ctx->local_addr_ready,
+                    local_addr);
+            }
+            if (remote_addr_len > 0 && remote_addr != NULL) {
+                cb_ctx->remote_addr_ready_len = picoquic_store_addr(&cb_ctx->remote_addr_ready,
+                    remote_addr);
+            }
         }
     };
 
     if (cb_ctx->callback_fn != NULL) {
+        picoquic_stream_data_cb_fn new_fn;
+        void * new_ctx;
+
         ret = (cb_ctx->callback_fn)(cnx, stream_id, bytes, length, fin_or_event, cb_ctx->callback_ctx);
+
+        /* Check that the callbacks were not reset during the last call */
+        new_fn = picoquic_get_callback_function(cnx);
+        new_ctx = picoquic_get_callback_context(cnx);
+
+        if (new_fn != test_local_address_callback || new_ctx != callback_ctx) {
+            cb_ctx->callback_fn = new_fn;
+            cb_ctx->callback_ctx = new_ctx;
+            picoquic_set_callback(cnx, test_local_address_callback, callback_ctx);
+        }
+    }
+
+    return ret;
+}
+
+int document_addresses_check(tls_api_address_are_documented_t * test_cb_ctx,
+    struct sockaddr * local_addr_ref, struct sockaddr * remote_addr_ref)
+{
+    int ret = 0;
+
+    if (ret == 0 && test_cb_ctx->nb_almost_ready != 1) {
+        DBG_PRINTF("Expected 1 almost ready callback, got %d\n", test_cb_ctx->nb_ready);
+        ret = -1;
+    }
+
+    if (ret == 0 && test_cb_ctx->local_addr_almost_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected almost ready local address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr(local_addr_ref,
+        (struct sockaddr*)&test_cb_ctx->local_addr_almost_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && test_cb_ctx->remote_addr_almost_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected almost ready remote address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr(remote_addr_ref,
+        (struct sockaddr*)&test_cb_ctx->remote_addr_almost_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && test_cb_ctx->nb_ready != 1) {
+        DBG_PRINTF("Expected 1 ready callback, got %d\n", test_cb_ctx->nb_ready);
+        ret = -1;
+    }
+
+    if (ret == 0 && test_cb_ctx->local_addr_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected ready local address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr(local_addr_ref,
+        (struct sockaddr*)&test_cb_ctx->local_addr_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from ready callback does not match\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && test_cb_ctx->remote_addr_ready_len == 0) {
+        DBG_PRINTF("%s", "Expected ready remote address, got length = 0\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && picoquic_compare_addr(remote_addr_ref,
+        (struct sockaddr*)&test_cb_ctx->remote_addr_ready) != 0) {
+        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
+        ret = -1;
     }
 
     return ret;
@@ -5768,7 +5858,7 @@ static int test_local_address_callback(picoquic_cnx_t* cnx,
 int document_addresses_test()
 {
     uint64_t simulated_time = 0; 
-    tls_api_address_are_documented_t address_callback_ctx;
+    tls_api_address_are_documented_t client_address_callback_ctx, server_address_callback_ctx;
 
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
     int ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 1, 0);
@@ -5777,69 +5867,36 @@ int document_addresses_test()
         ret = -1;
     }
     if (ret == 0) {
-        /* Set the call back to intercept the almost ready and ready transitions */
-        memset(&address_callback_ctx, 0, sizeof(tls_api_address_are_documented_t));
-        address_callback_ctx.callback_fn = picoquic_get_callback_function(test_ctx->cnx_client);
-        address_callback_ctx.callback_ctx = picoquic_get_callback_context(test_ctx->cnx_client);
-        picoquic_set_callback(test_ctx->cnx_client, test_local_address_callback, &address_callback_ctx);
+        /* Set the call backs to intercept the almost ready and ready transitions */
+        memset(&client_address_callback_ctx, 0, sizeof(tls_api_address_are_documented_t));
+        client_address_callback_ctx.callback_fn = picoquic_get_callback_function(test_ctx->cnx_client);
+        client_address_callback_ctx.callback_ctx = picoquic_get_callback_context(test_ctx->cnx_client);
+        picoquic_set_callback(test_ctx->cnx_client, test_local_address_callback, &client_address_callback_ctx);
+
+        memset(&server_address_callback_ctx, 0, sizeof(tls_api_address_are_documented_t));
+        server_address_callback_ctx.callback_fn = picoquic_get_default_callback_function(test_ctx->qserver);
+        server_address_callback_ctx.callback_ctx = picoquic_get_default_callback_context(test_ctx->qserver);
+        picoquic_set_default_callback(test_ctx->qserver, test_local_address_callback, &server_address_callback_ctx);
 
         ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
-            test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 20000, 3600000);
+            test_scenario_q_and_r, sizeof(test_scenario_q_and_r), 0, 0, 0, 20000, 3600000);
     }
 
     /* Verify that the addresses and calls are what we expect */
-    if (ret == 0 && address_callback_ctx.nb_almost_ready != 1) {
-        DBG_PRINTF("Expected 1 almost ready callback, got %d\n", address_callback_ctx.nb_ready);
-        ret = -1;
+    if (ret == 0) {
+        ret = document_addresses_check(&client_address_callback_ctx,
+            (struct sockaddr*)&test_ctx->client_addr, (struct sockaddr*)&test_ctx->server_addr);
+        if (ret != 0) {
+            DBG_PRINTF("%s", "Client addresses were not properly documented\n");
+        }
     }
 
-    if (ret == 0 && address_callback_ctx.local_addr_almost_ready_len == 0) {
-        DBG_PRINTF("%s", "Expected almost ready local address, got length = 0\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->client_addr,
-        (struct sockaddr*)&address_callback_ctx.local_addr_almost_ready) != 0) {
-        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && address_callback_ctx.remote_addr_almost_ready_len == 0) {
-        DBG_PRINTF("%s", "Expected almost ready remote address, got length = 0\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->server_addr,
-        (struct sockaddr*)&address_callback_ctx.remote_addr_almost_ready) != 0) {
-        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && address_callback_ctx.nb_ready != 1) {
-        DBG_PRINTF("Expected 1 ready callback, got %d\n", address_callback_ctx.nb_ready);
-        ret = -1;
-    }
-
-    if (ret == 0 && address_callback_ctx.local_addr_ready_len == 0) {
-        DBG_PRINTF("%s", "Expected ready local address, got length = 0\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->client_addr,
-        (struct sockaddr*)&address_callback_ctx.local_addr_ready) != 0) {
-        DBG_PRINTF("%s", "Local address from ready callback does not match\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && address_callback_ctx.remote_addr_ready_len == 0) {
-        DBG_PRINTF("%s", "Expected ready remote address, got length = 0\n");
-        ret = -1;
-    }
-
-    if (ret == 0 && picoquic_compare_addr((struct sockaddr*)&test_ctx->server_addr,
-        (struct sockaddr*)&address_callback_ctx.remote_addr_ready) != 0) {
-        DBG_PRINTF("%s", "Local address from almost ready callback does not match\n");
-        ret = -1;
+    if (ret == 0) {
+        ret = document_addresses_check(&server_address_callback_ctx,
+            (struct sockaddr*)&test_ctx->server_addr, (struct sockaddr*)&test_ctx->client_addr);
+        if (ret != 0) {
+            DBG_PRINTF("%s", "Server addresses were not properly documented\n");
+        }
     }
 
     /* Free the resource */

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -5735,7 +5735,7 @@ static int test_local_address_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
     picoquic_call_back_event_t fin_or_event, void* callback_ctx)
 {
-    int ret;
+    int ret = 0;
     int local_addr_len, remote_addr_len;
     struct sockaddr * local_addr;
     struct sockaddr * remote_addr;


### PR DESCRIPTION
This test tries to reproduce the issue #509 documented by @bkchr. 

The test is valuable in itself as it checks that specific code path, but the issue is not reproduced.  