### PR TITLE
Faster ack process and server performance

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3136,6 +3136,7 @@ uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, uint8_t* byte
             addr_to != NULL && picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->alt_local_addr) == 0) {
             path_x->alt_challenge_response = challenge_response;
             path_x->alt_response_required = 1;
+            cnx->alt_path_challenge_needed = 1;
         } else {
             DBG_PRINTF("%s", "Path challenge ignored, wrong addresses\n");
         }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1892,7 +1892,7 @@ static picoquic_packet_t* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larg
     uint64_t current_time, uint64_t ack_delay, picoquic_packet_context_enum pc)
 {
     picoquic_packet_context_t * pkt_ctx = &cnx->pkt_ctx[pc];
-    picoquic_packet_t* packet = pkt_ctx->retransmit_newest;
+    picoquic_packet_t* packet = pkt_ctx->retransmit_oldest;
 
     /* Check whether this is a new acknowledgement */
     if (largest > pkt_ctx->highest_acknowledged || pkt_ctx->highest_acknowledged == (uint64_t)((int64_t)-1)) {
@@ -1904,11 +1904,11 @@ static picoquic_packet_t* picoquic_update_rtt(picoquic_cnx_t* cnx, uint64_t larg
             /* if the ACK is reasonably recent, use it to update the RTT */
             /* find the stored copy of the largest acknowledged packet */
 
-            while (packet != NULL && packet->sequence_number > largest) {
-                packet = packet->next_packet;
+            while (packet != NULL && packet->previous_packet != NULL && packet->sequence_number < largest) {
+                packet = packet->previous_packet;
             }
 
-            if (packet == NULL || packet->sequence_number < largest) {
+            if (packet == NULL || packet->sequence_number != largest) {
                 /* There is no copy of this packet in store. It may have
                  * been deleted because too old, or maybe already
                  * retransmitted */

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1449,6 +1449,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header * ph
                         cnx->path[path_id]->alt_challenge_timeout = 0;
                         cnx->path[path_id]->alt_challenge_required = 1;
                         cnx->path[path_id]->alt_challenge_repeat_count = 0;
+                        cnx->alt_path_challenge_needed = 1;
                     }
                 }
                 else if (((cnx->path[path_id]->alt_peer_addr_len == 0 &&
@@ -1466,6 +1467,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header * ph
                     cnx->path[path_id]->alt_challenge_required = 1;
                     cnx->path[path_id]->alt_challenge_timeout = 0;
                     cnx->path[path_id]->alt_challenge_repeat_count = 0;
+                    cnx->alt_path_challenge_needed = 1;
                     /* Require a new challenge on the normal path */
                     new_challenge_required = 1;
                 }

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -666,6 +666,8 @@ typedef struct st_picoquic_cnx_t {
     unsigned int stream_blocked_bidir_sent : 1; /* If stream_blocked has been sent to peer and no stream limit update since */
     unsigned int stream_blocked_unidir_sent : 1; /* If stream_blocked has been sent to peer and no stream limit update since */
     unsigned int max_stream_data_needed : 1; /* If at least one stream needs more data */
+    unsigned int path_demotion_needed : 1; /* If at least one path was recently demoted */
+    unsigned int alt_path_challenge_needed : 1; /* If at least one alt path challenge is needed or in progress */
 
     /* Spin bit policy */
     picoquic_spinbit_version_enum spin_policy;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -584,6 +584,7 @@ typedef struct st_picoquic_packet_context_t {
     uint64_t send_sequence;
 
     picoquic_sack_item_t first_sack_item;
+    uint64_t next_sequence_hole;
     uint64_t time_stamp_largest_received;
     uint64_t highest_ack_sent;
     uint64_t highest_ack_sent_time;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -668,6 +668,7 @@ typedef struct st_picoquic_cnx_t {
     unsigned int max_stream_data_needed : 1; /* If at least one stream needs more data */
     unsigned int path_demotion_needed : 1; /* If at least one path was recently demoted */
     unsigned int alt_path_challenge_needed : 1; /* If at least one alt path challenge is needed or in progress */
+    unsigned int is_handshake_finished : 1; /* If there are no more packets to ack or retransmit in initial  or handshake contexts */
 
     /* Spin bit policy */
     picoquic_spinbit_version_enum spin_policy;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -895,18 +895,21 @@ void picoquic_delete_abandoned_paths(picoquic_cnx_t* cnx, uint64_t current_time,
 {
     int path_index_good = 1;
     int path_index_current = 1;
+    unsigned int is_demotion_in_progress = 0;
 
     while (path_index_current < cnx->nb_paths) {
         if (cnx->path[path_index_current]->challenge_failed ||
             (cnx->path[path_index_current]->path_is_demoted &&
                 current_time >= cnx->path[path_index_current]->demotion_time)) {
             /* Only increment the current index */
+            is_demotion_in_progress |= cnx->path[path_index_current]->path_is_demoted;
             path_index_current++;
         } else {
             if (cnx->path[path_index_current]->path_is_demoted &&
                 current_time < cnx->path[path_index_current]->demotion_time &&
                 *next_wake_time > cnx->path[path_index_current]->demotion_time) {
                 *next_wake_time = cnx->path[path_index_current]->demotion_time;
+                is_demotion_in_progress |= 1;
             }
 
             if (path_index_current > path_index_good) {
@@ -930,6 +933,7 @@ void picoquic_delete_abandoned_paths(picoquic_cnx_t* cnx, uint64_t current_time,
     }
 
     /* TODO: what if there are no paths left? */
+    cnx->path_demotion_needed = is_demotion_in_progress;
 }
 
 /* 
@@ -946,6 +950,7 @@ void picoquic_demote_path(picoquic_cnx_t* cnx, int path_index, uint64_t current_
 
         cnx->path[path_index]->path_is_demoted = 1;
         cnx->path[path_index]->demotion_time = current_time + 3* demote_timer;
+        cnx->path_demotion_needed = 1;
     }
 }
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3050,16 +3050,17 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
         picoquic_delete_abandoned_paths(cnx, current_time, &next_wake_time);
     }
 
-    /* Remove failed probes */
-    picoquic_delete_failed_probes(cnx);
-
     /* Check whether to insert a hole in the sequence of packets */
     picoquic_insert_hole_in_send_sequence_if_needed(cnx, current_time);
 
+    if (cnx->probe_first != NULL) {
+        /* Remove failed probes */
+        picoquic_delete_failed_probes(cnx);
 
-    /* If probes are in waiting, send the first one */
-    ret = picoquic_prepare_probe(cnx, current_time, send_buffer, send_buffer_max, send_length,
-        p_addr_to, to_len, p_addr_from, from_len, &addr_to_log, &next_wake_time);
+        /* If probes are in waiting, send the first one */
+        ret = picoquic_prepare_probe(cnx, current_time, send_buffer, send_buffer_max, send_length,
+            p_addr_to, to_len, p_addr_from, from_len, &addr_to_log, &next_wake_time);
+    }
 
     /* If alternate challenges are waiting, send them */
     if (ret == 0 && *send_length == 0 && cnx->alt_path_challenge_needed) {


### PR DESCRIPTION
This PR performs most of the obvious performance optimizations on the server side, significantly reducing the cost of packet processing. In Windows release mode, the loopback test runs now at 630 Mbps, 480 Mbps in debug mode. Most of the execution time is spent in the socket code -- 67.76% in SendMsg, 5.55% in RecvMsg.