### PR TITLE
Add a "stream_ctx" parameter in the callback for active streams.

### DIFF
--- a/picoquic/democlient.c
+++ b/picoquic/democlient.c
@@ -361,8 +361,10 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
             if (fin_or_event == picoquic_callback_stream_fin) {
                 if (picoquic_demo_client_close_stream(ctx, stream_ctx)) {
                     fin_stream_id = stream_id;
-                    fprintf(stdout, "Stream %d ended after %d bytes\n",
-                        (int)stream_id, (int)stream_ctx->received_length);
+                    if (stream_id <= 64) {
+                        fprintf(stdout, "Stream %d ended after %d bytes\n",
+                            (int)stream_id, (int)stream_ctx->received_length);
+                    }
                 }
             }
         }

--- a/picoquic/democlient.c
+++ b/picoquic/democlient.c
@@ -311,8 +311,9 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
     uint64_t fin_stream_id = PICOQUIC_DEMO_STREAM_ID_INITIAL;
     picoquic_demo_callback_ctx_t* ctx = (picoquic_demo_callback_ctx_t*)callback_ctx;
     picoquic_demo_client_stream_ctx_t* stream_ctx;
+#ifdef _WINDOWS
     UNREFERENCED_PARAMETER(v_stream_ctx);
-
+#endif
 
     ctx->last_interaction_time = picoquic_get_quic_time(cnx->quic);
     ctx->progress_observed = 1;

--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -93,7 +93,7 @@ int picoquic_demo_client_start_streams(picoquic_cnx_t* cnx,
     picoquic_demo_callback_ctx_t* ctx, uint64_t fin_stream_id);
 int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
 int picoquic_demo_client_initialize_context(
     picoquic_demo_callback_ctx_t* ctx,
     picoquic_demo_stream_desc_t const * demo_stream,

--- a/picoquic/demoserver.c
+++ b/picoquic/demoserver.c
@@ -250,7 +250,7 @@ static int h3zero_server_parse_request_frame(
                 ret = picoquic_reset_stream(cnx, stream_ctx->stream_id, H3ZERO_INTERNAL_ERROR);
             }
             else if (stream_ctx->echo_length != 0) {
-                ret = picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1);
+                ret = picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, stream_ctx);
             }
         }
     }
@@ -280,7 +280,9 @@ static int h3zero_server_callback_data(
         }
         else {
             /* Find or create stream context */
-            stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1);
+            if (stream_ctx == NULL) {
+                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1);
+            }
 
             if (stream_ctx == NULL) {
                 ret = picoquic_stop_sending(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
@@ -323,12 +325,15 @@ static int h3zero_server_callback_data(
 }
 
 int h3zero_server_callback_prepare_to_send(picoquic_cnx_t* cnx,
-    uint64_t stream_id, void* context, size_t space,
-    h3zero_server_callback_ctx_t* ctx)
+    uint64_t stream_id, h3zero_server_stream_ctx_t * stream_ctx,
+    void * context, size_t space, h3zero_server_callback_ctx_t* ctx)
 {
 
     int ret = -1;
-    h3zero_server_stream_ctx_t * stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+
+    if (stream_ctx == NULL) {
+        stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+    }
 
     if (stream_ctx == NULL) {
         ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
@@ -384,11 +389,11 @@ static int h3zero_server_init(picoquic_cnx_t* cnx)
  */
 int h3zero_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     h3zero_server_callback_ctx_t* ctx = (h3zero_server_callback_ctx_t*)callback_ctx;
-    h3zero_server_stream_ctx_t* stream_ctx = NULL;
+    h3zero_server_stream_ctx_t* stream_ctx = (h3zero_server_stream_ctx_t*)v_stream_ctx;
 
     if (ctx == NULL) {
         ctx = h3zero_server_callback_create_context();
@@ -413,7 +418,9 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
         case picoquic_callback_stream_reset: /* Client reset stream #x */
         case picoquic_callback_stop_sending: /* Client asks server to reset stream #x */
             /* TODO: special case for uni streams. */
-            stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+            if (stream_ctx == NULL) {
+                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+            }
             if (stream_ctx != NULL) {
                 stream_ctx->status = h3zero_server_stream_status_finished;
             }
@@ -427,7 +434,9 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
             break;
         case picoquic_callback_stream_gap:
             /* Gap indication, when unreliable streams are supported */
-            stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+            if (stream_ctx == NULL) {
+                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+            }
             if (stream_ctx != NULL) {
                 stream_ctx->status = h3zero_server_stream_status_finished;
             }
@@ -435,7 +444,7 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
             break;
         case picoquic_callback_prepare_to_send:
             /* Used for active streams */
-            ret = h3zero_server_callback_prepare_to_send(cnx, stream_id, (void*)bytes, length, ctx);
+            ret = h3zero_server_callback_prepare_to_send(cnx, stream_id, stream_ctx, (void*)bytes, length, ctx);
             break;
         case picoquic_callback_almost_ready:
         case picoquic_callback_ready:
@@ -515,7 +524,7 @@ static void picoquic_h09_server_callback_delete_context(picoquic_h09_server_call
 
 int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     picoquic_h09_server_callback_ctx_t* ctx = (picoquic_h09_server_callback_ctx_t*)callback_ctx;
     picoquic_h09_server_stream_ctx_t* stream_ctx = NULL;
@@ -713,7 +722,7 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
 
 int picoquic_demo_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     picoquic_alpn_enum alpn_code = picoquic_alpn_undef;
@@ -725,11 +734,11 @@ int picoquic_demo_server_callback(picoquic_cnx_t* cnx,
 
     switch (alpn_code) {
     case picoquic_alpn_http_3:
-        ret = h3zero_server_callback(cnx, stream_id, bytes, length, fin_or_event, callback_ctx);
+        ret = h3zero_server_callback(cnx, stream_id, bytes, length, fin_or_event, callback_ctx, v_stream_ctx);
         break;
     case picoquic_alpn_http_0_9:
     default:
-        ret = picoquic_h09_server_callback(cnx, stream_id, bytes, length, fin_or_event, callback_ctx);
+        ret = picoquic_h09_server_callback(cnx, stream_id, bytes, length, fin_or_event, callback_ctx, v_stream_ctx);
         break;
     }
 

--- a/picoquic/demoserver.c
+++ b/picoquic/demoserver.c
@@ -238,9 +238,9 @@ static int h3zero_server_parse_request_frame(
             }
 
             if (o_bytes != NULL) {
-                ret = picoquic_add_to_stream(cnx, stream_ctx->stream_id,
+                ret = picoquic_add_to_stream_with_ctx(cnx, stream_ctx->stream_id,
                     buffer, o_bytes - buffer,
-                    (stream_ctx->echo_length == 0) ? 1 : 0);
+                    (stream_ctx->echo_length == 0) ? 1 : 0, stream_ctx);
                 if (ret != 0) {
                     o_bytes = NULL;
                 }

--- a/picoquic/demoserver.h
+++ b/picoquic/demoserver.h
@@ -59,7 +59,7 @@ typedef struct st_h3zero_server_callback_ctx_t {
 
 int h3zero_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
 
 
 /* Defining then the Http 0.9 variant of the server
@@ -84,6 +84,7 @@ typedef struct st_picoquic_h09_server_stream_ctx_t {
 } picoquic_h09_server_stream_ctx_t;
 
 typedef struct st_picoquic_h09_server_callback_ctx_t {
+
     picoquic_h09_server_stream_ctx_t* first_stream;
     size_t buffer_max;
     uint8_t* buffer;
@@ -91,7 +92,7 @@ typedef struct st_picoquic_h09_server_callback_ctx_t {
 
 int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
 
 /* The generic server callback will call either http3 or http0.9,
  * according to the ALPN selected by the client
@@ -99,6 +100,6 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
 
 int picoquic_demo_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
 
 #endif /* DEMO_SERVER_H */

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1213,7 +1213,7 @@ int picoquic_incoming_stateless_reset(
     cnx->cnx_state = picoquic_state_disconnected;
 
     if (cnx->callback_fn) {
-        (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_stateless_reset, cnx->callback_ctx);
+        (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_stateless_reset, cnx->callback_ctx, NULL);
     }
 
     return PICOQUIC_ERROR_AEAD_CHECK;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -332,7 +332,7 @@ uint64_t picoquic_get_quic_time(picoquic_quic_t* quic); /* connection time, comp
  */
 typedef int (*picoquic_stream_data_cb_fn)(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx);
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void * stream_ctx);
 
 /* Callback function for producing a connection ID compatible
  * with the server environment.
@@ -556,7 +556,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
  * queued data has been sent.
  */
 int picoquic_mark_active_stream(picoquic_cnx_t* cnx,
-    uint64_t stream_id, int is_active);
+    uint64_t stream_id, int is_active, void* v_stream_ctx);
 
 /* Mark stream as high priority. This guarantees that the data
  * queued on this stream will be sent before data from any other

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -595,9 +595,16 @@ uint8_t* picoquic_provide_stream_data_buffer(void* context, size_t nb_bytes, int
  * when ready. The data is copied in an intermediate buffer managed by
  * the transport. Calling this API automatically erases the "active
  * mark" that might have been set by using "picoquic_mark_active_stream".
+ * It also erases the "app_stream_ctx" value set in previous calls to
+ * picoquic_add_to_stream_with_ctx or picoquic_mark_active_stream
  */
 int picoquic_add_to_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, const uint8_t* data, size_t length, int set_fin);
+
+/* Same as "picoquic_add_to_stream", but also sets the application stream context.
+ * The context is used in call backs, so the application can directly process responses.
+ */
+int picoquic_add_to_stream_with_ctx(picoquic_cnx_t * cnx, uint64_t stream_id, const uint8_t * data, size_t length, int set_fin, void * app_stream_ctx);
 
 /* Reset a stream, indicating that no more data will be sent on 
  * that stream and that any data currently queued can be abandoned. */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -404,6 +404,7 @@ typedef struct st_picoquic_stream_head_t {
     picoquic_stream_data_t* stream_data;
     uint64_t sent_offset;
     picoquic_stream_data_t* send_queue;
+    void * app_stream_ctx;
     picoquic_sack_item_t first_sack_item;
     /* Flags describing the state of the stream */
     unsigned int is_active : 1; /* The application is actively managing data sending through callbacks */

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -26,27 +26,25 @@
 #include <assert.h>
 #include "picosplay.h"
 
-void picosplay_check_sanity(picosplay_tree *tree);
-
 /* The single most important utility function. */
-static void rotate(picosplay_node *child);
+static void rotate(picosplay_node_t *child);
 /* And a few more. */
-static picosplay_node* leftmost(picosplay_node *node);
-static picosplay_node* rightmost(picosplay_node *node);
+static picosplay_node_t* leftmost(picosplay_node_t *node);
+static picosplay_node_t* rightmost(picosplay_node_t *node);
 
 
 /* The meat: splay the node x. */
-static void zig(picosplay_node *x);
-static void zigzig(picosplay_node *x, picosplay_node *p);
-static void zigzag(picosplay_node *x);
-static void splay(picosplay_tree *tree, picosplay_node *x) {
+static void zig(picosplay_node_t *x);
+static void zigzig(picosplay_node_t *x, picosplay_node_t *p);
+static void zigzag(picosplay_node_t *x);
+static void splay(picosplay_tree_t *tree, picosplay_node_t *x) {
     while(1) {
-        picosplay_node *p = x->parent;
+        picosplay_node_t *p = x->parent;
         if(p == NULL) {
             tree->root = x;
             return;
         }
-        picosplay_node *g = p->parent;
+        picosplay_node_t *g = p->parent;
         if(p->parent == NULL)
             zig(x);
         else
@@ -59,14 +57,14 @@ static void splay(picosplay_tree *tree, picosplay_node *x) {
 }
 
 /* When p is root, rotate on the edge between x and p.*/
-static void zig(picosplay_node *x) {
+static void zig(picosplay_node_t *x) {
     rotate(x);
 }
 
 /* When both x and p are left (or both right) children,
  * rotate on edge between p and g, then on edge between x and p.
  */
-static void zigzig(picosplay_node *x, picosplay_node *p) {
+static void zigzig(picosplay_node_t *x, picosplay_node_t *p) {
     rotate(p);
     rotate(x);
 }
@@ -74,21 +72,21 @@ static void zigzig(picosplay_node *x, picosplay_node *p) {
 /* When one of x and p is a left child and the other a right child,
  * rotate on the edge between x and p, then on the new edge between x and g.
  */
-static void zigzag(picosplay_node *x) {
+static void zigzag(picosplay_node_t *x) {
     rotate(x);
     rotate(x);
 }
 
 /* Initialize an empty tree, storing the picosplay_comparator. */
-void picosplay_init_tree(picosplay_tree* tree, picosplay_comparator comp) {
+void picosplay_init_tree(picosplay_tree_t* tree, picosplay_comparator comp) {
     tree->comp = comp;
     tree->root = NULL;
     tree->size = 0;
 }
 
 /* Return an empty tree, storing the picosplay_comparator. */
-picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
-    picosplay_tree *new = malloc(sizeof(picosplay_tree));
+picosplay_tree_t* picosplay_new_tree(picosplay_comparator comp) {
+    picosplay_tree_t *new = malloc(sizeof(picosplay_tree_t));
     if (new != NULL) {
         new->comp = comp;
         new->root = NULL;
@@ -100,8 +98,8 @@ picosplay_tree* picosplay_new_tree(picosplay_comparator comp) {
 /* picosplay_insert and return a new node with the given value, splaying the tree. 
  * The insertion is essentially a generic BST insertion.
  */
-picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
-    picosplay_node *new = malloc(sizeof(picosplay_node));
+picosplay_node_t* picosplay_insert(picosplay_tree_t *tree, void *value) {
+    picosplay_node_t *new = malloc(sizeof(picosplay_node_t));
 
     if (new != NULL) {
         new->value = value;
@@ -112,8 +110,8 @@ picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
             new->parent = NULL;
         }
         else {
-            picosplay_node *curr = tree->root;
-            picosplay_node *parent = NULL;
+            picosplay_node_t *curr = tree->root;
+            picosplay_node_t *parent = NULL;
             int left = 0;
             while (curr != NULL) {
                 parent = curr;
@@ -140,8 +138,8 @@ picosplay_node* picosplay_insert(picosplay_tree *tree, void *value) {
 }
 
 /* Find a node with the given value, splaying the tree. */
-picosplay_node* picosplay_find(picosplay_tree *tree, void *value) {
-    picosplay_node *curr = tree->root;
+picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value) {
+    picosplay_node_t *curr = tree->root;
     int found = 0;
     while(curr != NULL && !found) {
         int relation = tree->comp(value, curr->value);
@@ -163,13 +161,13 @@ picosplay_node* picosplay_find(picosplay_tree *tree, void *value) {
 }
 
 /* Remove a node with the given value, splaying the tree. */
-void picosplay_delete(picosplay_tree *tree, void *value) {
-    picosplay_node *node = picosplay_find(tree, value);
+void picosplay_delete(picosplay_tree_t *tree, void *value) {
+    picosplay_node_t *node = picosplay_find(tree, value);
     picosplay_delete_hint(tree, node);
 }
 
 /* Remove the node given by the pointer, splaying the tree. */
-void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node) {
+void picosplay_delete_hint(picosplay_tree_t *tree, picosplay_node_t *node) {
     if(node == NULL)
         return;
     splay(tree, node); /* Now node is tree's root. */
@@ -181,7 +179,7 @@ void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node) {
         tree->root = node->left;
         tree->root->parent = NULL;
     } else {
-        picosplay_node *x = leftmost(node->right);
+        picosplay_node_t *x = leftmost(node->right);
         if(x->parent != node) {
             x->parent->left = x->right;
             if(x->right != NULL)
@@ -198,7 +196,7 @@ void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node) {
     tree->size--;
 }
 
-void picosplay_empty_tree(picosplay_tree * tree)
+void picosplay_empty_tree(picosplay_tree_t * tree)
 {
     if (tree != NULL) {
         while (tree->root != NULL) {
@@ -207,7 +205,7 @@ void picosplay_empty_tree(picosplay_tree * tree)
     }
 }
 
-picosplay_node* picosplay_first(picosplay_tree *tree) {
+picosplay_node_t* picosplay_first(picosplay_tree_t *tree) {
     return leftmost(tree->root);
 }
 
@@ -216,7 +214,7 @@ picosplay_node* picosplay_first(picosplay_tree *tree) {
  *  - leftmost child in the right subtree
  *  - closest ascendant for which given node is in left subtree
  */
-picosplay_node* picosplay_next(picosplay_node *node) {
+picosplay_node_t* picosplay_next(picosplay_node_t *node) {
     if(node->right != NULL)
         return leftmost(node->right);
     while(node->parent != NULL && node == node->parent->right)
@@ -224,7 +222,7 @@ picosplay_node* picosplay_next(picosplay_node *node) {
     return node->parent;
 }
 
-picosplay_node* picosplay_last(picosplay_tree *tree) {
+picosplay_node_t* picosplay_last(picosplay_tree_t *tree) {
     return rightmost(tree->root);
 }
 
@@ -232,8 +230,8 @@ picosplay_node* picosplay_last(picosplay_tree *tree) {
 /* analyzer flags a memory leak in this code. We do not use it yet. */
 /* TODO: fix memory leak before restoring this. */
 /* An in-order traversal of the tree. */
-static void store(picosplay_node *node, void ***out);
-void* picosplay_contents(picosplay_tree *tree) {
+static void store(picosplay_node_t *node, void ***out);
+void* picosplay_contents(picosplay_tree_t *tree) {
     if(tree->size == 0)
         return NULL;
     void **out = malloc(tree->size * sizeof(void*));
@@ -242,7 +240,7 @@ void* picosplay_contents(picosplay_tree *tree) {
     return out - tree->size;
 }
 
-static void store(picosplay_node *node, void ***out) {
+static void store(picosplay_node_t *node, void ***out) {
     if(node->left != NULL)
         store(node->left, out);
     **out = node->value;
@@ -252,11 +250,11 @@ static void store(picosplay_node *node, void ***out) {
 }
 #endif
 /* This mutates the parental relationships, copy pointer to old parent. */
-static void mark_gp(picosplay_node *child);
+static void mark_gp(picosplay_node_t *child);
 
 /* Rotate to make the given child take its parent's place in the tree. */
-static void rotate(picosplay_node *child) {
-    picosplay_node *parent = child->parent;
+static void rotate(picosplay_node_t *child) {
+    picosplay_node_t *parent = child->parent;
     assert(parent != NULL);
     if(parent->left == child) { /* A left child given. */
         mark_gp(child);
@@ -273,9 +271,9 @@ static void rotate(picosplay_node *child) {
     }
 }
 
-static void mark_gp(picosplay_node *child) {
-    picosplay_node *parent = child->parent;
-    picosplay_node *grand = parent->parent;
+static void mark_gp(picosplay_node_t *child) {
+    picosplay_node_t *parent = child->parent;
+    picosplay_node_t *grand = parent->parent;
     child->parent = grand;
     parent->parent = child;
     if(grand == NULL)
@@ -286,8 +284,8 @@ static void mark_gp(picosplay_node *child) {
         grand->right = child;
 }
 
-static picosplay_node* leftmost(picosplay_node *node) {
-    picosplay_node *parent = NULL;
+static picosplay_node_t* leftmost(picosplay_node_t *node) {
+    picosplay_node_t *parent = NULL;
     while(node != NULL) {
         parent = node;
         node = node->left;
@@ -295,8 +293,8 @@ static picosplay_node* leftmost(picosplay_node *node) {
     return parent;
 }
 
-static picosplay_node* rightmost(picosplay_node *node) {
-    picosplay_node *parent = NULL;
+static picosplay_node_t* rightmost(picosplay_node_t *node) {
+    picosplay_node_t *parent = NULL;
     while(node != NULL) {
         parent = node;
         node = node->right;

--- a/picoquic/picosplay.h
+++ b/picoquic/picosplay.h
@@ -27,31 +27,31 @@
 
 typedef int (*picosplay_comparator)(void *left, void *right);
 
-typedef struct picosplay_node {
-    struct picosplay_node *parent, *left, *right;
+typedef struct st_picosplay_node_t {
+    struct st_picosplay_node_t *parent, *left, *right;
     void *value;
-} picosplay_node;
+} picosplay_node_t;
 
-typedef struct picosplay_tree {
-    picosplay_node *root;
+typedef struct st_picosplay_tree_t {
+    picosplay_node_t *root;
     picosplay_comparator comp;
     int size;
-} picosplay_tree;
+} picosplay_tree_t;
 
-void picosplay_init_tree(picosplay_tree* tree, picosplay_comparator comp);
-picosplay_tree* picosplay_new_tree(picosplay_comparator comp);
-picosplay_node* picosplay_insert(picosplay_tree *tree, void *value);
-picosplay_node* picosplay_find(picosplay_tree *tree, void *value);
-picosplay_node* picosplay_first(picosplay_tree *tree);
-picosplay_node* picosplay_next(picosplay_node *node);
-picosplay_node* picosplay_last(picosplay_tree *tree);
+void picosplay_init_tree(picosplay_tree_t* tree, picosplay_comparator comp);
+picosplay_tree_t* picosplay_new_tree(picosplay_comparator comp);
+picosplay_node_t* picosplay_insert(picosplay_tree_t *tree, void *value);
+picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value);
+picosplay_node_t* picosplay_first(picosplay_tree_t *tree);
+picosplay_node_t* picosplay_next(picosplay_node_t *node);
+picosplay_node_t* picosplay_last(picosplay_tree_t *tree);
 #if 0
 /* analyzer flags a memory leak in this code. We do not use it yet. */
 /* TODO: fix memory leak before restoring this. */
-void* picosplay_contents(picosplay_tree *tree);
+void* picosplay_contents(picosplay_tree_t *tree);
 #endif
-void picosplay_delete(picosplay_tree *tree, void *value);
-void picosplay_delete_hint(picosplay_tree *tree, picosplay_node *node);
-void picosplay_empty_tree(picosplay_tree *tree);
+void picosplay_delete(picosplay_tree_t *tree, void *value);
+void picosplay_delete_hint(picosplay_tree_t *tree, picosplay_node_t *node);
+void picosplay_empty_tree(picosplay_tree_t *tree);
 
 #endif /* PICOSPLAY_H */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2113,7 +2113,7 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
             /* Give the application a chance to clean up its state */
             cnx->cnx_state = picoquic_state_disconnected;
             if (cnx->callback_fn) {
-                (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx);
+                (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
             }
         }
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -113,8 +113,8 @@ int picoquic_mark_high_priority_stream(picoquic_cnx_t * cnx, uint64_t stream_id,
     return 0;
 }
 
-int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
-    const uint8_t* data, size_t length, int set_fin)
+int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
+    const uint8_t* data, size_t length, int set_fin, void * app_stream_ctx)
 {
     int ret = 0;
     picoquic_stream_head_t* stream = picoquic_find_stream_for_writing(cnx, stream_id, &ret);
@@ -171,9 +171,16 @@ int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
     if (ret == 0) {
         cnx->nb_bytes_queued += length;
         stream->is_active = 0;
+        stream->app_stream_ctx = app_stream_ctx;
     }
 
     return ret;
+}
+
+int picoquic_add_to_stream(picoquic_cnx_t* cnx, uint64_t stream_id,
+    const uint8_t* data, size_t length, int set_fin)
+{
+    return picoquic_add_to_stream_with_ctx(cnx, stream_id, data, length, set_fin, NULL);
 }
 
 int picoquic_reset_stream(picoquic_cnx_t* cnx,

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -1075,7 +1075,7 @@ int main(int argc, char** argv)
 
     /* Get the parameters */
     int opt;
-    while ((opt = getopt(argc, argv, "c:k:p:u:v:1rhzDLf:i:s:e:l:m:n:a:t:S:I:g:")) != -1) {
+    while ((opt = getopt(argc, argv, "c:k:p:u:v:f:i:s:e:l:m:n:a:t:S:I:g:1rhzDL")) != -1) {
         switch (opt) {
         case 'c':
             server_cert_file = optarg;

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -31,7 +31,7 @@ static int compare_int(void *l, void *r) {
     return *((int*)l) - *((int*)r);
 }
 
-static int check_node_sanity(picosplay_node *x, void *floor, void *ceil, picosplay_comparator comp) {
+static int check_node_sanity(picosplay_node_t *x, void *floor, void *ceil, picosplay_comparator comp) {
     int count = 0;
 
     if (x != NULL) {
@@ -72,7 +72,7 @@ static int check_node_sanity(picosplay_node *x, void *floor, void *ceil, picospl
 int splay_test() {
     int ret = 0;
     int count = 0;
-    picosplay_tree *tree = picosplay_new_tree(&compare_int);
+    picosplay_tree_t *tree = picosplay_new_tree(&compare_int);
     int values[] = {3, 4, 1, 2, 8, 5, 7};
     int values_first[] = { 3, 3, 1, 1, 1, 1, 1 };
     int values_last[] = { 3, 4, 4, 4, 8, 8, 8 };

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -118,7 +118,7 @@ static void stress_debug_break()
 
 static int stress_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     picoquic_stress_server_callback_ctx_t* ctx = (picoquic_stress_server_callback_ctx_t*)callback_ctx;
@@ -302,7 +302,7 @@ static void stress_client_start_streams(picoquic_cnx_t* cnx,
 
 static int stress_client_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     picoquic_stress_client_callback_ctx_t* ctx = (picoquic_stress_client_callback_ctx_t*)callback_ctx;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -297,7 +297,7 @@ static int test_api_queue_initial_queries(picoquic_test_tls_api_ctx_t* test_ctx,
     }
 
     if (test_ctx->stream0_target > 0) {
-        ret = picoquic_mark_active_stream(test_ctx->cnx_client, 0, 1);
+        ret = picoquic_mark_active_stream(test_ctx->cnx_client, 0, 1, NULL);
     }
 
     if (more_stream == 0) {
@@ -319,7 +319,7 @@ static int test_api_queue_initial_queries(picoquic_test_tls_api_ctx_t* test_ctx,
 
 static int test_api_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     /* Need to implement the server sending strategy */
     test_api_callback_t* cb_ctx = (test_api_callback_t*)callback_ctx;
@@ -5796,7 +5796,7 @@ typedef struct st_tls_api_address_are_documented_t {
 
 static int test_local_address_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     int local_addr_len, remote_addr_len;
@@ -5840,7 +5840,7 @@ static int test_local_address_callback(picoquic_cnx_t* cnx,
         picoquic_stream_data_cb_fn new_fn;
         void * new_ctx;
 
-        ret = (cb_ctx->callback_fn)(cnx, stream_id, bytes, length, fin_or_event, cb_ctx->callback_ctx);
+        ret = (cb_ctx->callback_fn)(cnx, stream_id, bytes, length, fin_or_event, cb_ctx->callback_ctx, NULL);
 
         /* Check that the callbacks were not reset during the last call */
         new_fn = picoquic_get_callback_function(cnx);

--- a/quicwind/quicwind_proc.c
+++ b/quicwind/quicwind_proc.c
@@ -152,7 +152,7 @@ static void quicwind_delete_context(picoquic_cnx_t * cnx, quicwind_callback_ctx_
 
 int quicwind_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx)
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx)
 {
     int ret = 0;
     uint64_t fin_stream_id = PICOQUIC_DEMO_STREAM_ID_INITIAL;


### PR DESCRIPTION
This seem to improve performance by 10-20% in "many streams" trial. Loopback test of the scenario `*1000:/10000` now executes at 100 Mbps in debug mode. 