### PR TITLE
Initial version of new binary file logging

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -107,8 +107,8 @@ extern "C" {
 #define PICOQUIC_RESET_PACKET_MIN_SIZE (PICOQUIC_RESET_PACKET_PAD_SIZE + PICOQUIC_RESET_SECRET_SIZE)
 
 #define PICOQUIC_LOG_PACKET_MAX_SEQUENCE 100
-#define PICOQUIC_LOG_CC_MAGIC 0x50515452 /* Hex rendering of 'PQTR' */
-#define PICOQUIC_LOG_CC_NB 15
+
+#define FOURCC(a, b, c, d) ((((uint32_t)(d)<<24) | ((c)<<16) | ((b)<<8) | (a)))
 
 /*
 * Connection states, useful to expose the state to the application.

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1015,6 +1015,28 @@ void picoquic_log_time(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time,
 
 void picoquic_set_key_log_file(picoquic_quic_t *quic, FILE* F_keylog);
 
+typedef enum {
+    picoquic_log_event_packet_sent = 0x0002,
+    picoquic_log_event_packet_recv = 0x0003,
+    picoquic_log_event_packet_dropped = 0x0004,
+
+    picoquic_log_event_new_connection = 0x0010,
+    picoquic_log_event_connection_close = 0x0011,
+    picoquic_log_event_connection_id_update = 0x0012,
+
+    picoquic_log_event_tls_key_update = 0x0020,
+    picoquic_log_event_tls_key_retired = 0x0021,
+
+    picoquic_log_event_version_update = 0x0035,
+    picoquic_log_event_param_update = 0x0036,
+    picoquic_log_event_alpn_update = 0x0037,
+    picoquic_log_event_cc_update = 0x0038,
+    picoquic_log_event_stream_update = 0x0039,
+
+    picoquic_log_event_frame_sent = 0x0082,
+    picoquic_log_event_frame_recv = 0x0083,
+} picoquic_log_event_type;
+
 /* Handling of cc_log */
 int picoquic_open_cc_dump(picoquic_cnx_t * cnx);
 void picoquic_close_cc_dump(picoquic_cnx_t * cnx);


### PR DESCRIPTION
* Introduces a new extensible binary log file format that is able to capture all relevant information for
  * CC logging,
  * QLOG logging,
  * Debugging.
* Use the new bytestream writer to log the CC messages.
* Update the converter to output the same CSV data as before.

This PR is for replacing the binary file format only. It does not introduce new logging information yet.