### PR TITLE
Travis: Really update to gcc8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - g++-8
     - cmake
     - cmake-data
     - libssl-dev 
@@ -16,6 +15,12 @@ matrix:
         - name: Linux (gcc-8)
           os: linux
           dist: xenial
+          addons:
+            apt:
+                sources:
+                   - ubuntu-toolchain-r-test
+                packages:
+                   - g++-8
           env:
               - CC=gcc-8
               - CXX=g++-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: xenial
-language: cpp
+language: minimal
 sudo: required
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - g++
+    - g++-8
     - cmake
     - cmake-data
     - libssl-dev 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ script:
   # Now build picotls examples and test
   - echo $CC
   - echo $CXX
+  - $CC --version
   - ${EXTRA} cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${CMAKE_OPTS} .
   - if [ "$CHECK" == "cppcheck" ]; then cppcheck --project=compile_commands.json --quiet; fi
   - ${EXTRA} make


### PR DESCRIPTION
Found a issue with Travis and use language: cpp

the CC and CCX variable are override.. and don't build with gcc-8/g++-8