### PR TITLE
Support post method

### DIFF
--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -47,6 +47,7 @@ typedef struct st_picoquic_demo_stream_desc_t {
     char const* doc_name;
     char const* f_name;
     int is_binary;
+    uint64_t post_size;
 } picoquic_demo_stream_desc_t;
 
 #define PICOQUIC_DEMO_STREAM_LIST_MAX 16

--- a/picoquic/democlient.h
+++ b/picoquic/democlient.h
@@ -60,6 +60,8 @@ typedef struct st_picoquic_demo_stream_ctx_t {
     size_t received_length;
     size_t scenario_index;
     uint64_t stream_id;
+    size_t post_size;
+    size_t post_sent;
     FILE* F; /* NULL if stream is closed or no_disk. */
     int is_open;
 } picoquic_demo_client_stream_ctx_t;
@@ -84,11 +86,12 @@ typedef struct st_picoquic_demo_client_callback_ctx_t {
 picoquic_alpn_enum picoquic_parse_alpn(char const * alpn);
 
 int h3zero_client_init(picoquic_cnx_t* cnx);
+int demo_client_prepare_to_send(void * context, size_t space, size_t echo_length, size_t * echo_sent);
 int h3zero_client_create_stream_request(
-    uint8_t * buffer, size_t max_bytes, uint8_t const * path, size_t path_len, size_t * consumed, const char * host);
+    uint8_t * buffer, size_t max_bytes, uint8_t const * path, size_t path_len, size_t post_size, const char * host, size_t * consumed);
 
 int h09_demo_client_prepare_stream_open_command(
-    uint8_t * command, size_t max_size, uint8_t const* path, size_t path_len, size_t * consumed);
+    uint8_t * command, size_t max_size, uint8_t const* path, size_t path_len, size_t post_size, const char * host, size_t * consumed);
 
 int picoquic_demo_client_start_streams(picoquic_cnx_t* cnx,
     picoquic_demo_callback_ctx_t* ctx, uint64_t fin_stream_id);

--- a/picoquic/demoserver.h
+++ b/picoquic/demoserver.h
@@ -37,17 +37,21 @@
 
 typedef enum {
     h3zero_server_stream_status_none = 0,
-    h3zero_server_stream_status_receiving,
+    h3zero_server_stream_status_receiving_frame,
+    h3zero_server_stream_status_receiving_request,
+    h3zero_server_stream_status_receiving_data,
     h3zero_server_stream_status_finished
 } h3zero_server_stream_status_t;
 
 typedef struct st_h3zero_server_stream_ctx_t {
     struct st_h3zero_server_stream_ctx_t* next_stream;
+    h3zero_data_stream_state_t stream_state;
     h3zero_server_stream_status_t status;
     uint64_t stream_id;
     size_t received_length;
     size_t echo_length;
     size_t echo_sent;
+    int is_post;
     uint8_t frame[H3ZERO_SERVER_FRAME_MAX];
 } h3zero_server_stream_ctx_t;
 
@@ -70,6 +74,8 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
 
 typedef enum {
     picoquic_h09_server_stream_status_none = 0,
+    picoquic_h09_server_stream_status_header,
+    picoquic_h09_server_stream_status_crlf,
     picoquic_h09_server_stream_status_receiving,
     picoquic_h09_server_stream_status_finished
 } picoquic_h09_server_stream_status_t;
@@ -82,7 +88,9 @@ typedef struct st_picoquic_h09_server_stream_ctx_t {
     size_t response_length;
     size_t echo_length;
     size_t echo_sent;
+    size_t post_received;
     uint8_t command[PICOQUIC_FIRST_COMMAND_MAX];
+    int method;
 } picoquic_h09_server_stream_ctx_t;
 
 typedef struct st_picoquic_h09_server_callback_ctx_t {

--- a/picoquic/h3zero.c
+++ b/picoquic/h3zero.c
@@ -778,8 +778,8 @@ uint8_t * h3zero_create_bad_method_header_frame(uint8_t * bytes, uint8_t * bytes
         *bytes++ = '0';
         *bytes++ = '5';
     }
-    /* Only the GET method is allowed */
-    bytes = h3zero_qpack_code_encode(bytes, bytes_max, 0xC0, 0x3F, H3ZERO_QPACK_ALLOW_GET);
+    /* Allow GET and POST */
+    bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_ALLOW_GET, (uint8_t *)"GET, POST", 9);
 
     return bytes;
 }
@@ -810,9 +810,6 @@ uint8_t * h3zero_parse_data_stream(uint8_t * bytes, uint8_t * bytes_max,
         *error_found = H3ZERO_INTERNAL_ERROR;
         return NULL;
     }
-
-    /* TODO: the frame type may be encoded as a varint */
-    /* TODO: ignore unknown frame types */
 
     if (!stream_state->frame_header_parsed) {
         size_t frame_type_length;

--- a/picoquic/h3zero.h
+++ b/picoquic/h3zero.h
@@ -125,6 +125,7 @@ typedef enum {
 } http_header_enum_t;
 
 #define H3ZERO_QPACK_CODE_GET 17
+#define H3ZERO_QPACK_CODE_POST 20
 #define H3ZERO_QPACK_CODE_PATH 1
 #define H3ZERO_QPACK_CODE_404 27
 #define H3ZERO_QPACK_CODE_200 25
@@ -192,6 +193,8 @@ uint8_t * h3zero_qpack_int_decode(uint8_t * bytes, uint8_t * bytes_max,
 uint8_t * h3zero_parse_qpack_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     h3zero_header_parts_t * parts);
 
+uint8_t * h3zero_create_post_header_frame(uint8_t * bytes, uint8_t * bytes_max,
+    uint8_t const * path, size_t path_length, char const * host, h3zero_content_type_enum content_type);
 uint8_t * h3zero_create_request_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     uint8_t const * path, size_t path_length, char const * host);
 uint8_t * h3zero_create_response_header_frame(uint8_t * bytes, uint8_t * bytes_max,

--- a/picoquic/h3zero.h
+++ b/picoquic/h3zero.h
@@ -132,6 +132,7 @@ typedef enum {
 #define H3ZERO_QPACK_ALLOW_GET 76
 #define H3ZERO_QPACK_AUTHORITY 0
 #define H3ZERO_QPACK_SCHEME_HTTPS 23
+#define H3ZERO_QPACK_TEXT_PLAIN 53
 
 typedef struct st_h3zero_qpack_static_t {
     int index;
@@ -192,11 +193,11 @@ uint8_t * h3zero_qpack_int_decode(uint8_t * bytes, uint8_t * bytes_max,
 
 uint8_t * h3zero_parse_qpack_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     h3zero_header_parts_t * parts);
-
-uint8_t * h3zero_create_post_header_frame(uint8_t * bytes, uint8_t * bytes_max,
-    uint8_t const * path, size_t path_length, char const * host, h3zero_content_type_enum content_type);
 uint8_t * h3zero_create_request_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     uint8_t const * path, size_t path_length, char const * host);
+uint8_t * h3zero_create_post_header_frame(uint8_t * bytes, uint8_t * bytes_max,
+    uint8_t const * path, size_t path_length, char const * host,
+    h3zero_content_type_enum content_type);
 uint8_t * h3zero_create_response_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     h3zero_content_type_enum doc_type);
 uint8_t * h3zero_create_not_found_header_frame(uint8_t * bytes, uint8_t * bytes_max);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -689,13 +689,17 @@ int parse_demo_scenario_test()
  * network simulation.
  */
 static const picoquic_demo_stream_desc_t demo_test_scenario[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "root.html", 0 },
-    { 0, 4, 0, "12345", "doc-12345.txt", 0 } };
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "root.html", 0, 0 },
+    { 0, 4, 0, "12345", "doc-12345.txt", 0, 0 },
+    { 0, 8, 4, "post-test", "post-test.html", 0, 12345 }
+};
+
 static size_t const nb_demo_test_scenario = sizeof(demo_test_scenario) / sizeof(picoquic_demo_stream_desc_t);
 
 static size_t const demo_test_stream_length[] = {
     128,
-    12345
+    12345,
+    190
 };
 
 static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server_callback_fn)
@@ -783,6 +787,11 @@ static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server
         else if (stream->received_length < demo_test_stream_length[i]) {
             DBG_PRINTF("Scenario stream %d, only %d bytes received\n", 
                 (int)i, (int)stream->received_length);
+            ret = -1;
+        }
+        else if (stream->post_sent < demo_test_scenario[i].post_size) {
+            DBG_PRINTF("Scenario stream %d, only %d bytes sent\n",
+                (int)i, (int)stream->post_sent);
             ret = -1;
         }
     }

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -245,7 +245,7 @@ static uint8_t qpack_test_get_ats2[] = {
 
 static uint8_t qpack_test_post_zzz[] = {
     QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0 | 20, 0x50 | 1,
-    0x80 | 3, QPACK_TEST_HEADER_QPACK_PATH
+    0x80 | 3, QPACK_TEST_HEADER_QPACK_PATH, 0xC0 | 53
 };
 
 static uint8_t qpack_test_string_index_html[] = { QPACK_TEST_HEADER_INDEX_HTML };
@@ -382,6 +382,9 @@ int h3zero_parse_qpack_test()
     for (size_t i = 0; ret == 0 && i < nb_qpack_test_case; i++) {
         ret = h3zero_parse_qpack_test_one(i,
             qpack_test_case[i].bytes, qpack_test_case[i].bytes_length);
+        if (ret != 0) {
+            DBG_PRINTF("Parse QPACK test %d fails.\n", i);
+        }
     }
 
     return ret;

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -243,6 +243,11 @@ static uint8_t qpack_test_get_ats2[] = {
     0xa1, 0x72, 0x1e, 0x9f, 0xd1, 0xc1, 0xd7
 };
 
+static uint8_t qpack_test_post_zzz[] = {
+    QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0 | 20, 0x50 | 1,
+    0x80 | 3, QPACK_TEST_HEADER_QPACK_PATH
+};
+
 static uint8_t qpack_test_string_index_html[] = { QPACK_TEST_HEADER_INDEX_HTML };
 static uint8_t qpack_test_string_slash[] = { '/' };
 static uint8_t qpack_test_string_zzz[] = { 'Z', 'Z', 'Z' };
@@ -307,6 +312,10 @@ static qpack_test_case_t qpack_test_case[] = {
     {
         qpack_test_get_ats2, sizeof(qpack_test_get_ats2),
         { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), 0, 0}
+    },
+    {
+        qpack_test_post_zzz, sizeof(qpack_test_post_zzz),
+        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), 0, 0}
     }
 };
 

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -421,6 +421,7 @@ int h3zero_prepare_qpack_test()
             else {
                 DBG_PRINTF("Case %d, unexpected method: %d\n", j, qpack_test_case[j].parts.method);
                 ret = -1;
+                break;
             }
         }
         else if (qpack_test_case[j].parts.content_type != 0) {

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -590,22 +590,28 @@ int h3zero_stream_test()
 char * parse_demo_scenario_text1 = "/;t:test.html;8:0:b:main.jpg;12:0:/bla/bla/";
 char * parse_demo_scenario_text2 = "/;b:main.jpg;t:test.html;";
 char * parse_demo_scenario_text3 = "*1000:/";
+char * parse_demo_scenario_text4 = "/cgi-sink:1000000;4:/";
 
 static const picoquic_demo_stream_desc_t parse_demo_scenario_desc1[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
-    { 0, 4, 0, "test.html", "test.html", 0 },
-    { 0, 8, 0, "main.jpg", "main.jpg", 1 },
-    { 0, 12, 0, "/bla/bla/", "_bla_bla_", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, 0},
+    { 0, 4, 0, "test.html", "test.html", 0, 0 },
+    { 0, 8, 0, "main.jpg", "main.jpg", 1, 0 },
+    { 0, 12, 0, "/bla/bla/", "_bla_bla_", 0, 0 }
 };
 
 static const picoquic_demo_stream_desc_t parse_demo_scenario_desc2[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
-    { 0, 4, 0, "main.jpg", "main.jpg", 1 },
-    { 0, 8, 4, "test.html", "test.html", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, 0 },
+    { 0, 4, 0, "main.jpg", "main.jpg", 1, 0 },
+    { 0, 8, 4, "test.html", "test.html", 0, 0 }
 };
 
 static const picoquic_demo_stream_desc_t parse_demo_scenario_desc3[] = {
-    { 1000, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 }
+    { 1000, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, 0 }
+};
+
+static const picoquic_demo_stream_desc_t parse_demo_scenario_desc4[] = {
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/cgi-sink", "_cgi-sink", 0, 1000000 },
+    { 0, 4, 0, "/", "_", 0, 0 }
 };
 
 int parse_demo_scenario_test_one(char * text, size_t nb_streams_ref, picoquic_demo_stream_desc_t const * desc_ref)
@@ -632,6 +638,9 @@ int parse_demo_scenario_test_one(char * text, size_t nb_streams_ref, picoquic_de
                     ret = -1;
                 }
                 else if (strcmp(desc[i].f_name, desc_ref[i].f_name) != 0) {
+                    ret = -1;
+                }
+                else if (desc[i].post_size !=  desc_ref[i].post_size) {
                     ret = -1;
                 }
             }
@@ -664,6 +673,12 @@ int parse_demo_scenario_test()
         ret = parse_demo_scenario_test_one(parse_demo_scenario_text3,
             sizeof(parse_demo_scenario_desc3) / sizeof(picoquic_demo_stream_desc_t),
             parse_demo_scenario_desc3);
+    }
+
+    if (ret == 0) {
+        ret = parse_demo_scenario_test_one(parse_demo_scenario_text4,
+            sizeof(parse_demo_scenario_desc4) / sizeof(picoquic_demo_stream_desc_t),
+            parse_demo_scenario_desc4);
     }
 
     return ret;

--- a/quicwind/quicwind_proc.c
+++ b/quicwind/quicwind_proc.c
@@ -401,12 +401,12 @@ int quicwind_start_download(picoquic_cnx_t * cnx, quicwind_callback_ctx_t * ctx,
             switch (ctx->alpn) {
             case picoquic_alpn_http_3:
                 ret = h3zero_client_create_stream_request(
-                    request, sizeof(request), path, path_len, &request_length, cnx->sni);
+                    request, sizeof(request), path, path_len, 0, cnx->sni, &request_length);
                 break;
             case picoquic_alpn_http_0_9:
             default:
                 ret = h09_demo_client_prepare_stream_open_command(
-                    request, sizeof(request), path, path_len, &request_length);
+                    request, sizeof(request), path, path_len, 0, cnx->sni, &request_length);
                 break;
             }
 


### PR DESCRIPTION
Adding support for POST in the H3 stack and in the demo app. This will be useful when testing congestion control, as the traces are easier to collect on the sender side.