### PR TITLE
Apply preferred address

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -700,6 +700,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(preferred_address)
+        {
+            int ret = preferred_address_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+        
         TEST_METHOD(test_cnxid_renewal)
         {
             int ret = cnxid_renewal_test();

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1463,7 +1463,6 @@ int picoquic_prepare_server_address_migration(picoquic_cnx_t* cnx)
         }
         else if(ipv4_received || ipv6_received) {
             struct sockaddr_storage dest_addr;
-            struct sockaddr * srce_addr;
 
             memset(&dest_addr, 0, sizeof(struct sockaddr_storage));
 
@@ -1472,24 +1471,20 @@ int picoquic_prepare_server_address_migration(picoquic_cnx_t* cnx)
                 /* select IPv4 */
                 ipv6_received = 0;
             }
-            else if (ipv6_received && cnx->path[0]->peer_addr.ss_family == AF_INET6) {
-                /* select IPv6 */
-                ipv4_received = 0;
-            }
 
-            if (ipv4_received) {
-                /* configure an IPv4 sockaddr */
-                struct sockaddr_in * d4 = (struct sockaddr_in *)&dest_addr;
-                d4->sin_family = AF_INET;
-                d4->sin_port = cnx->remote_parameters.prefered_address.ipv4Port;
-                memcpy(&d4->sin_addr, cnx->remote_parameters.prefered_address.ipv4Address, 4);
-            }
-            else {
+            if (ipv6_received) {
                 /* configure an IPv6 sockaddr */
                 struct sockaddr_in6 * d6 = (struct sockaddr_in6 *)&dest_addr;
                 d6->sin6_family = AF_INET;
                 d6->sin6_port = cnx->remote_parameters.prefered_address.ipv6Port;
                 memcpy(&d6->sin6_addr, cnx->remote_parameters.prefered_address.ipv6Address, 16);
+            }
+            else {
+                /* configure an IPv4 sockaddr */
+                struct sockaddr_in * d4 = (struct sockaddr_in *)&dest_addr;
+                d4->sin_family = AF_INET;
+                d4->sin_port = cnx->remote_parameters.prefered_address.ipv4Port;
+                memcpy(&d4->sin_addr, cnx->remote_parameters.prefered_address.ipv4Address, 4);
             }
 
             ret = picoquic_create_probe(cnx, (struct sockaddr *)&dest_addr, NULL);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1442,6 +1442,63 @@ void picoquic_implicit_handshake_ack(picoquic_cnx_t* cnx, picoquic_packet_contex
     }
 }
 
+/* Program a migration to the server preferred address if present */
+int picoquic_prepare_server_address_migration(picoquic_cnx_t* cnx)
+{
+    int ret = 0;
+
+    if (cnx->remote_parameters.prefered_address.is_defined)
+    {
+        int ipv4_received = cnx->remote_parameters.prefered_address.ipv4Port != 0;
+        int ipv6_received = cnx->remote_parameters.prefered_address.ipv6Port != 0;
+
+        /* Add the connection ID to the local stash */
+        ret = picoquic_enqueue_cnxid_stash(cnx, 1,
+            cnx->remote_parameters.prefered_address.connection_id.id_len,
+            cnx->remote_parameters.prefered_address.connection_id.id,
+            cnx->remote_parameters.prefered_address.statelessResetToken,
+            NULL);
+        if (ret != 0) {
+            ret = picoquic_connection_error(cnx, (uint16_t)ret, picoquic_frame_type_new_connection_id);
+        }
+        else if(ipv4_received || ipv6_received) {
+            struct sockaddr_storage dest_addr;
+            struct sockaddr * srce_addr;
+
+            memset(&dest_addr, 0, sizeof(struct sockaddr_storage));
+
+            /* program a migration. */
+            if (ipv4_received && cnx->path[0]->peer_addr.ss_family == AF_INET) {
+                /* select IPv4 */
+                ipv6_received = 0;
+            }
+            else if (ipv6_received && cnx->path[0]->peer_addr.ss_family == AF_INET6) {
+                /* select IPv6 */
+                ipv4_received = 0;
+            }
+
+            if (ipv4_received) {
+                /* configure an IPv4 sockaddr */
+                struct sockaddr_in * d4 = (struct sockaddr_in *)&dest_addr;
+                d4->sin_family = AF_INET;
+                d4->sin_port = cnx->remote_parameters.prefered_address.ipv4Port;
+                memcpy(&d4->sin_addr, cnx->remote_parameters.prefered_address.ipv4Address, 4);
+            }
+            else {
+                /* configure an IPv6 sockaddr */
+                struct sockaddr_in6 * d6 = (struct sockaddr_in6 *)&dest_addr;
+                d6->sin6_family = AF_INET;
+                d6->sin6_port = cnx->remote_parameters.prefered_address.ipv6Port;
+                memcpy(&d6->sin6_addr, cnx->remote_parameters.prefered_address.ipv6Address, 16);
+            }
+
+            ret = picoquic_create_probe(cnx, (struct sockaddr *)&dest_addr, NULL);
+        }
+    }
+
+    return ret;
+}
+
 /* Prepare the next packet to send when in one of the client initial states */
 int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length, uint64_t * next_wake_time)
@@ -1662,9 +1719,14 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
                                 cnx->tls_stream[1].send_queue == NULL &&
                                 cnx->tls_stream[2].send_queue == NULL) {
                                 cnx->cnx_state = picoquic_state_client_ready_start;
-                                if (cnx->callback_fn != NULL) {
-                                    if (cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_almost_ready, cnx->callback_ctx) != 0) {
-                                        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_INTERNAL_ERROR, 0);
+                                /* Start migration to server preferred address if present */
+                                ret = picoquic_prepare_server_address_migration(cnx);
+                                if (ret == 0) {
+                                    /* Signal the application */
+                                    if (cnx->callback_fn != NULL) {
+                                        if (cnx->callback_fn(cnx, 0, NULL, 0, picoquic_callback_almost_ready, cnx->callback_ctx) != 0) {
+                                            picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_INTERNAL_ERROR, 0);
+                                        }
                                     }
                                 }
                             }

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -222,6 +222,7 @@ size_t picoquic_decode_transport_param_prefered_address(uint8_t * bytes, size_t 
         byte_index += 2;
         cnx_id_length = bytes[byte_index++];
         if (byte_index + cnx_id_length + 16 <= bytes_max &&
+            cnx_id_length > 0 &&
             cnx_id_length == picoquic_parse_connection_id(bytes + byte_index, cnx_id_length,
                 &prefered_address->connection_id)){
             byte_index += cnx_id_length;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -135,6 +135,7 @@ static const picoquic_test_def_t test_table[] = {
     { "migration" , migration_test },
     { "migration_long", migration_test_long },
     { "migration_with_loss", migration_test_loss },
+    { "preferred_address", preferred_address_test},
     { "cnxid_renewal",  cnxid_renewal_test },
     { "retire_cnxid", retire_cnxid_test },
     { "server_busy", server_busy_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -167,6 +167,7 @@ int document_addresses_test();
 int socket_ecn_test();
 int zero_rtt_vnego_test();
 int null_sni_test();
+int preferred_address_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -134,6 +134,7 @@ typedef struct st_picoquic_test_tls_api_ctx_t {
     picoquic_cnx_t* cnx_client;
     picoquic_cnx_t* cnx_server;
     int client_use_nat;
+    int server_use_multiple_addresses;
     struct sockaddr_in client_addr;
     struct sockaddr_in server_addr;
     test_api_callback_t client_callback;


### PR DESCRIPTION
Make sure that the preferred address functionality actually works. The preferred address can be set as part of the default parameters for the server context. The parameter will be copied to the context of server's connections when they are created, a new CID will be created, etc. When the client receives a preferred address parameter, it will schedule a probe for the new address, and migrate there when the probe's challenge is answered. The unit test verifies that this works as expected.