### PR TITLE
Add "no disk" option on demo client.

### DIFF
--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -58,7 +58,8 @@ typedef struct st_picoquic_demo_stream_ctx_t {
     size_t received_length;
     size_t scenario_index;
     uint64_t stream_id;
-    FILE* F; /* NULL if stream is closed. */
+    FILE* F; /* NULL if stream is closed or no_disk. */
+    int is_open;
 } picoquic_demo_client_stream_ctx_t;
 
 typedef struct st_picoquic_demo_client_callback_ctx_t {
@@ -75,6 +76,7 @@ typedef struct st_picoquic_demo_client_callback_ctx_t {
     picoquic_alpn_enum alpn;
 
     int progress_observed;
+    int no_disk;
 } picoquic_demo_callback_ctx_t;
 
 picoquic_alpn_enum picoquic_parse_alpn(char const * alpn);
@@ -95,7 +97,8 @@ int picoquic_demo_client_initialize_context(
     picoquic_demo_callback_ctx_t* ctx,
     picoquic_demo_stream_desc_t const * demo_stream,
     size_t nb_demo_streams,
-    char const * alpn);
+    char const * alpn,
+    int no_disk);
 void picoquic_demo_client_delete_context(picoquic_demo_callback_ctx_t* ctx);
 
 int demo_client_parse_scenario_desc(char * text, size_t * nb_streams, picoquic_demo_stream_desc_t ** desc);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -658,7 +658,7 @@ static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server
     picoquic_demo_callback_ctx_t callback_ctx;
     int ret;
 
-    ret = picoquic_demo_client_initialize_context(&callback_ctx, demo_test_scenario, nb_demo_test_scenario, alpn);
+    ret = picoquic_demo_client_initialize_context(&callback_ctx, demo_test_scenario, nb_demo_test_scenario, alpn, 0);
 
     if (ret == 0) {
         ret = tls_api_init_ctx(&test_ctx,


### PR DESCRIPTION
This allow testing without writing the received test files to disk. On some tests, writing to disk costs as much as 35% of the overall client CPU. Not having that allows measurements that concentrate on transport issues.