### PR TITLE
Avoid uint32 casts

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1898,7 +1898,7 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
             if (old_path != NULL) {
                 if (p->length + p->checksum_overhead > old_path->send_mtu) {
-                    old_path->send_mtu = (uint32_t)(p->length + p->checksum_overhead);
+                    old_path->send_mtu = p->length + p->checksum_overhead;
                     if (old_path->send_mtu > old_path->send_mtu_max_tried) {
                         old_path->send_mtu_max_tried = old_path->send_mtu;
                     }
@@ -2473,7 +2473,7 @@ static int picoquic_process_ack_range(
 
                     /* If packet is larger than the current MTU, update the MTU */
                     if ((p->length + p->checksum_overhead) > old_path->send_mtu) {
-                        old_path->send_mtu = (uint32_t)(p->length + p->checksum_overhead);
+                        old_path->send_mtu = p->length + p->checksum_overhead;
                         old_path->mtu_probe_sent = 0;
                     }
                 }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1056,11 +1056,11 @@ int picoquic_incoming_initial(
         if (picoquic_verify_retry_token((*pcnx)->quic, addr_from, current_time,
             &(*pcnx)->original_cnxid, ph->token_bytes, ph->token_length) != 0) {
             uint8_t token_buffer[256];
-            uint32_t token_size;
+            size_t token_size;
 
             if (picoquic_prepare_retry_token((*pcnx)->quic, addr_from, 
                 current_time + PICOQUIC_TOKEN_DELAY_SHORT, &ph->dest_cnx_id,
-                token_buffer, (uint32_t)sizeof(token_buffer), &token_size) != 0){ 
+                token_buffer, sizeof(token_buffer), &token_size) != 0){ 
                 ret = PICOQUIC_ERROR_MEMORY;
             }
             else {

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -243,9 +243,9 @@ int picoquic_parse_packet_header(
                                     ph->pc = 0;
                                 }
                                 else {
-                                    ph->token_length = (uint32_t)tok_len;
-                                    ph->token_bytes = bytes + ph->offset + (uint32_t)l_tok_len;
-                                    ph->offset += (uint32_t)(l_tok_len + (size_t)tok_len);
+                                    ph->token_length = (size_t)tok_len;
+                                    ph->token_bytes = bytes + ph->offset + l_tok_len;
+                                    ph->offset += l_tok_len + (size_t)tok_len;
                                 }
 
                                 break;
@@ -831,8 +831,8 @@ int picoquic_prepare_version_negotiation(
 
         if (quic->F_log != NULL) {
             picoquic_log_outgoing_segment(quic->F_log, 1, NULL,
-                bytes, 0, (uint32_t)sp->length,
-                bytes, (uint32_t)sp->length);
+                bytes, 0, sp->length,
+                bytes, sp->length);
         }
 
         picoquic_queue_stateless_packet(quic, sp);
@@ -944,9 +944,9 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
         /* Encode DCIL */
         byte_index += picoquic_format_connection_id(bytes + byte_index,
             PICOQUIC_MAX_PACKET_SIZE - byte_index - checksum_length, cnx->initial_cnxid);
-        byte_index += (uint32_t)data_bytes;
+        byte_index += data_bytes;
         memcpy(&bytes[byte_index], token, token_length);
-        byte_index += (uint32_t)token_length;
+        byte_index += token_length;
 
         sp->length = byte_index;
 
@@ -962,8 +962,8 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
 
         if (cnx->quic->F_log != NULL) {
             picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
-                bytes, 0, (uint32_t)sp->length,
-                bytes, (uint32_t)sp->length);
+                bytes, 0, sp->length,
+                bytes, sp->length);
         }
 
         picoquic_queue_stateless_packet(cnx->quic, sp);
@@ -987,7 +987,7 @@ void picoquic_ignore_incoming_handshake(
     /* The data starts at ph->index, and its length
      * is ph->payload_length. */
     int ret = 0;
-    uint32_t byte_index = 0;
+    size_t byte_index = 0;
     int ack_needed = 0;
     picoquic_packet_context_enum pc;
     
@@ -1009,7 +1009,7 @@ void picoquic_ignore_incoming_handshake(
         int frame_is_pure_ack = 0;
         ret = picoquic_skip_frame(cnx, &bytes[byte_index],
             ph->payload_length - byte_index, &frame_length, &frame_is_pure_ack);
-        byte_index += (uint32_t)frame_length;
+        byte_index += frame_length;
         if (frame_is_pure_ack == 0) {
             ack_needed = 1;
         }
@@ -1793,7 +1793,7 @@ int picoquic_incoming_segment(
 
     /* Log the incoming segment */
     if (quic->F_log != NULL && (cnx == NULL || cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || quic->use_long_log)) {
-        picoquic_log_decrypted_segment(quic->F_log, 1, cnx, 1, &ph, bytes, (uint32_t)*consumed, ret);
+        picoquic_log_decrypted_segment(quic->F_log, 1, cnx, 1, &ph, bytes, *consumed, ret);
     }
 
     if (ret == 0) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2044,12 +2044,12 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
                     /* On a server that does address validation, send a NEW TOKEN frame */
                     if (cnx->client_mode == 0 && (cnx->quic->flags&picoquic_context_check_token) != 0) {
                         uint8_t token_buffer[256];
-                        uint32_t token_size;
+                        size_t token_size;
                         picoquic_connection_id_t n_cid = picoquic_null_connection_id;
 
                         if (picoquic_prepare_retry_token(cnx->quic, (struct sockaddr *)&cnx->path[0]->peer_addr,
                             current_time + PICOQUIC_TOKEN_DELAY_LONG, &n_cid, 
-                            token_buffer, (uint32_t) sizeof(token_buffer), &token_size) == 0) {
+                            token_buffer, sizeof(token_buffer), &token_size) == 0) {
                             if (picoquic_queue_new_token_frame(cnx, token_buffer, token_size) != 0) {
                                 picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_INTERNAL_ERROR, picoquic_frame_type_new_token);
                             }

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -129,7 +129,7 @@ int picoquic_tls_client_authentication_activated(picoquic_quic_t* quic);
 
 int picoquic_prepare_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_peer,
     uint64_t current_time, picoquic_connection_id_t * odcid,
-    uint8_t * token, uint32_t token_max, uint32_t * token_size);
+    uint8_t * token, size_t token_max, size_t * token_size);
 
 int picoquic_verify_retry_token(picoquic_quic_t* quic, struct sockaddr * addr_peer,
     uint64_t current_time, picoquic_connection_id_t * odcid,

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -481,7 +481,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
 
                         switch (extension_type) {
                         case picoquic_tp_initial_max_stream_data_bidi_local:
-                            cnx->remote_parameters.initial_max_stream_data_bidi_local = (uint32_t)
+                            cnx->remote_parameters.initial_max_stream_data_bidi_local = 
                                 picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
 
                             /* If we sent zero rtt data, the streams were created with the
@@ -490,7 +490,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                             picoquic_update_stream_initial_remote(cnx);
                             break;
                         case picoquic_tp_initial_max_stream_data_bidi_remote:
-                            cnx->remote_parameters.initial_max_stream_data_bidi_remote = (uint32_t)
+                            cnx->remote_parameters.initial_max_stream_data_bidi_remote = 
                                 picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                             /* If we sent zero rtt data, the streams were created with the
                             * old value of the remote parameter. We need to update that.
@@ -498,7 +498,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                             picoquic_update_stream_initial_remote(cnx);
                             break;
                         case picoquic_tp_initial_max_stream_data_uni:
-                            cnx->remote_parameters.initial_max_stream_data_uni = (uint32_t)
+                            cnx->remote_parameters.initial_max_stream_data_uni = 
                                 picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                             /* If we sent zero rtt data, the streams were created with the
                             * old value of the remote parameter. We need to update that.
@@ -506,14 +506,14 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                             picoquic_update_stream_initial_remote(cnx);
                             break;
                         case picoquic_tp_initial_max_data:
-                            cnx->remote_parameters.initial_max_data = (uint32_t)
+                            cnx->remote_parameters.initial_max_data = 
                                 picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                             cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
                             break;
                         case picoquic_tp_initial_max_streams_bidi: {
                             uint64_t old_limit = cnx->max_stream_id_bidir_remote;
                             cnx->remote_parameters.initial_max_stream_id_bidir =
-                                picoquic_decode_transport_param_stream_id((uint32_t)
+                                picoquic_decode_transport_param_stream_id(
                                     picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret), extension_mode,
                                     PICOQUIC_STREAM_ID_BIDIR);
 
@@ -550,7 +550,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                         case picoquic_tp_initial_max_streams_uni: {
                             uint64_t old_limit = cnx->max_stream_id_unidir_remote;
                             cnx->remote_parameters.initial_max_stream_id_unidir =
-                                picoquic_decode_transport_param_stream_id((uint32_t)
+                                picoquic_decode_transport_param_stream_id(
                                     picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret), extension_mode,
                                     PICOQUIC_STREAM_ID_UNIDIR);
 


### PR DESCRIPTION
Some more cleanup after the change to size_t for memory buffer sizes/lengths.