### PR TITLE
Update initial RTT on implicit ACK.

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1011,6 +1011,9 @@ int picoquic_process_ack_of_ack_frame(
     picoquic_sack_item_t* first_sack,
     uint8_t* bytes, size_t bytes_max, size_t* consumed, int is_ecn_14);
 
+void picoquic_update_path_rtt(picoquic_cnx_t* cnx, picoquic_path_t * old_path, int64_t rtt_estimate,
+    picoquic_packet_context_t * pkt_ctx, uint64_t current_time, uint64_t ack_delay);
+
 /* stream management */
 picoquic_stream_head_t* picoquic_create_stream(picoquic_cnx_t* cnx, uint64_t stream_id);
 void picoquic_update_stream_initial_remote(picoquic_cnx_t* cnx);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1507,6 +1507,12 @@ void picoquic_implicit_handshake_ack(picoquic_cnx_t* cnx, picoquic_packet_contex
 
         /* Update the congestion control state for the path */
         if (old_path != NULL) {
+            if (old_path->smoothed_rtt == PICOQUIC_INITIAL_RTT && old_path->rtt_variant == 0) {
+                uint64_t rtt_estimate = current_time - p->send_time;
+
+                picoquic_update_path_rtt(cnx, old_path, rtt_estimate, &cnx->pkt_ctx[pc], current_time, 0);
+            }
+
             if (cnx->congestion_alg != NULL) {
                 cnx->congestion_alg->alg_notify(old_path,
                     picoquic_congestion_notification_acknowledgement,


### PR DESCRIPTION
Ensures that RTT is initialized even when server does not send explicit ACK in initial packet.