### PR TITLE
Fix size_t vs. uint32_t conversions

### DIFF
--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -461,14 +461,14 @@ void picoquic_log_packet_header(FILE* F, uint64_t log_cnxid64, picoquic_packet_h
         picoquic_log_connection_id(F, &ph->dest_cnx_id);
         fprintf(F, ", ");
         picoquic_log_connection_id(F, &ph->srce_cnx_id);
-        fprintf(F, ", Seq: %d, pl: %d\n", ph->pn, ph->pl_val);
+        fprintf(F, ", Seq: %d, pl: %zd\n", ph->pn, ph->pl_val);
         if (ph->ptype == picoquic_packet_initial) {
             picoquic_log_prefix_initial_cid64(F, log_cnxid64);
-            fprintf(F, "    Token length: %d", ph->token_length);
+            fprintf(F, "    Token length: %zd", ph->token_length);
             if (ph->token_length > 0) {
-                uint32_t printed_length = (ph->token_length > 16) ? 16 : ph->token_length;
+                size_t printed_length = (ph->token_length > 16) ? 16 : ph->token_length;
                 fprintf(F, ", Token: ");
-                for (uint8_t i = 0; i < printed_length; i++) {
+                for (size_t i = 0; i < printed_length; i++) {
                     fprintf(F, "%02x", ph->token_bytes[i]);
                 }
                 if (printed_length < ph->token_length) {
@@ -1395,12 +1395,12 @@ void picoquic_log_decrypted_segment(void* F_log, int log_cnxid, picoquic_cnx_t* 
 void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* cnx,
     uint8_t * bytes,
     uint64_t sequence_number,
-    uint32_t length,
-    uint8_t* send_buffer, uint32_t send_length)
+    size_t length,
+    uint8_t* send_buffer, size_t send_length)
 {
     picoquic_cnx_t* pcnx = cnx;
     picoquic_packet_header ph;
-    uint32_t checksum_length = (cnx != NULL) ? picoquic_get_checksum_length(cnx, 0) : 16;
+    size_t checksum_length = (cnx != NULL) ? picoquic_get_checksum_length(cnx, 0) : 16;
     struct sockaddr_in default_addr;
     int ret;
 

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -41,7 +41,7 @@
 int picoquic_is_old_header_invariant(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
+    size_t length,
     picoquic_packet_header* ph)
 {
     int ret = 0; /* return 1 if old invariant */
@@ -140,7 +140,7 @@ int picoquic_is_old_header_invariant(
 int picoquic_parse_packet_header(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
+    size_t length,
     struct sockaddr* addr_from,
     picoquic_packet_header* ph,
     picoquic_cnx_t** pcnx,
@@ -172,7 +172,7 @@ int picoquic_parse_packet_header(
                 l_dest_id = bytes[5];
                 if (6u + l_dest_id + 1u > length) {
                     l_srce_id = 255;
-                    i_srce_id = length;
+                    i_srce_id = (uint32_t)length;
                 }
                 else {
                     l_srce_id = bytes[6 + l_dest_id];
@@ -617,13 +617,13 @@ size_t picoquic_remove_packet_protection(picoquic_cnx_t* cnx,
 int picoquic_parse_header_and_decrypt(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
-    uint32_t packet_length,
+    size_t length,
+    size_t packet_length,
     struct sockaddr* addr_from,
     uint64_t current_time,
     picoquic_packet_header* ph,
     picoquic_cnx_t** pcnx,
-    uint32_t * consumed,
+    size_t * consumed,
     int * new_ctx_created)
 {
     /* Parse the clear text header. Ret == 0 means an incorrect packet that could not be parsed */
@@ -732,7 +732,7 @@ int picoquic_parse_header_and_decrypt(
 int picoquic_incoming_version_negotiation(
     picoquic_cnx_t* cnx,
     uint8_t* bytes,
-    uint32_t length,
+    size_t length,
     struct sockaddr* addr_from,
     picoquic_packet_header* ph,
     uint64_t current_time)
@@ -850,7 +850,7 @@ int picoquic_prepare_version_negotiation(
  */
 void picoquic_process_unexpected_cnxid(
     picoquic_quic_t* quic,
-    uint32_t length,
+    size_t length,
     struct sockaddr* addr_from,
     struct sockaddr* addr_to,
     unsigned long if_index_to,
@@ -860,7 +860,7 @@ void picoquic_process_unexpected_cnxid(
         ph->ptype == picoquic_packet_1rtt_protected) {
         picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(quic);
         if (sp != NULL) {
-            uint32_t pad_size = length - PICOQUIC_RESET_SECRET_SIZE -1;
+            size_t pad_size = length - PICOQUIC_RESET_SECRET_SIZE -1;
             uint8_t* bytes = sp->bytes;
             size_t byte_index = 0;
 
@@ -918,11 +918,11 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
 
     if (sp != NULL) {
         uint8_t* bytes = sp->bytes;
-        uint32_t byte_index = 0;
+        size_t byte_index = 0;
         size_t data_bytes = 0;
-        uint32_t header_length = 0;
-        uint32_t pn_offset;
-        uint32_t pn_length;
+        size_t header_length = 0;
+        size_t pn_offset;
+        size_t pn_length;
 
         cnx->path[0]->remote_cnxid = ph->srce_cnx_id;
 
@@ -1752,9 +1752,9 @@ int picoquic_incoming_encrypted(
 int picoquic_incoming_segment(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
-    uint32_t packet_length,
-    uint32_t * consumed,
+    size_t length,
+    size_t packet_length,
+    size_t * consumed,
     struct sockaddr* addr_from,
     struct sockaddr* addr_to,
     int if_index_to,
@@ -1941,20 +1941,20 @@ int picoquic_incoming_segment(
 int picoquic_incoming_packet(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t packet_length,
+    size_t packet_length,
     struct sockaddr* addr_from,
     struct sockaddr* addr_to,
     int if_index_to,
     unsigned char received_ecn,
     uint64_t current_time)
 {
-    uint32_t consumed_index = 0;
+    size_t consumed_index = 0;
     int ret = 0;
     picoquic_connection_id_t previous_destid = picoquic_null_connection_id;
 
 
     while (consumed_index < packet_length) {
-        uint32_t consumed = 0;
+        size_t consumed = 0;
 
         ret = picoquic_incoming_segment(quic, bytes + consumed_index, 
             packet_length - consumed_index, packet_length,

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -219,9 +219,9 @@ typedef struct st_picoquic_packet_t {
     struct st_picoquic_path_t * send_path;
     uint64_t sequence_number;
     uint64_t send_time;
-    uint32_t length;
-    uint32_t checksum_overhead;
-    uint32_t offset;
+    size_t length;
+    size_t checksum_overhead;
+    size_t offset;
     picoquic_packet_type_enum ptype;
     picoquic_packet_context_enum pc;
     unsigned int is_evaluated : 1;
@@ -556,7 +556,7 @@ void picoquic_delete_stateless_packet(picoquic_stateless_packet_t* sp);
 int picoquic_incoming_packet(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
+    size_t length,
     struct sockaddr* addr_from,
     struct sockaddr* addr_to,
     int if_index_to,

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -113,12 +113,12 @@ typedef struct st_picoquic_packet_header_t {
     picoquic_connection_id_t srce_cnx_id;
     uint32_t pn;
     uint32_t vn;
-    uint32_t offset;
-    uint32_t pn_offset;
+    size_t offset;
+    size_t pn_offset;
     picoquic_packet_type_enum ptype;
     uint64_t pnmask;
     uint64_t pn64;
-    uint16_t payload_length;
+    size_t payload_length;
     int version_index;
     int epoch;
     picoquic_packet_context_enum pc;
@@ -129,9 +129,9 @@ typedef struct st_picoquic_packet_header_t {
     unsigned int has_reserved_bit_set : 1;
     unsigned int is_old_invariant : 1;
 
-    uint32_t token_length;
+    size_t token_length;
     uint8_t * token_bytes;
-    uint16_t pl_val;
+    size_t pl_val;
 } picoquic_packet_header;
 
 /* PMTU discovery requirement status */
@@ -552,8 +552,8 @@ typedef struct st_picoquic_path_t {
     uint64_t max_reorder_gap;
 
     /* MTU */
-    uint32_t send_mtu;
-    uint32_t send_mtu_max_tried;
+    size_t send_mtu;
+    size_t send_mtu_max_tried;
 
     /* Congestion control state */
     uint64_t cwin;
@@ -910,30 +910,30 @@ char* picoquic_string_duplicate(const char* original);
 int picoquic_parse_packet_header(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
+    size_t length,
     struct sockaddr* addr_from,
     picoquic_packet_header* ph,
     picoquic_cnx_t** pcnx,
     int receiving);
 
-uint32_t picoquic_create_packet_header(
+size_t picoquic_create_packet_header(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
     uint64_t sequence_number,
     picoquic_connection_id_t * dest_cnxid,
     picoquic_connection_id_t * srce_cnxid,
     uint8_t* bytes,
-    uint32_t * pn_offset,
-    uint32_t * pn_length);
+    size_t* pn_offset,
+    size_t* pn_length);
 
-uint32_t  picoquic_predict_packet_header_length(
+size_t picoquic_predict_packet_header_length(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type);
 
 void picoquic_update_payload_length(
-    uint8_t* bytes, size_t pnum_index, size_t header_length, uint32_t packet_length);
+    uint8_t* bytes, size_t pnum_index, size_t header_length, size_t packet_length);
 
-uint32_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode);
+size_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode);
 
 int picoquic_is_stream_frame_unlimited(const uint8_t* bytes);
 int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, uint8_t* bytes,
@@ -952,18 +952,18 @@ int picoquic_parse_ack_header(
 
 uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t pn);
 
-uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx,
+size_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     picoquic_packet_type_enum ptype,
     uint8_t * bytes, uint64_t sequence_number,
     picoquic_connection_id_t * remote_cnxid,
     picoquic_connection_id_t * local_cnxid,
-    uint32_t length, uint32_t header_length,
-    uint8_t* send_buffer, uint32_t send_buffer_max,
+    size_t length, size_t header_length,
+    uint8_t* send_buffer, size_t send_buffer_max,
     void * aead_context, void* pn_enc);
 
 void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret,
-    uint32_t length, uint32_t header_length, uint32_t checksum_overhead,
-    size_t * send_length, uint8_t * send_buffer, uint32_t send_buffer_max,
+    size_t length, size_t header_length, size_t checksum_overhead,
+    size_t * send_length, uint8_t * send_buffer, size_t send_buffer_max,
     picoquic_connection_id_t * remote_cnxid,
     picoquic_connection_id_t * local_cnxid,
     picoquic_path_t * path_x, uint64_t current_time);
@@ -974,13 +974,13 @@ void picoquic_ready_state_transition(picoquic_cnx_t* cnx, uint64_t current_time)
 int picoquic_parse_header_and_decrypt(
     picoquic_quic_t* quic,
     uint8_t* bytes,
-    uint32_t length,
-    uint32_t packet_length,
+    size_t length,
+    size_t packet_length,
     struct sockaddr* addr_from,
     uint64_t current_time,
     picoquic_packet_header* ph,
     picoquic_cnx_t** pcnx,
-    uint32_t * consumed,
+    size_t * consumed,
     int * new_context_created);
 
 /* Handling of packet logging */
@@ -990,8 +990,8 @@ void picoquic_log_decrypted_segment(void* F_log, int log_cnxid, picoquic_cnx_t* 
 void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* cnx,
     uint8_t * bytes,
     uint64_t sequence_number,
-    uint32_t length,
-    uint8_t* send_buffer, uint32_t send_length);
+    size_t length,
+    uint8_t* send_buffer, size_t send_length);
 
 void picoquic_log_packet_address(FILE* F, uint64_t log_cnxid64, picoquic_cnx_t* cnx,
     struct sockaddr* addr_peer, int receiving, size_t length, uint64_t current_time);
@@ -1074,7 +1074,7 @@ int picoquic_copy_before_retransmit(picoquic_packet_t * old_p,
     size_t send_buffer_max_minus_checksum,
     int * packet_is_pure_ack,
     int * do_not_detect_spurious,
-    uint32_t * length);
+    size_t * length);
 uint8_t* picoquic_decode_crypto_hs_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
     const uint8_t* bytes_max, int epoch);
 int picoquic_prepare_crypto_hs_frame(picoquic_cnx_t* cnx, int epoch,

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -236,7 +236,7 @@ int picoquic_stop_sending(picoquic_cnx_t* cnx,
  * Manage content padding
  */
 
-uint32_t picoquic_pad_to_target_length(uint8_t * bytes, uint32_t length, uint32_t target)
+size_t picoquic_pad_to_target_length(uint8_t * bytes, size_t length, size_t target)
 {
     if (length < target) {
         memset(bytes + length, 0, target - length);
@@ -246,9 +246,9 @@ uint32_t picoquic_pad_to_target_length(uint8_t * bytes, uint32_t length, uint32_
     return length;
 }
 
-uint32_t picoquic_pad_to_policy(picoquic_cnx_t * cnx, uint8_t * bytes, uint32_t length, uint32_t max_length)
+size_t picoquic_pad_to_policy(picoquic_cnx_t * cnx, uint8_t * bytes, size_t length, uint32_t max_length)
 {
-    uint32_t target = cnx->padding_minsize;
+    size_t target = cnx->padding_minsize;
 
     if (length > target && cnx->padding_multiple != 0) {
         uint32_t delta = (length - target) % cnx->padding_multiple;
@@ -307,7 +307,7 @@ void picoquic_recycle_packet(picoquic_quic_t * quic, picoquic_packet_t* packet)
 }
 
 void picoquic_update_payload_length(
-    uint8_t* bytes, size_t pnum_index, size_t header_length, uint32_t packet_length)
+    uint8_t* bytes, size_t pnum_index, size_t header_length, size_t packet_length)
 {
     if ((bytes[0] & 0x80) != 0 && header_length > 6 && packet_length > header_length && packet_length < 0x4000)
     {
@@ -352,17 +352,17 @@ static int picoquic_is_sending_old_invariant(
     return use_old_invariants;
 }
 
-uint32_t picoquic_create_packet_header(
+size_t picoquic_create_packet_header(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
     uint64_t sequence_number,
     picoquic_connection_id_t * remote_cnxid,
     picoquic_connection_id_t * local_cnxid,
     uint8_t* bytes,
-    uint32_t * pn_offset,
-    uint32_t * pn_length)
+    size_t* pn_offset,
+    size_t* pn_length)
 {
-    uint32_t length = 0;
+    size_t length = 0;
     picoquic_connection_id_t dest_cnx_id =
         (cnx->client_mode && (packet_type == picoquic_packet_initial ||
             packet_type == picoquic_packet_0rtt_protected)
@@ -453,7 +453,7 @@ uint32_t picoquic_create_packet_header(
     return length;
 }
 
-uint32_t picoquic_predict_packet_header_length(
+size_t picoquic_predict_packet_header_length(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type)
 {
@@ -509,9 +509,9 @@ uint32_t picoquic_predict_packet_header_length(
 /*
  * Management of packet protection
  */
-uint32_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode)
+size_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode)
 {
-    uint32_t ret = 16;
+    size_t ret = 16;
 
     if (is_cleartext_mode || cnx->crypto_context[2].aead_encrypt == NULL) {
         ret = picoquic_aead_get_checksum_length(cnx->crypto_context[0].aead_encrypt);
@@ -522,22 +522,22 @@ uint32_t picoquic_get_checksum_length(picoquic_cnx_t* cnx, int is_cleartext_mode
     return ret;
 }
 
-uint32_t picoquic_protect_packet(picoquic_cnx_t* cnx, 
+size_t picoquic_protect_packet(picoquic_cnx_t* cnx, 
     picoquic_packet_type_enum ptype,
     uint8_t * bytes, 
     uint64_t sequence_number,
     picoquic_connection_id_t * remote_cnxid,
     picoquic_connection_id_t * local_cnxid,
-    uint32_t length, uint32_t header_length,
-    uint8_t* send_buffer, uint32_t send_buffer_max,
+    size_t length, size_t header_length,
+    uint8_t* send_buffer, size_t send_buffer_max,
     void * aead_context, void* pn_enc)
 {
-    uint32_t send_length;
-    uint32_t h_length;
-    uint32_t pn_offset = 0;
-    uint32_t sample_offset = 0;
-    uint32_t pn_length = 0;
-    uint32_t aead_checksum_length = (uint32_t)picoquic_aead_get_checksum_length(aead_context);
+    size_t send_length;
+    size_t h_length;
+    size_t pn_offset = 0;
+    size_t sample_offset = 0;
+    size_t pn_length = 0;
+    size_t aead_checksum_length = picoquic_aead_get_checksum_length(aead_context);
 
     /* Create the packet header just before encrypting the content */
     h_length = picoquic_create_packet_header(cnx, ptype,
@@ -716,7 +716,7 @@ void picoquic_queue_for_retransmit(picoquic_cnx_t* cnx, picoquic_path_t * path_x
 
 picoquic_packet_t* picoquic_dequeue_retransmit_packet(picoquic_cnx_t* cnx, picoquic_packet_t* p, int should_free)
 {
-    uint32_t dequeued_length = p->length + p->checksum_overhead;
+    size_t dequeued_length = p->length + p->checksum_overhead;
     picoquic_packet_context_enum pc = p->pc;
 
     if (p->previous_packet == NULL) {
@@ -843,8 +843,8 @@ void picoquic_insert_hole_in_send_sequence_if_needed(picoquic_cnx_t* cnx, uint64
  */
 
 void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret, 
-    uint32_t length, uint32_t header_length, uint32_t checksum_overhead,
-    size_t * send_length, uint8_t * send_buffer, uint32_t send_buffer_max,
+    size_t length, size_t header_length, size_t checksum_overhead,
+    size_t * send_length, uint8_t * send_buffer, size_t send_buffer_max,
     picoquic_connection_id_t * remote_cnxid,
     picoquic_connection_id_t * local_cnxid,
     picoquic_path_t * path_x, uint64_t current_time)
@@ -982,7 +982,7 @@ int picoquic_copy_before_retransmit(picoquic_packet_t * old_p,
     size_t send_buffer_max_minus_checksum,
     int * packet_is_pure_ack,
     int * do_not_detect_spurious,
-    uint32_t * length)
+    size_t * length)
 {
     /* check if this is an ACK only packet */
     int ret = 0;
@@ -1060,10 +1060,10 @@ int picoquic_copy_before_retransmit(picoquic_packet_t * old_p,
 int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
     picoquic_packet_context_enum pc,
     picoquic_path_t * path_x, uint64_t current_time, uint64_t * next_retransmit_time,
-    picoquic_packet_t* packet, size_t send_buffer_max, int* is_cleartext_mode, uint32_t* header_length)
+    picoquic_packet_t* packet, size_t send_buffer_max, int* is_cleartext_mode, size_t* header_length)
 {
     picoquic_packet_t* old_p = cnx->pkt_ctx[pc].retransmit_oldest;
-    uint32_t length = 0;
+    size_t length = 0;
 
     /* TODO: while packets are pure ACK, drop them from retransmit queue */
     while (old_p != NULL) {
@@ -1293,9 +1293,9 @@ int picoquic_should_send_max_data(picoquic_cnx_t* cnx)
 }
 
 /* Compute the next logical probe length */
-static uint32_t picoquic_next_mtu_probe_length(picoquic_cnx_t* cnx, picoquic_path_t * path_x)
+static uint64_t picoquic_next_mtu_probe_length(picoquic_cnx_t* cnx, picoquic_path_t * path_x)
 {
-    uint32_t probe_length;
+    uint64_t probe_length;
 
     if (path_x->send_mtu_max_tried == 0) {
         if (cnx->remote_parameters.max_packet_size > 0) {
@@ -1346,7 +1346,7 @@ picoquic_pmtu_discovery_status_enum picoquic_is_mtu_probe_needed(picoquic_cnx_t*
              * Of course we don't know at this stage how much data will be sent 
              * on the connection; we take the amount of data queued as a proxy
              * for that. */
-            uint32_t next_probe = picoquic_next_mtu_probe_length(cnx, path_x);
+            uint64_t next_probe = picoquic_next_mtu_probe_length(cnx, path_x);
             if (next_probe > path_x->send_mtu) {
                 uint64_t packets_to_send_before = cnx->nb_bytes_queued / path_x->send_mtu;
                 uint64_t packets_to_send_after = cnx->nb_bytes_queued / next_probe;
@@ -1365,13 +1365,13 @@ picoquic_pmtu_discovery_status_enum picoquic_is_mtu_probe_needed(picoquic_cnx_t*
 }
 
 /* Prepare an MTU probe packet */
-uint32_t picoquic_prepare_mtu_probe(picoquic_cnx_t* cnx,
+uint64_t picoquic_prepare_mtu_probe(picoquic_cnx_t* cnx,
     picoquic_path_t * path_x,
-    uint32_t header_length, uint32_t checksum_length,
+    size_t header_length, size_t checksum_length,
     uint8_t* bytes)
 {
-    uint32_t probe_length = picoquic_next_mtu_probe_length(cnx, path_x);
-    uint32_t length = header_length;
+    uint64_t probe_length = picoquic_next_mtu_probe_length(cnx, path_x);
+    size_t length = header_length;
 
     bytes[length++] = picoquic_frame_type_ping;
     bytes[length++] = 0;
@@ -1391,10 +1391,10 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, 
     picoquic_packet_type_enum packet_type = picoquic_packet_0rtt_protected;
     size_t data_bytes = 0;
     int padding_required = 0;
-    uint32_t header_length = 0;
+    size_t header_length = 0;
     uint8_t* bytes = packet->bytes;
-    uint32_t length = 0;
-    uint32_t checksum_overhead = picoquic_aead_get_checksum_length(cnx->crypto_context[1].aead_encrypt);
+    size_t length = 0;
+    size_t checksum_overhead = picoquic_aead_get_checksum_length(cnx->crypto_context[1].aead_encrypt);
 
     send_buffer_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : send_buffer_max;
 
@@ -1502,14 +1502,14 @@ picoquic_packet_type_enum picoquic_packet_type_from_epoch(int epoch)
 }
 
 /* Prepare a required repetition or ack  in a previous context */
-uint32_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
+size_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc,
     picoquic_path_t * path_x, picoquic_packet_t* packet, size_t send_buffer_max, uint64_t current_time, 
-    uint64_t * next_retransmit_time, uint32_t * header_length)
+    uint64_t * next_retransmit_time, size_t * header_length)
 {
     int is_cleartext_mode = (pc == picoquic_packet_context_initial) ? 1 : 0;
-    uint32_t length = 0;
+    size_t length = 0;
     size_t data_bytes = 0;
-    uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+    size_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
 
     *header_length = 0;
 
@@ -1645,13 +1645,13 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
     int ret = 0;
     int tls_ready = 0;
     picoquic_packet_type_enum packet_type = 0;
-    uint32_t checksum_overhead = 8;
+    size_t checksum_overhead = 8;
     int is_cleartext_mode = 1;
     size_t data_bytes = 0;
     int retransmit_possible = 0;
-    uint32_t header_length = 0;
+    size_t header_length = 0;
     uint8_t* bytes = packet->bytes;
-    uint32_t length = 0;
+    size_t length = 0;
     int epoch = 0;
     picoquic_packet_context_enum pc = picoquic_packet_context_initial;
 
@@ -1835,7 +1835,7 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
                                 cnx->original_cnxid.id_len != 0)) {
                             /* Pad to minimum packet length. But don't do that if the
                              * initial packet will be coalesced with 0-RTT packet */
-                            length = picoquic_pad_to_target_length(bytes, length, (uint32_t)(send_buffer_max - checksum_overhead));
+                            length = picoquic_pad_to_target_length(bytes, length, send_buffer_max - checksum_overhead);
                         }
 
                         if (packet_type == picoquic_packet_0rtt_protected) {
@@ -1900,12 +1900,12 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
     int epoch = 0;
     picoquic_packet_type_enum packet_type = picoquic_packet_initial;
     picoquic_packet_context_enum pc = picoquic_packet_context_initial;
-    uint32_t checksum_overhead = 8;
+    size_t checksum_overhead = 8;
     int is_cleartext_mode = 1;
     size_t data_bytes = 0;
-    uint32_t header_length = 0;
+    size_t header_length = 0;
     uint8_t* bytes = packet->bytes;
-    uint32_t length = 0;
+    size_t length = 0;
 
     if (*next_wake_time > cnx->start_time + PICOQUIC_MICROSEC_HANDSHAKE_MAX) {
         *next_wake_time = cnx->start_time + PICOQUIC_MICROSEC_HANDSHAKE_MAX;
@@ -2112,11 +2112,11 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
     int ret = 0;
     /* TODO: manage multiple streams. */
     picoquic_packet_type_enum packet_type = 0;
-    uint32_t checksum_overhead = 8;
+    size_t checksum_overhead = 8;
     int is_cleartext_mode = 1;
-    uint32_t header_length = 0;
+    size_t header_length = 0;
     uint8_t* bytes = packet->bytes;
-    uint32_t length = 0;
+    size_t length = 0;
     picoquic_packet_context_enum pc = picoquic_packet_context_application;
 
     /* The only purpose of the test below is to appease the static analyzer, so it
@@ -2392,11 +2392,11 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x,
     int is_cleartext_mode = 0;
     int is_pure_ack = 1;
     size_t data_bytes = 0;
-    uint32_t header_length = 0;
+    size_t header_length = 0;
     uint8_t* bytes = packet->bytes;
-    uint32_t length = 0;
-    uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
-    uint32_t send_buffer_min_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : (uint32_t)send_buffer_max;
+    size_t length = 0;
+    size_t checksum_overhead = picoquic_get_checksum_length(cnx, is_cleartext_mode);
+    size_t send_buffer_min_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : send_buffer_max;
 
     /*
      * Manage the end of false start transition.
@@ -2893,11 +2893,11 @@ int picoquic_prepare_probe(picoquic_cnx_t* cnx,
             }
             else {
                 uint8_t * bytes = packet->bytes;
-                uint32_t length = 0;
-                uint32_t header_length = 0;
+                size_t length = 0;
+                size_t header_length = 0;
                 picoquic_packet_type_enum packet_type = picoquic_packet_1rtt_protected;
                 picoquic_packet_context_enum pc = picoquic_packet_context_application;
-                uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, 0);
+                size_t checksum_overhead = picoquic_get_checksum_length(cnx, 0);
                 size_t data_bytes = 0;
                 int inactive_path_index = -1;
 
@@ -3018,11 +3018,11 @@ static int picoquic_prepare_alt_challenge(picoquic_cnx_t* cnx,
                 }
                 else {
                     uint8_t * bytes = packet->bytes;
-                    uint32_t length = 0;
-                    uint32_t header_length = 0;
+                    size_t length = 0;
+                    size_t header_length = 0;
                     picoquic_packet_type_enum packet_type = picoquic_packet_1rtt_protected;
                     picoquic_packet_context_enum pc = picoquic_packet_context_application;
-                    uint32_t checksum_overhead = picoquic_get_checksum_length(cnx, 0);
+                    size_t checksum_overhead = picoquic_get_checksum_length(cnx, 0);
                     size_t data_bytes = 0;
 
                     length = picoquic_predict_packet_header_length(

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1612,9 +1612,9 @@ void picoquic_aead_free(void* aead_context)
     ptls_aead_free((ptls_aead_context_t*)aead_context);
 }
 
-uint32_t picoquic_aead_get_checksum_length(void* aead_context)
+size_t picoquic_aead_get_checksum_length(void* aead_context)
 {
-    uint32_t tag_size = (uint32_t)((ptls_aead_context_t*)aead_context)->algo->tag_size;
+    size_t tag_size = ((ptls_aead_context_t*)aead_context)->algo->tag_size;
     /* TODO: remove this temporary fix to deal with Feb 2019 change in picotls */
     if (tag_size > 16) {
         tag_size = 16;
@@ -2148,7 +2148,7 @@ int picoquic_prepare_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_p
 
 int picoquic_verify_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_peer,
     uint64_t current_time, picoquic_connection_id_t * odcid,
-    uint8_t * token, uint32_t token_size)
+    uint8_t * token, size_t token_size)
 {
     int ret = 0;
     uint8_t text[128];

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -63,7 +63,7 @@ void picoquic_public_random_seed(picoquic_quic_t* quic);
 void picoquic_public_random(void* buf, size_t len);
 uint64_t picoquic_public_uniform_random(uint64_t rnd_max);
 
-uint32_t picoquic_aead_get_checksum_length(void* aead_context);
+size_t picoquic_aead_get_checksum_length(void* aead_context);
 
 size_t picoquic_aead_encrypt_generic(uint8_t* output, uint8_t* input, size_t input_length,
     uint64_t seq_num, uint8_t* auth_data, size_t auth_data_length, void* aead_context);
@@ -132,7 +132,7 @@ int picoquic_prepare_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_p
 
 int picoquic_verify_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_peer,
     uint64_t current_time, picoquic_connection_id_t * odcid,
-    uint8_t * token, uint32_t token_size);
+    uint8_t * token, size_t token_size);
 
 void picoquic_cid_free_under_mask_ctx(void * v_pn_enc);
 int picoquic_cid_get_under_mask_ctx(void ** v_pn_enc, const void * secret);

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -388,9 +388,9 @@ int parseheadertest()
     }
 
     for (size_t i = 0; ret == 0 && i < nb_test_entries; i++) {
-        uint32_t header_length;
-        uint32_t pn_offset;
-        uint32_t pn_length;
+        size_t header_length;
+        size_t pn_offset;
+        size_t pn_length;
 
         if (test_entries[i].decode_test_only) {
             continue;
@@ -441,12 +441,12 @@ int test_packet_decrypt_one(
     uint64_t current_time = 0;
     picoquic_packet_header received_ph;
     picoquic_cnx_t* server_cnx = NULL;
-    uint32_t consumed = 0;
+    size_t consumed = 0;
     int new_context_created = 0;
 
     /* Decrypt the packet */
     decoding_return = picoquic_parse_header_and_decrypt(q_server,
-        send_buffer, (uint32_t)send_length, (uint32_t)packet_length,
+        send_buffer, send_length, packet_length,
         addr_from,
         current_time, &received_ph, &server_cnx,
         &consumed, &new_context_created);
@@ -501,8 +501,8 @@ int test_packet_encrypt_one(
 )
 {
     int ret = 0;
-    uint32_t header_length = 0;
-    uint32_t checksum_overhead = 0;
+    size_t header_length = 0;
+    size_t checksum_overhead = 0;
     size_t send_length = 0;
     uint8_t send_buffer[PICOQUIC_MAX_PACKET_SIZE];
     picoquic_path_t * path_x = cnx_client->path[0];

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -1486,7 +1486,7 @@ int test_copy_for_retransmit()
     int ret = 0;
     picoquic_packet_t old_p;
     uint8_t new_bytes[PICOQUIC_MAX_PACKET_SIZE];
-    uint32_t length = 0;
+    size_t length = 0;
     int packet_is_pure_ack = 0;
     int do_not_detect_spurious = 1;
     uint64_t simulated_time = 0;
@@ -1532,7 +1532,7 @@ int test_copy_for_retransmit()
         old_p.is_ack_trap = copy_retransmit_case[i].is_ack_trap;
         old_p.send_path = cnx->path[0];
 
-        length = (uint32_t)copy_retransmit_case[i].b1_offset;
+        length = copy_retransmit_case[i].b1_offset;
 
         ret = picoquic_copy_before_retransmit(&old_p, cnx, new_bytes,
             copy_retransmit_case[i].copy_max,


### PR DESCRIPTION
This change uses size_t for most of the length variables in picoquic.

It fixes some implicit conversions in arithmetic expressions (calculated in uint32_t and then converted to size_t). It also avoids some explicit size_t -> uint32_t conversions.