### PR TITLE
Try fixes on initial fuzzer.

### DIFF
--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -1821,7 +1821,7 @@ void picoquic_open_cc_dump(picoquic_cnx_t * cnx)
         const size_t suffix_len = strlen(suffix);
         size_t folder_length = strlen(cnx->quic->cc_log_dir);
 
-        if (folder_length + 1 + 2*cnx->initial_cnxid.id_len + suffix_len + 1 > sizeof(cc_log_file_name)) {
+        if (folder_length + (size_t)1 + ((size_t)2)* (size_t)cnx->initial_cnxid.id_len + suffix_len + (size_t)1 > sizeof(cc_log_file_name)) {
             ret = -1;
         }
         else {

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -92,6 +92,8 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -439,7 +439,7 @@ typedef struct st_picoquic_stream_head_t {
 #define IS_CLIENT_STREAM_ID(id) (unsigned int)(((id) & 1) == 0)
 #define IS_BIDIR_STREAM_ID(id)  (unsigned int)(((id) & 2) == 0)
 #define IS_LOCAL_STREAM_ID(id, client_mode)  (unsigned int)(((id)^(client_mode)) & 1)
-#define STREAM_ID_FROM_RANK(rank, is_server_stream, is_unidir) (((rank-1ull)<<2)|(uint64_t)((is_unidir)<<1)|(is_server_stream))
+#define STREAM_ID_FROM_RANK(rank, is_server_stream, is_unidir) ((((uint64_t)(rank)-(uint64_t)1)<<2)|(((uint64_t)is_unidir)<<1)|((uint64_t)(is_server_stream)))
 #define STREAM_RANK_FROM_ID(id) ((id + 4)>>2)
 #define STREAM_TYPE_FROM_ID(id) ((id)&3)
 #define NEXT_STREAM_ID_FOR_TYPE(id) ((id)+4)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -221,10 +221,10 @@ picoquic_quic_t* picoquic_create(uint32_t nb_connections,
         }
 
         if (ret == 0) {
-            quic->table_cnx_by_id = picohash_create(nb_connections * 4,
+            quic->table_cnx_by_id = picohash_create((size_t)nb_connections * 4,
                 picoquic_cnx_id_hash, picoquic_cnx_id_compare);
 
-            quic->table_cnx_by_net = picohash_create(nb_connections * 4,
+            quic->table_cnx_by_net = picohash_create((size_t)nb_connections * 4,
                 picoquic_net_id_hash, picoquic_net_id_compare);
 
             if (quic->table_cnx_by_id == NULL || quic->table_cnx_by_net == NULL) {
@@ -1606,7 +1606,7 @@ picoquic_stream_head_t* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t strea
 void picoquic_add_output_streams(picoquic_cnx_t* cnx, uint64_t old_limit, uint64_t new_limit, unsigned int is_bidir)
 {
     uint64_t old_rank = STREAM_RANK_FROM_ID(old_limit);
-    uint64_t first_new_id = STREAM_ID_FROM_RANK(old_rank + 1, !cnx->client_mode, !is_bidir);
+    uint64_t first_new_id = STREAM_ID_FROM_RANK(old_rank + 1ull, !cnx->client_mode, !is_bidir);
     picoquic_stream_head_t* stream = picoquic_find_stream(cnx, first_new_id );
 
     while (stream) {

--- a/picoquic_t/picoquic_t.vcxproj
+++ b/picoquic_t/picoquic_t.vcxproj
@@ -105,6 +105,8 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picoquictest;$(SolutionDir)\picoquicfirst;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -87,12 +87,16 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;_WINDOWS;_WINDOWS64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)\picoquic;$(SolutionDir)\picohttp;$(OPENSSL64DIR)\include;..\..\picotls\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <ForceConformanceInForLoopScope>true</ForceConformanceInForLoopScope>
+      <RemoveUnreferencedCodeData>true</RemoveUnreferencedCodeData>
+      <DebugInformationFormat>OldStyle</DebugInformationFormat>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -1066,8 +1066,8 @@ static int stress_or_fuzz_test(picoquic_fuzz_fn fuzz_fn, void * fuzz_ctx, uint64
         ret = -1;
     }
     else {
-        DBG_PRINTF("Stress complete after simulating %3f s. in %3f s., returns %d\n",
-            run_time_seconds, wall_time_seconds, ret);
+        DBG_PRINTF("Stress complete after simulating %3f s. in %3f s., returns %d, rand %x\n",
+            run_time_seconds, wall_time_seconds, ret, (int)((picoquic_test_random(&stress_random_ctx)>>48)&0xFFFF));
     }
 
     picoquic_fuzz_in_progress = 0;
@@ -1285,6 +1285,7 @@ int random_tester_test()
 
 /*
  * Initial fuzz test.
+ *
  * This test specializes in fuzzing the initial packet, and checking what happens. All the
  * packets sent there are illegitimate, and should result in broken connections.
  *
@@ -1343,7 +1344,9 @@ static uint32_t initial_fuzzer(void * fuzz_ctx, picoquic_cnx_t* cnx,
                 }
                 break;
             case 2:
-                memcpy(&bytes[header_length], test_skip_list[ctx->current_frame].val, len);
+                if (length + len <= bytes_max) {
+                    memcpy(&bytes[header_length], test_skip_list[ctx->current_frame].val, len);
+                }
                 if (length > header_length + len) {
                     memset(&bytes[header_length + len], 0, length - (header_length + len));
                 }

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -416,14 +416,14 @@ int stress_client_set_callback(picoquic_cnx_t* cnx)
             }
             picoquic_set_callback(cnx, stress_client_callback, ctx);
 
-            if ((ctx->message_disconnect_trigger = (uint32_t) picoquic_test_uniform_random(&stress_random_ctx, 2* picoquic_stress_max_message_before_drop)) >= picoquic_stress_max_message_before_drop){
+            if ((ctx->message_disconnect_trigger = (uint32_t) picoquic_test_uniform_random(&stress_random_ctx, ((uint64_t)2)* picoquic_stress_max_message_before_drop)) >= picoquic_stress_max_message_before_drop){
                 ctx->message_disconnect_trigger = 0;
             }
             else {
                 ctx->message_disconnect_trigger++;
             }
 
-            if ((ctx->message_migration_trigger = (uint32_t)picoquic_test_uniform_random(&stress_random_ctx, 2 * picoquic_stress_max_message_before_migrate)) >= picoquic_stress_max_message_before_migrate) {
+            if ((ctx->message_migration_trigger = (uint32_t)picoquic_test_uniform_random(&stress_random_ctx, ((uint64_t)2) * picoquic_stress_max_message_before_migrate)) >= picoquic_stress_max_message_before_migrate) {
                 ctx->message_migration_trigger = 0;
             }
             else {


### PR DESCRIPTION
Fuzz_initial fails randomly at times on Windows "release" builds, but not on Windows "debug" builds. This points to a possible memory initialization issue, which we need to find.