### PR TITLE
Many stream scenario

### DIFF
--- a/picoquic/democlient.c
+++ b/picoquic/democlient.c
@@ -172,15 +172,13 @@ static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
             stream_ctx->F = NULL;
         }
         else {
-            char * x_name = fname;
+            char const * x_name = fname;
             char repeat_name[512];
             if (nb_repeat > 0) {
 #ifdef _WINDOWS
-                if (sprintf_s(repeat_name, sizeof(repeat_name), "r%dx%s", nb_repeat, fname) <= 0) {
-                    ret = -1;
-                }
+                ret = sprintf_s(repeat_name, sizeof(repeat_name), "r%dx%s", nb_repeat, fname) <= 0;
 #else
-                (void)sprintf_s(repeat_name, "r%dx%s", nb_repeat, fname);
+                ret = sprintf(repeat_name, "r%dx%s", nb_repeat, fname) <= 0;
 #endif
                 x_name = repeat_name;
             }
@@ -508,14 +506,14 @@ void picoquic_demo_client_delete_context(picoquic_demo_callback_ctx_t* ctx)
     }
 }
 
-char * demo_client_parse_stream_spaces(char * text) {
+char const * demo_client_parse_stream_spaces(char const * text) {
     while (*text == ' ' || *text == '\t' || *text == '\n' || *text == '\r') {
         text++;
     }
     return text;
 }
 
-char * demo_client_parse_stream_repeat(char * text, int * number)
+char const * demo_client_parse_stream_repeat(char const * text, int * number)
 {
     int rep = 0;
 
@@ -540,7 +538,7 @@ char * demo_client_parse_stream_repeat(char * text, int * number)
     return text;
 }
 
-char * demo_client_parse_stream_number(char * text, uint64_t default_number, uint64_t * number)
+char const * demo_client_parse_stream_number(char const * text, uint64_t default_number, uint64_t * number)
 {
     if (text[0] < '0' || text[0] > '9') {
         *number = default_number;
@@ -565,7 +563,7 @@ char * demo_client_parse_stream_number(char * text, uint64_t default_number, uin
     return text;
 }
 
-char * demo_client_parse_stream_format(char * text, int default_format, int * is_binary)
+char const * demo_client_parse_stream_format(char const * text, int default_format, int * is_binary)
 {
     if (text[0] != 'b' && text[0] != 't') {
         *is_binary = default_format;
@@ -586,7 +584,7 @@ char * demo_client_parse_stream_format(char * text, int default_format, int * is
     return text;
 }
 
-char * demo_client_parse_stream_path(char * text, 
+char const * demo_client_parse_stream_path(char const * text, 
     char ** path, char ** f_name)
 {
     size_t l_path = 0;
@@ -650,7 +648,7 @@ char * demo_client_parse_stream_path(char * text,
     return text;
 }
 
-char * demo_client_parse_stream_desc(char * text, uint64_t default_stream, uint64_t default_previous,
+char const * demo_client_parse_stream_desc(char const * text, uint64_t default_stream, uint64_t default_previous,
     picoquic_demo_stream_desc_t * desc)
 {
     text = demo_client_parse_stream_repeat(text, &desc->repeat_count);
@@ -692,7 +690,7 @@ void demo_client_delete_scenario_desc(size_t nb_streams, picoquic_demo_stream_de
     free(desc);
 }
 
-size_t demo_client_parse_nb_stream(char * text) {
+size_t demo_client_parse_nb_stream(char const * text) {
     size_t n = 0;
     int after_semi = 1;
 
@@ -711,7 +709,7 @@ size_t demo_client_parse_nb_stream(char * text) {
     return n;
 }
 
-int demo_client_parse_scenario_desc(char * text, size_t * nb_streams, picoquic_demo_stream_desc_t ** desc)
+int demo_client_parse_scenario_desc(char const * text, size_t * nb_streams, picoquic_demo_stream_desc_t ** desc)
 {
     int ret = 0;
     /* first count the number of streams and allocate memory */

--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -41,6 +41,7 @@ typedef enum {
 #define PICOQUIC_DEMO_STREAM_ID_INITIAL (uint64_t)((int64_t)-1)
 
 typedef struct st_picoquic_demo_stream_desc_t {
+    int repeat_count;
     uint64_t stream_id;
     uint64_t previous_stream_id;
     char const* doc_name;

--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -102,7 +102,7 @@ int picoquic_demo_client_initialize_context(
     int no_disk);
 void picoquic_demo_client_delete_context(picoquic_demo_callback_ctx_t* ctx);
 
-int demo_client_parse_scenario_desc(char * text, size_t * nb_streams, picoquic_demo_stream_desc_t ** desc);
+int demo_client_parse_scenario_desc(char const * text, size_t * nb_streams, picoquic_demo_stream_desc_t ** desc);
 void demo_client_delete_scenario_desc(size_t nb_streams, picoquic_demo_stream_desc_t * desc);
 
 #endif /* DEMO_CLIENT_H */

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -340,6 +340,60 @@ char const* picoquic_log_frame_names(uint8_t frame_type)
     return frame_name;
 }
 
+char const* picoquic_log_tp_name(uint64_t tp_number)
+{
+    char const * tp_name = "unknown";
+
+    switch (tp_number) {
+    case picoquic_tp_original_connection_id:
+        tp_name = "ocid";
+        break;
+    case picoquic_tp_idle_timeout:
+        tp_name = "ocid";
+        break;
+    case picoquic_tp_stateless_reset_token:
+        tp_name = "stateless_reset_token";
+        break;
+    case picoquic_tp_max_packet_size:
+        tp_name = "max_packet_size";
+        break;
+    case picoquic_tp_initial_max_data:
+        tp_name = "initial_max_data";
+        break;
+    case picoquic_tp_initial_max_stream_data_bidi_local:
+        tp_name = "max_stream_data_bidi_local";
+        break;
+    case picoquic_tp_initial_max_stream_data_bidi_remote:
+        tp_name = "max_stream_data_bidi_remote";
+        break;
+    case picoquic_tp_initial_max_stream_data_uni:
+        tp_name = "max_stream_data_uni";
+        break;
+    case picoquic_tp_initial_max_streams_bidi:
+        tp_name = "max_streams_bidi";
+        break;
+    case picoquic_tp_initial_max_streams_uni:
+        tp_name = "max_streams_uni";
+        break;
+    case picoquic_tp_ack_delay_exponent:
+        tp_name = "ack_delay_exponent";
+        break;
+    case picoquic_tp_max_ack_delay:
+        tp_name = "max_ack_delay";
+        break;
+    case picoquic_tp_disable_migration:
+        tp_name = "disable_migration";
+        break;
+    case picoquic_tp_server_preferred_address:
+        tp_name = "server_preferred_address";
+        break;
+    default:
+        break;
+    }
+
+    return tp_name;
+}
+
 void picoquic_log_connection_id(FILE* F, picoquic_connection_id_t * cid)
 {
     fprintf(F, "<");
@@ -1480,7 +1534,7 @@ void picoquic_log_transport_extension_content(FILE* F, int log_cnxid, uint64_t c
                 if (log_cnxid != 0) {
                     fprintf(F, "%" PRIx64 ": ", cnx_id_64);
                 }
-                fprintf(F, "    Malformed extension list, only %d byte avaliable.\n", (int)(bytes_max - byte_index));
+                fprintf(F, "    Malformed extension list, only %d byte available.\n", (int)(bytes_max - byte_index));
                 ret = -1;
             }
             else {
@@ -1519,8 +1573,8 @@ void picoquic_log_transport_extension_content(FILE* F, int log_cnxid, uint64_t c
                             if (log_cnxid != 0) {
                                 fprintf(F, "%" PRIx64 ": ", cnx_id_64);
                             }
-                            fprintf(F, "        Extension type: %d, length %d (0x%04x / 0x%04x), ",
-                                extension_type, extension_length, extension_type, extension_length);
+                            fprintf(F, "        Extension type: %d (%s), length %d, ",
+                                extension_type, picoquic_log_tp_name(extension_type), extension_length);
 
                             if (byte_index + extension_length > extensions_end) {
                                 if (log_cnxid != 0) {

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1643,7 +1643,7 @@ int picoquic_incoming_segment(
             *previous_dest_id = ph.dest_cnx_id;
 
             /* if needed, log that the packet is received */
-            if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE)) {
+            if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || quic->use_long_log)) {
                 picoquic_log_packet_address(quic->F_log,
                     picoquic_val64_connection_id((cnx == NULL) ? ph.dest_cnx_id : picoquic_get_logging_cnxid(cnx)),
                     cnx, addr_from, 1, packet_length, current_time);
@@ -1655,7 +1655,7 @@ int picoquic_incoming_segment(
     }
 
     /* Log the incoming segment */
-    if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE)) {
+    if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || quic->use_long_log)) {
         picoquic_log_decrypted_segment(quic->F_log, 1, cnx, 1, &ph, bytes, (uint32_t)*consumed, ret);
     }
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -361,6 +361,7 @@ typedef struct st_picoquic_quic_t {
 
     picoquic_fuzz_fn fuzz_fn;
     void* fuzz_ctx;
+    unsigned int use_long_log : 1;
 } picoquic_quic_t;
 
 picoquic_packet_context_enum picoquic_context_from_epoch(int epoch);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -516,7 +516,7 @@ uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     send_length += /* header_length */ h_length;
 
     /* if needed, log the segment before header protection is applied */
-    if (cnx->quic->F_log != NULL && cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE) {
+    if (cnx->quic->F_log != NULL && (cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || cnx->quic->use_long_log)) {
         picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
             bytes, sequence_number, length,
             send_buffer, send_length);
@@ -3124,7 +3124,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     }
 
     /* if needed, log that the packet is sent */
-    if (*send_length > 0 && cnx->quic->F_log != NULL && cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE) {
+    if (*send_length > 0 && cnx->quic->F_log != NULL && (cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || cnx->quic->use_long_log)) {
         picoquic_log_packet_address(cnx->quic->F_log,
             picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)),
             cnx, (struct sockaddr *)&addr_to_log, 0, *send_length, current_time);

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -230,8 +230,8 @@ int quic_server(const char* server_name, int server_port,
         from_length = to_length = sizeof(struct sockaddr_storage);
         if_index_to = 0;
 
-        if (just_once != 0 && F_log != NULL &&  delta_t > 10000 && cnx_server != NULL && cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE
-            || qserver->use_long_log) {
+        if (just_once != 0 && F_log != NULL &&  delta_t > 10000 && cnx_server != NULL && 
+            (cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || qserver->use_long_log)) {
             picoquic_log_congestion_state(F_log, cnx_server, current_time);
         }
 
@@ -482,7 +482,7 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
     const char * alpn, const char * root_crt,
     uint32_t proposed_version, int force_zero_share, int force_migration,
     int nb_packets_before_key_update, int mtu_max, FILE* F_log,
-    int client_cnx_id_length, char * client_scenario_text, char const * cc_log_dir,
+    int client_cnx_id_length, char const * client_scenario_text, char const * cc_log_dir,
     int no_disk, int use_long_log)
 {
     /* Start: start the QUIC process with cert and key files */

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -163,7 +163,7 @@ int quic_server(const char* server_name, int server_port,
     const char* pem_cert, const char* pem_key,
     int just_once, int do_hrr, picoquic_connection_id_cb_fn cnx_id_callback,
     void* cnx_id_callback_ctx, uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
-    int dest_if, int mtu_max, uint32_t proposed_version, FILE * F_log, char const * cc_log_dir)
+    int dest_if, int mtu_max, uint32_t proposed_version, FILE * F_log, char const * cc_log_dir, int use_long_log)
 {
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
@@ -185,7 +185,6 @@ int quic_server(const char* server_name, int server_port,
     picoquic_stateless_packet_t* sp;
     int64_t delay_max = 10000000;
     int connection_done = 0;
-    int log_count = 0;
 
     /* Open a UDP socket */
     ret = picoquic_open_server_sockets(&server_sockets, server_port);
@@ -208,8 +207,11 @@ int quic_server(const char* server_name, int server_port,
 
             picoquic_set_default_congestion_algorithm(qserver, picoquic_cubic_algorithm);
 
-            /* TODO: add log level, to reduce size in "normal" cases */
             PICOQUIC_SET_LOG(qserver, F_log);
+
+            if (use_long_log) {
+                qserver->use_long_log = 1;
+            }
 
             picoquic_set_key_log_file_from_env(qserver);
 
@@ -228,7 +230,8 @@ int quic_server(const char* server_name, int server_port,
         from_length = to_length = sizeof(struct sockaddr_storage);
         if_index_to = 0;
 
-        if (just_once != 0 && F_log != NULL &&  delta_t > 10000 && cnx_server != NULL && cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE) {
+        if (just_once != 0 && F_log != NULL &&  delta_t > 10000 && cnx_server != NULL && cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE
+            || qserver->use_long_log) {
             picoquic_log_congestion_state(F_log, cnx_server, current_time);
         }
 
@@ -239,8 +242,7 @@ int quic_server(const char* server_name, int server_port,
             delta_t, &current_time);
 
         if (just_once != 0 && F_log != NULL && 
-            (cnx_server == NULL || cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE)) {
-            log_count++;
+            (cnx_server == NULL || cnx_server->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || qserver->use_long_log)) {
             if (bytes_recv > 0) {
                 fprintf(F_log, "Select returns %d, from length %d after %d us (wait for %d us)\n",
                     bytes_recv, from_length, (int)(current_time - time_before), (int)delta_t);
@@ -375,29 +377,6 @@ int quic_server(const char* server_name, int server_port,
 
 static const char * test_scenario_default = "0:index.html;4:test.html;8:1234567;12:main.jpg;16:war-and-peace.txt;20:en/latest/;24:/file-123K";
 
-#if 0
-static const picoquic_demo_stream_desc_t test_scenario[] = {
-#ifdef PICOQUIC_TEST_AGAINST_ATS
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "", "slash.html", 0 },
-    { 8, 4, "en/latest/", "slash_en_slash_latest.html", 0 }
-#else
-#ifdef PICOQUIC_TEST_AGAINST_QUICKLY
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "123.txt", "123.txt", 0 }
-#else
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "index.html", "index.html", 0 },
-    { 4, 0, "test.html", "test.html", 0 },
-    { 8, 0, "1234567", "doc-1234567.html", 0 },
-    { 12, 0, "main.jpg", "main.jpg", 1 },
-    { 16, 0, "war-and-peace.txt", "war-and-peace.txt", 0 },
-    { 20, 0, "en/latest/", "slash_en_slash_latest.html", 0 },
-    { 24, 0, "/file-123K", "file-123k.txt", 0 }
-#endif
-#endif
-};
-
-static const size_t test_scenario_nb = sizeof(test_scenario) / sizeof(picoquic_demo_stream_desc_t);
-#endif
-
 #define PICOQUIC_DEMO_CLIENT_MAX_RECEIVE_BATCH 4
 
 /* Client client migration to a new port number: 
@@ -504,7 +483,7 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
     uint32_t proposed_version, int force_zero_share, int force_migration,
     int nb_packets_before_key_update, int mtu_max, FILE* F_log,
     int client_cnx_id_length, char * client_scenario_text, char const * cc_log_dir,
-    int no_disk)
+    int no_disk, int use_long_log)
 {
     /* Start: start the QUIC process with cert and key files */
     int ret = 0;
@@ -601,6 +580,9 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
             (void)picoquic_set_default_connection_id_length(qclient, (uint8_t)client_cnx_id_length);
 
             PICOQUIC_SET_LOG(qclient, F_log);
+            if (use_long_log) {
+                qclient->use_long_log = 1;
+            }
 
             picoquic_set_key_log_file_from_env(qclient);
 
@@ -696,7 +678,8 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
             delta_t,
             &current_time);
 
-        if (bytes_recv != 0 && F_log != NULL) {
+        if (bytes_recv != 0 && F_log != NULL &&
+            (cnx_client == NULL || cnx_client->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || qclient->use_long_log)){
             fprintf(F_log, "Select returns %d, from length %d\n", bytes_recv, from_length);
         }
 
@@ -1018,6 +1001,7 @@ void usage()
     fprintf(stderr, "                        val and mask must be hex strings of same length, 4 to 18\n");
     fprintf(stderr, "  -k file               key file (default: %s)\n", SERVER_KEY_FILE);
     fprintf(stderr, "  -l file               Log file, Log to stdout if file = \"n\". No logging if absent.\n");
+    fprintf(stderr, "  -L                    Log all packets. If absent, log stops after 100 packets.\n");
     fprintf(stderr, "  -p port               server port (default: %d)\n", default_server_port);
     fprintf(stderr, "  -m mtu_max            Largest mtu value that can be tried for discovery\n");
     fprintf(stderr, "  -n sni                sni (default: server name)\n");
@@ -1071,6 +1055,7 @@ int main(int argc, char** argv)
     int nb_packets_before_update = 0;
     int client_cnx_id_length = 8;
     int no_disk = 0;
+    int use_long_log = 0;
     picoquic_connection_id_callback_ctx_t * cnx_id_cbdata = NULL;
     uint64_t* reset_seed = NULL;
     uint64_t reset_seed_x[2];
@@ -1090,7 +1075,7 @@ int main(int argc, char** argv)
 
     /* Get the parameters */
     int opt;
-    while ((opt = getopt(argc, argv, "c:k:p:u:v:1rhzDf:i:s:e:l:m:n:a:t:S:I:g:")) != -1) {
+    while ((opt = getopt(argc, argv, "c:k:p:u:v:1rhzDLf:i:s:e:l:m:n:a:t:S:I:g:")) != -1) {
         switch (opt) {
         case 'c':
             server_cert_file = optarg;
@@ -1154,6 +1139,9 @@ int main(int argc, char** argv)
             break;
         case 'l':
             log_file = optarg;
+            break;
+        case 'L':
+            use_long_log = 1;
             break;
         case 'm':
             mtu_max = atoi(optarg);
@@ -1273,13 +1261,13 @@ int main(int argc, char** argv)
             server_cert_file, server_key_file, just_once, do_hrr,
             (cnx_id_cbdata == NULL) ? NULL : picoquic_connection_id_callback,
             (cnx_id_cbdata == NULL) ? NULL : (void*)cnx_id_cbdata,
-            (uint8_t*)reset_seed, dest_if, mtu_max, proposed_version, F_log, cc_log_dir);
+            (uint8_t*)reset_seed, dest_if, mtu_max, proposed_version, F_log, cc_log_dir, use_long_log);
         printf("Server exit with code = %d\n", ret);
     } else {
         /* Run as client */
         printf("Starting PicoQUIC connection to server IP = %s, port = %d\n", server_name, server_port);
         ret = quic_client(server_name, server_port, sni, alpn, root_trust_file, proposed_version, force_zero_share, 
-            force_migration, nb_packets_before_update, mtu_max, F_log, client_cnx_id_length, client_scenario, cc_log_dir, no_disk);
+            force_migration, nb_packets_before_update, mtu_max, F_log, client_cnx_id_length, client_scenario, cc_log_dir, no_disk, use_long_log);
 
         printf("Client exit with code = %d\n", ret);
     }

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -373,6 +373,9 @@ int quic_server(const char* server_name, int server_port,
     return ret;
 }
 
+static const char * test_scenario_default = "0:index.html;4:test.html;8:1234567;12:main.jpg;16:war-and-peace.txt;20:en/latest/;24:/file-123K";
+
+#if 0
 static const picoquic_demo_stream_desc_t test_scenario[] = {
 #ifdef PICOQUIC_TEST_AGAINST_ATS
     { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "", "slash.html", 0 },
@@ -393,6 +396,7 @@ static const picoquic_demo_stream_desc_t test_scenario[] = {
 };
 
 static const size_t test_scenario_nb = sizeof(test_scenario) / sizeof(picoquic_demo_stream_desc_t);
+#endif
 
 #define PICOQUIC_DEMO_CLIENT_MAX_RECEIVE_BATCH 4
 
@@ -544,18 +548,17 @@ int quic_client(const char* ip_address_text, int server_port, const char * sni,
         fprintf(stdout, "Files not saved to disk (-D, no_disk)\n");
     }
 
-    if (client_scenario_text != NULL) {
-        fprintf(stdout, "Testing scenario: <%s>\n", client_scenario_text);
-        ret = demo_client_parse_scenario_desc(client_scenario_text, &client_sc_nb, &client_sc);
-        if (ret != 0) {
-            fprintf(stdout, "Cannot parse the specified scenario.\n");
-        }
-        else {
-            ret = picoquic_demo_client_initialize_context(&callback_ctx, client_sc, client_sc_nb, alpn, no_disk);
-        }
+    if (client_scenario_text == NULL) {
+        client_scenario_text = test_scenario_default;
+    }
+
+    fprintf(stdout, "Testing scenario: <%s>\n", client_scenario_text);
+    ret = demo_client_parse_scenario_desc(client_scenario_text, &client_sc_nb, &client_sc);
+    if (ret != 0) {
+        fprintf(stdout, "Cannot parse the specified scenario.\n");
     }
     else {
-        ret = picoquic_demo_client_initialize_context(&callback_ctx, test_scenario, test_scenario_nb, alpn, no_disk);
+        ret = picoquic_demo_client_initialize_context(&callback_ctx, client_sc, client_sc_nb, alpn, no_disk);
     }
 
     if (ret == 0) {

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -564,18 +564,23 @@ int h3zero_stream_test()
 
 char * parse_demo_scenario_text1 = "/;t:test.html;8:0:b:main.jpg;12:0:/bla/bla/";
 char * parse_demo_scenario_text2 = "/;b:main.jpg;t:test.html;";
+char * parse_demo_scenario_text3 = "*1000:/";
 
 static const picoquic_demo_stream_desc_t parse_demo_scenario_desc1[] = {
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
-    { 4, 0, "test.html", "test.html", 0 },
-    { 8, 0, "main.jpg", "main.jpg", 1 },
-    { 12, 0, "/bla/bla/", "_bla_bla_", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
+    { 0, 4, 0, "test.html", "test.html", 0 },
+    { 0, 8, 0, "main.jpg", "main.jpg", 1 },
+    { 0, 12, 0, "/bla/bla/", "_bla_bla_", 0 }
 };
 
 static const picoquic_demo_stream_desc_t parse_demo_scenario_desc2[] = {
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
-    { 4, 0, "main.jpg", "main.jpg", 1 },
-    { 8, 4, "test.html", "test.html", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
+    { 0, 4, 0, "main.jpg", "main.jpg", 1 },
+    { 0, 8, 4, "test.html", "test.html", 0 }
+};
+
+static const picoquic_demo_stream_desc_t parse_demo_scenario_desc3[] = {
+    { 1000, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 }
 };
 
 int parse_demo_scenario_test_one(char * text, size_t nb_streams_ref, picoquic_demo_stream_desc_t const * desc_ref)
@@ -630,6 +635,12 @@ int parse_demo_scenario_test()
             parse_demo_scenario_desc2);
     }
 
+    if (ret == 0) {
+        ret = parse_demo_scenario_test_one(parse_demo_scenario_text3,
+            sizeof(parse_demo_scenario_desc3) / sizeof(picoquic_demo_stream_desc_t),
+            parse_demo_scenario_desc3);
+    }
+
     return ret;
 }
 
@@ -638,8 +649,8 @@ int parse_demo_scenario_test()
  * network simulation.
  */
 static const picoquic_demo_stream_desc_t demo_test_scenario[] = {
-    { 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "root.html", 0 },
-    { 4, 0, "12345", "doc-12345.txt", 0 } };
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "root.html", 0 },
+    { 0, 4, 0, "12345", "doc-12345.txt", 0 } };
 static size_t const nb_demo_test_scenario = sizeof(demo_test_scenario) / sizeof(picoquic_demo_stream_desc_t);
 
 static size_t const demo_test_stream_length[] = {

--- a/picoquictest/log_tp_test_ref.txt
+++ b/picoquictest/log_tp_test_ref.txt
@@ -1,60 +1,60 @@
 102030405060708:     Extension list (43 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 8000ffff
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 80400000
-102030405060708:         Extension type: 8, length 4 (0x0008 / 0x0004), 80004000
-102030405060708:         Extension type: 1, length 1 (0x0001 / 0x0001), 1e
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
-102030405060708:         Extension type: 9, length 4 (0x0009 / 0x0004), 80004000
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 8000ffff
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 80400000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 4, 80004000
+102030405060708:         Extension type: 1 (ocid), length 1, 1e
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
+102030405060708:         Extension type: 9 (max_streams_uni), length 4, 80004000
 
 102030405060708:     Extension list (33 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 81000000
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 81000000
-102030405060708:         Extension type: 8, length 1 (0x0008 / 0x0001), 01
-102030405060708:         Extension type: 1, length 2 (0x0001 / 0x0002), 40ff
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 81000000
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 81000000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 1, 01
+102030405060708:         Extension type: 1 (ocid), length 2, 40ff
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
 
 102030405060708:     Extension list (27 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 81000000
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 81000000
-102030405060708:         Extension type: 8, length 1 (0x0008 / 0x0001), 01
-102030405060708:         Extension type: 1, length 2 (0x0001 / 0x0002), 40ff
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 81000000
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 81000000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 1, 01
+102030405060708:         Extension type: 1 (ocid), length 2, 40ff
 
 102030405060708:     Extension list (55 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 8000ffff
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 80400000
-102030405060708:         Extension type: 8, length 4 (0x0008 / 0x0004), 80004000
-102030405060708:         Extension type: 1, length 1 (0x0001 / 0x0001), 1e
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
-102030405060708:         Extension type: 2, length 16 (0x0002 / 0x0010), 0102030405060708090a0b0c0d0e0f10
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 8000ffff
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 80400000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 4, 80004000
+102030405060708:         Extension type: 1 (ocid), length 1, 1e
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
+102030405060708:         Extension type: 2 (stateless_reset_token), length 16, 0102030405060708090a0b0c0d0e0f10
 
 102030405060708:     Extension list (53 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 81000000
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 81000000
-102030405060708:         Extension type: 8, length 1 (0x0008 / 0x0001), 02
-102030405060708:         Extension type: 1, length 2 (0x0001 / 0x0002), 40ff
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
-102030405060708:         Extension type: 2, length 16 (0x0002 / 0x0010), 0102030405060708090a0b0c0d0e0f10
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 81000000
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 81000000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 1, 02
+102030405060708:         Extension type: 1 (ocid), length 2, 40ff
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
+102030405060708:         Extension type: 2 (stateless_reset_token), length 16, 0102030405060708090a0b0c0d0e0f10
 
 102030405060708:     Extension list (31 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 80010000
-102030405060708:         Extension type: 4, length 8 (0x0004 / 0x0008), c0000000ffffffff
-102030405060708:         Extension type: 1, length 1 (0x0001 / 0x0001), 1e
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 80010000
+102030405060708:         Extension type: 4 (initial_max_data), length 8, c0000000ffffffff
+102030405060708:         Extension type: 1 (ocid), length 1, 1e
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
 
 102030405060708:     Extension list (38 bytes):
-102030405060708:         Extension type: 1, length 2 (0x0001 / 0x0002), 400a
-102030405060708:         Extension type: 8, length 1 (0x0008 / 0x0001), 02
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 80002000
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 80004000
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c0
-102030405060708:         Extension type: 10, length 1 (0x000a / 0x0001), 11
+102030405060708:         Extension type: 1 (ocid), length 2, 400a
+102030405060708:         Extension type: 8 (max_streams_bidi), length 1, 02
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 80002000
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 80004000
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c0
+102030405060708:         Extension type: 10 (ack_delay_exponent), length 1, 11
 
 102030405060708:     Extension list (102 bytes):
-102030405060708:         Extension type: 5, length 4 (0x0005 / 0x0004), 81000000
-102030405060708:         Extension type: 4, length 4 (0x0004 / 0x0004), 81000000
-102030405060708:         Extension type: 8, length 1 (0x0008 / 0x0001), 02
-102030405060708:         Extension type: 1, length 2 (0x0001 / 0x0002), 40ff
-102030405060708:         Extension type: 3, length 2 (0x0003 / 0x0002), 45c8
-102030405060708:         Extension type: 2, length 16 (0x0002 / 0x0010), 0102030405060708090a0b0c0d0e0f10
-102030405060708:         Extension type: 13, length 45 (0x000d / 0x002d), 0a000001115100000000000000000000000000000000000004010203040102030405060708090a0b0c0d0e0f10
+102030405060708:         Extension type: 5 (max_stream_data_bidi_local), length 4, 81000000
+102030405060708:         Extension type: 4 (initial_max_data), length 4, 81000000
+102030405060708:         Extension type: 8 (max_streams_bidi), length 1, 02
+102030405060708:         Extension type: 1 (ocid), length 2, 40ff
+102030405060708:         Extension type: 3 (max_packet_size), length 2, 45c8
+102030405060708:         Extension type: 2 (stateless_reset_token), length 16, 0102030405060708090a0b0c0d0e0f10
+102030405060708:         Extension type: 13 (server_preferred_address), length 45, 0a000001115100000000000000000000000000000000000004010203040102030405060708090a0b0c0d0e0f10
 


### PR DESCRIPTION
Add an option to specify "many downloads" in the demo scenario. For example, "*1000:/12345;" will request 1000 downloads of 12345 bytes.
Add logging of TP names, because debugging the "many downloads" trial runs requires looking at parameter values.
Add option to log all packets, instead of just the first 100 packets.
This is part of performance work, to check what happens when a larger number of streams are open.