### PR TITLE
Align with latest version of TLS, update key logging procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Picoquic is developed in C, and can be built under Windows or Linux. Building th
 project requires first managing the dependencies, Picotls (https://github.com/h2o/picotls)
 and OpenSSL. Please note that you will need a recent version of Picotls --
 the Picotls API has eveolved recently to support the latest version of QUIC. The
-current code is tested against the Picotls version of Wed Feb 13 00:19:19 2019 +0900,
-after commit `a834170c3529ace968b6588f1aec793ba4a6e3d6`.
+current code is tested against the Picotls version of Mon Feb 18 14:22:09 2019 +0900,
+after commit `e278d032381414641c286ae6f02c407f83c7586c`.
 
 ## Picoquic on Windows
 

--- a/ci/build_picotls.ps1
+++ b/ci/build_picotls.ps1
@@ -1,5 +1,5 @@
 # Build at a known-good commit
-$COMMIT_ID="a834170c3529ace968b6588f1aec793ba4a6e3d6"
+$COMMIT_ID="e278d032381414641c286ae6f02c407f83c7586c"
 
 # Match expectations of picotlsvs project.
 foreach ($dir in "$Env:OPENSSLDIR","$Env:OPENSSL64DIR") {

--- a/ci/build_picotls.sh
+++ b/ci/build_picotls.sh
@@ -2,7 +2,7 @@
 #build last picotls master (for Travis)
 
 # Build at a known-good commit
-COMMIT_ID=a834170c3529ace968b6588f1aec793ba4a6e3d6
+COMMIT_ID=e278d032381414641c286ae6f02c407f83c7586c
 
 cd ..
 git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags https://github.com/h2o/picotls

--- a/picoquic/wincompat.h
+++ b/picoquic/wincompat.h
@@ -29,6 +29,10 @@
 #ifndef gettimeofday
 #define gettimeofday wintimeofday
 
+#ifndef __attribute__
+#define __attribute__(X)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
The logging format used by Picotls changed in a PR dated 2/18/2019. This prevents users from simply compiling the latest version of Picotls and linking with Picoquic.