### PR TITLE
Add test of version negotiation with 0-RTT

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -658,6 +658,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(zero_rtt_vnego)
+        {
+            int ret = zero_rtt_vnego_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+        
         TEST_METHOD(test_probe_api)
         {
             int ret = probe_api_test();

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -207,12 +207,10 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
             /* Request setting ECN_1 in outgoing packets */
             if (setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, &ecn, sizeof(ecn)) < 0) {
                 DBG_PRINTF("setsockopt IPV6_TCLASS (0x%x) fails, errno: %d\n", ecn, errno);
-                ret = -1;
                 *send_set = 0;
             }
             else {
                 *send_set = 1;
-                ret = 0;
             }
         }
 #else
@@ -247,12 +245,10 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
             /* Request setting ECN_1 in outgoing packets */
             if (setsockopt(sd, IPPROTO_IP, IP_TOS, &ecn, sizeof(ecn)) < 0) {
                 DBG_PRINTF("setsockopt IPv4 IP_TOS (0x%x) fails, errno: %d\n", ecn, errno);
-                ret = -1;
                 *send_set = 0;
             }
             else {
                 *send_set = 1;
-                ret = 0;
             }
         }
 #else

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -127,6 +127,7 @@ static const picoquic_test_def_t test_table[] = {
     { "pn_vector", cleartext_pn_vector_test },
     { "zero_rtt_spurious", zero_rtt_spurious_test },
     { "zero_rtt_retry", zero_rtt_retry_test },
+    { "zero_rtt_vnego", zero_rtt_vnego_test },
     { "random_tester", random_tester_test},
     { "transmit_cnxid", transmit_cnxid_test },
     { "probe_api", probe_api_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -165,6 +165,7 @@ int tls_retry_token_test();
 int optimistic_ack_test();
 int document_addresses_test();
 int socket_ecn_test();
+int zero_rtt_vnego_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Verify that the content of the 0-RTT packet is correctly retransmitted on the new connection.

This addresses issue #367 