### PR TITLE
Revise the log option and the log strategy for performance

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1643,7 +1643,7 @@ int picoquic_incoming_segment(
             *previous_dest_id = ph.dest_cnx_id;
 
             /* if needed, log that the packet is received */
-            if (quic->F_log != NULL) {
+            if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE)) {
                 picoquic_log_packet_address(quic->F_log,
                     picoquic_val64_connection_id((cnx == NULL) ? ph.dest_cnx_id : picoquic_get_logging_cnxid(cnx)),
                     cnx, addr_from, 1, packet_length, current_time);
@@ -1655,7 +1655,9 @@ int picoquic_incoming_segment(
     }
 
     /* Log the incoming segment */
-    picoquic_log_decrypted_segment(quic->F_log, 1, cnx, 1, &ph, bytes, (uint32_t)*consumed, ret);
+    if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE)) {
+        picoquic_log_decrypted_segment(quic->F_log, 1, cnx, 1, &ph, bytes, (uint32_t)*consumed, ret);
+    }
 
     if (ret == 0) {
         if (cnx == NULL) {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -101,6 +101,8 @@ extern "C" {
 #define PICOQUIC_RESET_SECRET_SIZE 16
 #define PICOQUIC_RESET_PACKET_MIN_SIZE (1 + 20 + 16)
 
+#define PICOQUIC_LOG_PACKET_MAX_SEQUENCE 100
+
 
 /*
 * Connection states, useful to expose the state to the application.

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -838,7 +838,6 @@ void picoquic_delete_path(picoquic_cnx_t* cnx, int path_index)
     picoquic_path_t * path_x = cnx->path[path_index];
     picoquic_packet_t* p = NULL;
 
-    DBG_PRINTF("delete path[%d] (%x)\n", path_index, path_x);
     if (cnx->quic->F_log != NULL) {
         fflush(cnx->quic->F_log);
     }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -494,7 +494,7 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     send_length += /* header_length */ h_length;
 
     /* if needed, log the segment before header protection is applied */
-    if (cnx->quic->F_log != NULL) {
+    if (cnx->quic->F_log != NULL && cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE) {
         picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
             bytes, sequence_number, length,
             send_buffer, send_length);
@@ -3103,7 +3103,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     }
 
     /* if needed, log that the packet is sent */
-    if (*send_length > 0 && cnx->quic->F_log != NULL) {
+    if (*send_length > 0 && cnx->quic->F_log != NULL && cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE) {
         picoquic_log_packet_address(cnx->quic->F_log,
             picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)),
             cnx, (struct sockaddr *)&addr_to_log, 0, *send_length, current_time);

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -94,27 +94,26 @@ static int debug_suspended = 0;
 
 void debug_printf(const char* fmt, ...)
 {
-    if (debug_suspended == 0) {
+    if (debug_suspended == 0 && debug_out != NULL) {
         va_list args;
         va_start(args, fmt);
-        vfprintf(debug_out ? debug_out : stderr, fmt, args);
+        vfprintf(debug_out, fmt, args);
         va_end(args);
     }
 }
 
 void debug_dump(const void * x, int len)
 {
-    if (debug_suspended == 0) {
-        FILE * F = debug_out ? debug_out : stderr;
+    if (debug_suspended == 0 && debug_out != NULL) {
         uint8_t * bytes = (uint8_t *)x;
 
         for (int i = 0; i < len;) {
-            fprintf(F, "%04x:  ", (int)i);
+            fprintf(debug_out, "%04x:  ", (int)i);
 
             for (int j = 0; j < 16 && i < len; j++, i++) {
-                fprintf(F, "%02x ", bytes[i]);
+                fprintf(debug_out, "%02x ", bytes[i]);
             }
-            fprintf(F, "\n");
+            fprintf(debug_out, "\n");
         }
     }
 }


### PR DESCRIPTION
Change the behavior of the "picoquicdemo" client and server so that login is controlled by the "-l" option:
* -l file : log to file
* -l - : log to stdout
* option not present: no logging at all.

Also change the behavior of various log routines so logs always go to the selected log file, and logging on a connection stops after 100 packets have been sent.