### PR TITLE
Post call back

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1017,5 +1017,11 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+
+        TEST_METHOD(h09_post) {
+            int ret = h09_post_test();
+
+            Assert::AreEqual(ret, 0);
+        }
     };
 }

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1006,12 +1006,16 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
-
         TEST_METHOD(esni) {
             int ret = esni_test();
 
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(h3zero_post) {
+            int ret = h3zero_post_test();
+
+            Assert::AreEqual(ret, 0);
+        }
     };
 }

--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -27,10 +27,65 @@
 #include "h3zero.h"
 #include "democlient.h"
 #include "demoserver.h"
+
+
+static picohttp_server_stream_ctx_t * picohttp_find_or_create_stream(
+    picoquic_cnx_t* cnx,
+    uint64_t stream_id,
+    picohttp_server_stream_ctx_t ** p_first_stream,
+    int should_create,
+    int is_h3)
+{
+    picohttp_server_stream_ctx_t * stream_ctx = NULL;
+
+    /* if stream is already present, check its state. New bytes? */
+    stream_ctx = *p_first_stream;
+    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id) {
+        stream_ctx = stream_ctx->next_stream;
+    }
+
+    if (stream_ctx == NULL && should_create) {
+        stream_ctx = (picohttp_server_stream_ctx_t*)
+            malloc(sizeof(picohttp_server_stream_ctx_t));
+        if (stream_ctx == NULL) {
+            /* Could not handle this stream */
+            picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
+        }
+        else {
+            memset(stream_ctx, 0, sizeof(picohttp_server_stream_ctx_t));
+            stream_ctx->next_stream = *p_first_stream;
+            *p_first_stream = stream_ctx;
+            stream_ctx->stream_id = stream_id;
+        }
+    }
+
+    return stream_ctx;
+}
+
+
+static void picohttp_delete_stream(picohttp_server_stream_ctx_t* stream_ctx)
+{
+
+    if (stream_ctx->path_callback != NULL) {
+        (void)stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx);
+    }
+
+    if (stream_ctx->is_h3) {
+        h3zero_delete_data_stream_state(&stream_ctx->ps.stream_state);
+    }
+    else {
+        if (stream_ctx->ps.hq.path != NULL) {
+            free(stream_ctx->ps.hq.path);
+        }
+    }
+    
+    free(stream_ctx);
+}
+
 /*
  * Create and delete server side connection context
  */
-static h3zero_server_callback_ctx_t * h3zero_server_callback_create_context(picohttp_server_parameters_t * param)
+static h3zero_server_callback_ctx_t* h3zero_server_callback_create_context(picohttp_server_parameters_t* param)
 {
     h3zero_server_callback_ctx_t* ctx = (h3zero_server_callback_ctx_t*)
         malloc(sizeof(h3zero_server_callback_ctx_t));
@@ -57,14 +112,11 @@ static h3zero_server_callback_ctx_t * h3zero_server_callback_create_context(pico
 
 static void h3zero_server_callback_delete_context(h3zero_server_callback_ctx_t* ctx)
 {
-    picohttp_server_stream_ctx_t * stream_ctx;
+    picohttp_server_stream_ctx_t* stream_ctx;
 
     while ((stream_ctx = ctx->first_stream) != NULL) {
         ctx->first_stream = stream_ctx->next_stream;
-        if (stream_ctx->path_callback != NULL) {
-            (void)stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx->path_callback_ctx, stream_ctx);
-        }
-        free(stream_ctx);
+        picohttp_delete_stream(stream_ctx);
     }
 
     if (ctx->buffer != NULL) {
@@ -75,37 +127,6 @@ static void h3zero_server_callback_delete_context(h3zero_server_callback_ctx_t* 
     free(ctx);
 }
 
-static picohttp_server_stream_ctx_t * h3zero_find_or_create_stream(
-    picoquic_cnx_t* cnx,
-    uint64_t stream_id,
-    h3zero_server_callback_ctx_t* ctx,
-    int should_create)
-{
-    picohttp_server_stream_ctx_t * stream_ctx = NULL;
-
-    /* if stream is already present, check its state. New bytes? */
-    stream_ctx = ctx->first_stream;
-    while (stream_ctx != NULL && stream_ctx->stream_id != stream_id) {
-        stream_ctx = stream_ctx->next_stream;
-    }
-
-    if (stream_ctx == NULL && should_create) {
-        stream_ctx = (picohttp_server_stream_ctx_t*)
-            malloc(sizeof(picohttp_server_stream_ctx_t));
-        if (stream_ctx == NULL) {
-            /* Could not handle this stream */
-            picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
-        }
-        else {
-            memset(stream_ctx, 0, sizeof(picohttp_server_stream_ctx_t));
-            stream_ctx->next_stream = ctx->first_stream;
-            ctx->first_stream = stream_ctx;
-            stream_ctx->stream_id = stream_id;
-        }
-    }
-
-    return stream_ctx;
-}
 
 /*
  * Incoming data call back.
@@ -187,30 +208,30 @@ static int h3zero_server_process_request_frame(
     *o_bytes++ = h3zero_frame_header;
     o_bytes += 2; /* reserve two bytes for frame length */
 
-    if (stream_ctx->stream_state.header.method != h3zero_method_get &&
-        stream_ctx->stream_state.header.method != h3zero_method_post) {
+    if (stream_ctx->ps.stream_state.header.method != h3zero_method_get &&
+        stream_ctx->ps.stream_state.header.method != h3zero_method_post) {
         /* No such method supported -- error 405, header include "allow GET. POST" */
         o_bytes = h3zero_create_bad_method_header_frame(o_bytes, o_bytes_max);
     }
-    else if (stream_ctx->stream_state.header.method == h3zero_method_get &&
-        demo_server_parse_path(stream_ctx->stream_state.header.path, stream_ctx->stream_state.header.path_length, &stream_ctx->echo_length) != 0) {
+    else if (stream_ctx->ps.stream_state.header.method == h3zero_method_get &&
+        demo_server_parse_path(stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, &stream_ctx->echo_length) != 0) {
         /* If unknown, 404 */
         o_bytes = h3zero_create_not_found_header_frame(o_bytes, o_bytes_max);
         /* TODO: consider known-url?data construct */
     }
     else {
-        if (stream_ctx->stream_state.header.method == h3zero_method_post) {
+        if (stream_ctx->ps.stream_state.header.method == h3zero_method_post) {
             if (stream_ctx->path_callback == NULL && stream_ctx->post_received == 0) {
-                int path_item = picohttp_find_path_item(stream_ctx->stream_state.header.path, stream_ctx->stream_state.header.path_length, path_table, path_table_nb);
+                int path_item = picohttp_find_path_item(stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, path_table, path_table_nb);
                 if (path_item >= 0) {
                     /* TODO-POST: move this code to post-fin callback.*/
                     stream_ctx->path_callback = path_table[path_item].path_callback;
-                    stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->stream_state.header.path, stream_ctx->stream_state.header.path_length, picohttp_callback_post, NULL, stream_ctx);
+                    stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post, stream_ctx);
                 }
             }
 
             if (stream_ctx->path_callback != NULL) {
-                response_length = stream_ctx->path_callback(cnx, post_response, sizeof(post_response), picohttp_callback_post_fin, stream_ctx->path_callback_ctx, stream_ctx);
+                response_length = stream_ctx->path_callback(cnx, post_response, sizeof(post_response), picohttp_callback_post_fin, stream_ctx);
             } else {
                 /* Prepare generic POST response */
                 (void)picoquic_sprintf((char*)post_response, sizeof(post_response), &response_length, demo_server_post_response_page, (int)stream_ctx->post_received);
@@ -254,7 +275,7 @@ static int h3zero_server_process_request_frame(
                 if (stream_ctx->echo_length == 0) {
                     if (response_length <= sizeof(post_response)) {
                         if (o_bytes + response_length <= o_bytes_max) {
-                            memcpy(o_bytes, (stream_ctx->stream_state.header.method == h3zero_method_post) ? post_response : (uint8_t*)demo_server_default_page, response_length);
+                            memcpy(o_bytes, (stream_ctx->ps.stream_state.header.method == h3zero_method_post) ? post_response : (uint8_t*)demo_server_default_page, response_length);
                             o_bytes += response_length;
                         }
                         else {
@@ -324,7 +345,7 @@ static int h3zero_server_callback_data(
         else {
             /* Find or create stream context */
             if (stream_ctx == NULL) {
-                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1);
+                stream_ctx = picohttp_find_or_create_stream(cnx, stream_id, &ctx->first_stream, 1, 1);
             }
 
             if (stream_ctx == NULL) {
@@ -339,24 +360,26 @@ static int h3zero_server_callback_data(
                 size_t available_data = 0;
                 uint8_t * bytes_max = bytes + length;
                 while (bytes < bytes_max) {
-                    bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->stream_state, &available_data, &error_found);
+                    bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->ps.stream_state, &available_data, &error_found);
                     if (bytes == NULL) {
                         ret = picoquic_close(cnx, error_found);
                         break;
                     }
                     else if (available_data > 0) {
-                        if (stream_ctx->stream_state.header_found && stream_ctx->post_received == 0) {
-                            int path_item = picohttp_find_path_item(stream_ctx->stream_state.header.path, stream_ctx->stream_state.header.path_length, ctx->path_table, ctx->path_table_nb);
+                        if (stream_ctx->ps.stream_state.header_found && stream_ctx->post_received == 0) {
+                            int path_item = picohttp_find_path_item(stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, ctx->path_table, ctx->path_table_nb);
                             if (path_item >= 0) {
                                 stream_ctx->path_callback = ctx->path_table[path_item].path_callback;
-                                stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->stream_state.header.path, stream_ctx->stream_state.header.path_length, picohttp_callback_post, NULL, stream_ctx);
+                                stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post, stream_ctx);
                             }
+
+                            (void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
                         }
 
                         /* Received data for a POST command. */
                         if (stream_ctx->path_callback != NULL) {
                             /* if known URL, pass the data to URL specific callback. */
-                            ret = stream_ctx->path_callback(cnx, bytes, available_data, picohttp_callback_post_data, stream_ctx->path_callback_ctx, stream_ctx);
+                            ret = stream_ctx->path_callback(cnx, bytes, available_data, picohttp_callback_post_data, stream_ctx);
                         }
                         stream_ctx->post_received += available_data;
                         bytes += available_data;
@@ -365,7 +388,7 @@ static int h3zero_server_callback_data(
                 
                 if (fin_or_event == picoquic_callback_stream_fin) {
                     /* Process the request header. */
-                    if (stream_ctx->stream_state.header_found) {
+                    if (stream_ctx->ps.stream_state.header_found) {
                         ret = h3zero_server_process_request_frame(cnx, stream_ctx, ctx->path_table, ctx->path_table_nb);
                     }
                     else {
@@ -398,7 +421,7 @@ int h3zero_server_callback_prepare_to_send(picoquic_cnx_t* cnx,
     int ret = -1;
 
     if (stream_ctx == NULL) {
-        stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+        stream_ctx = picohttp_find_or_create_stream(cnx, stream_id, &ctx->first_stream, 0, 1);
     }
 
     if (stream_ctx == NULL) {
@@ -407,7 +430,7 @@ int h3zero_server_callback_prepare_to_send(picoquic_cnx_t* cnx,
     else {
         if (stream_ctx->path_callback != NULL) {
             /* Get data from callback context of specific URL */
-            ret = stream_ctx->path_callback(cnx, context, space, picohttp_callback_provide_data, stream_ctx->path_callback_ctx, stream_ctx);
+            ret = stream_ctx->path_callback(cnx, context, space, picohttp_callback_provide_data, stream_ctx);
         }
         else {
             /* default reply for known URL */
@@ -492,14 +515,13 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
         case picoquic_callback_stop_sending: /* Client asks server to reset stream #x */
             /* TODO: special case for uni streams. */
             if (stream_ctx == NULL) {
-                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+                stream_ctx = picohttp_find_or_create_stream(cnx, stream_id, &ctx->first_stream, 0, 1);
             }
             if (stream_ctx != NULL) {
                 /* reset post callback. */
                 if (stream_ctx->path_callback != NULL) {
-                    ret = stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx->path_callback_ctx, stream_ctx);
+                    ret = stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx);
                 }
-                stream_ctx->status = picohttp_server_stream_status_finished;
             }
             picoquic_reset_stream(cnx, stream_id, 0);
             break;
@@ -514,13 +536,13 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
         case picoquic_callback_stream_gap:
             /* Gap indication, when unreliable streams are supported */
             if (stream_ctx == NULL) {
-                stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 0);
+                stream_ctx = picohttp_find_or_create_stream(cnx, stream_id, &ctx->first_stream, 0, 1);
             }
             if (stream_ctx != NULL) {
                 if (stream_ctx->path_callback != NULL) {
-                    ret = stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx->path_callback_ctx, stream_ctx);
+                    ret = stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx);
                 }
-                stream_ctx->status = picohttp_server_stream_status_finished;
+                stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
             }
             picoquic_stop_sending(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
             break;
@@ -589,7 +611,7 @@ static void picoquic_h09_server_callback_delete_context(picoquic_h09_server_call
 
     while ((stream_ctx = ctx->first_stream) != NULL) {
         ctx->first_stream = stream_ctx->next_stream;
-        free(stream_ctx);
+        picohttp_delete_stream(stream_ctx);
     }
 
     free(ctx);
@@ -690,15 +712,10 @@ static void picoquic_h09_server_parse_protocol(uint8_t* command, size_t command_
     }
 }
 
-static int picoquic_h09_server_process_command(uint8_t* command, size_t command_length, int * method, size_t * echo_length)
+static int picohttp_server_parse_commandline(uint8_t* command, size_t command_length, picohttp_server_stream_ctx_t* stream_ctx)
 {
     int ret = 0;
-    size_t byte_index = 0;
     size_t consumed;
-    int proto;
-
-
-    *echo_length = 0;
 
     /* Find first line of command, ignore the rest */
     for (size_t i = 0; i < command_length; i++) {
@@ -709,33 +726,43 @@ static int picoquic_h09_server_process_command(uint8_t* command, size_t command_
     }
 
     /* Parse protocol version and strip white spaces at the end of the command */
-    picoquic_h09_server_parse_protocol(command, command_length, &proto, &consumed);
+    picoquic_h09_server_parse_protocol(command, command_length, &stream_ctx->ps.hq.proto, &consumed);
     command_length -= consumed;
 
     /* parse the method */
-    *method = picoquic_h09_server_parse_method(command, command_length, &consumed);
+    stream_ctx->method = picoquic_h09_server_parse_method(command, command_length, &consumed);
 
-    if (*method < 0) {
+    /* Skip white spaces between method and path, and copy path if present */
+    if (stream_ctx->method < 0) {
         ret = -1;
-    } else {
-        byte_index = consumed;
-
+    }
+    else {
         /* Skip at list one space */
-        while (command_length > byte_index && (command[byte_index] == ' ' || command[byte_index] == '\t')) {
-            byte_index++;
+        while (command_length > consumed && (command[consumed] == ' ' || command[consumed] == '\t')) {
+            consumed++;
         }
 
-        if (byte_index >= command_length) {
+        if (consumed >= command_length) {
             ret = -1;
         }
-    }
+        else {
+            size_t path_length = command_length - consumed;
+            uint8_t* path = (uint8_t*)malloc(path_length + 1);
 
-    /* if the input is in incorrect form, return 0 length error message */
-    if (ret == 0 && *method != 1) {
-        ret = demo_server_parse_path(command + byte_index, command_length - byte_index, echo_length);
+            if (path != NULL) {
+                memcpy(path, command + consumed, path_length);
+                path[path_length] = 0;
+                stream_ctx->ps.hq.path = path;
+                stream_ctx->ps.hq.path_length = path_length;
+            }
+            else {
+                ret = -1;
+            }
+        }
     }
 
     return ret;
+
 }
 
 /*
@@ -759,13 +786,15 @@ static int picoquic_h09_server_process_command(uint8_t* command, size_t command_
 
 int picoquic_h09_server_process_data(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, picohttp_server_stream_ctx_t* stream_ctx)
+    picoquic_call_back_event_t fin_or_event, 
+    picoquic_h09_server_callback_ctx_t* app_ctx,
+    picohttp_server_stream_ctx_t* stream_ctx)
 {
     int ret = 0;
     size_t processed = 0;
 
     while (processed < length) {
-        if (stream_ctx->status == picohttp_server_stream_status_none) {
+        if (stream_ctx->ps.hq.status == picohttp_server_stream_status_none) {
             /* If the command has not been received yet, try to process it */
             int crlf_present = 0;
 
@@ -773,8 +802,8 @@ int picoquic_h09_server_process_data(picoquic_cnx_t* cnx,
                 if (bytes[processed] == '\r' || bytes[processed] == '\n') {
                     crlf_present = 1;
                 }
-                else if (stream_ctx->command_length < sizeof(stream_ctx->frame)) {
-                    stream_ctx->frame[stream_ctx->command_length++] = bytes[processed];
+                else if (stream_ctx->ps.hq.command_length < sizeof(stream_ctx->frame)) {
+                    stream_ctx->frame[stream_ctx->ps.hq.command_length++] = bytes[processed];
                 }
                 else {
                     /* Too much data */
@@ -784,41 +813,51 @@ int picoquic_h09_server_process_data(picoquic_cnx_t* cnx,
             }
 
             if (crlf_present) {
-                stream_ctx->status = picohttp_server_stream_status_crlf;
+                stream_ctx->ps.hq.status = picohttp_server_stream_status_crlf;
             }
 
             if (crlf_present || fin_or_event == picoquic_callback_stream_fin) {
                 /* Parse the command */
-                stream_ctx->method = picoquic_h09_server_parse_method(stream_ctx->frame, stream_ctx->command_length, NULL);
+                ret = picohttp_server_parse_commandline(stream_ctx->frame, stream_ctx->ps.hq.command_length, stream_ctx);
             }
         }
-        else if (stream_ctx->status == picohttp_server_stream_status_crlf) {
+        else if (stream_ctx->ps.hq.status == picohttp_server_stream_status_crlf) {
             if (bytes[processed] == '\n') {
                 /* empty line */
-                stream_ctx->status = picohttp_server_stream_status_receiving;
+                stream_ctx->ps.hq.status = picohttp_server_stream_status_receiving;
             }
             else if (bytes[processed] != '\r') {
-                stream_ctx->status = picohttp_server_stream_status_header;
+                stream_ctx->ps.hq.status = picohttp_server_stream_status_header;
             }
             processed++;
         }
-        else if (stream_ctx->status == picohttp_server_stream_status_header) {
+        else if (stream_ctx->ps.hq.status == picohttp_server_stream_status_header) {
             if (bytes[processed] == '\n') {
-                stream_ctx->status = picohttp_server_stream_status_crlf;
+                stream_ctx->ps.hq.status = picohttp_server_stream_status_crlf;
             }
             processed++;
         }
-        else if (stream_ctx->status == picohttp_server_stream_status_receiving) {
+        else if (stream_ctx->ps.hq.status == picohttp_server_stream_status_receiving) {
+            /* Received data for a POST command. */
+            size_t available = length - processed;
+
+            if (stream_ctx->post_received == 0 && available > 0) {
+                int path_item = picohttp_find_path_item(stream_ctx->ps.hq.path, stream_ctx->ps.hq.path_length, app_ctx->path_table, app_ctx->path_table_nb);
+                if (path_item >= 0) {
+                    stream_ctx->path_callback = app_ctx->path_table[path_item].path_callback;
+                    stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post, stream_ctx);
+                }
+                stream_ctx->post_received += available;
+                (void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
+            }
+
             if (stream_ctx->path_callback != NULL) {
                 /* pass data to selected API */
-                ret = stream_ctx->path_callback(cnx, bytes + processed, length - processed, picohttp_callback_post_data, stream_ctx->path_callback_ctx, stream_ctx);
+                ret = stream_ctx->path_callback(cnx, bytes + processed, available, picohttp_callback_post_data, stream_ctx);
                 /* TODO-POST: how to handle errors ?*/
             }
-            else {
-                /* default processing: ignore the data, just count the bytes */
-                stream_ctx->post_received += length - processed;
-                processed = length;
-            }
+            stream_ctx->post_received += available;
+            processed = length;
         }
         else {
             /* No more processing expected on this stream. */
@@ -827,88 +866,102 @@ int picoquic_h09_server_process_data(picoquic_cnx_t* cnx,
     }
 
     /* if FIN present, process request through http 0.9 */
-    if (fin_or_event == picoquic_callback_stream_fin || (stream_ctx->method == 0 && stream_ctx->status == picohttp_server_stream_status_crlf)) {
-        char buf[256];
+    if (fin_or_event == picoquic_callback_stream_fin || (stream_ctx->method == 0 && stream_ctx->ps.hq.status == picohttp_server_stream_status_crlf)) {
+        char buf[1024];
+        uint8_t post_response[512];
+        int is_bad_request = 0;
+        int is_not_found = 0;
 
-        stream_ctx->frame[stream_ctx->command_length] = 0;
-        /* if data generated, just send it. Otherwise, just FIN the stream. */
-        stream_ctx->status = picohttp_server_stream_status_finished;
+        stream_ctx->frame[stream_ctx->ps.hq.command_length] = 0;
+        stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
 
-        if (picoquic_h09_server_process_command(stream_ctx->frame, stream_ctx->command_length, &stream_ctx->method, &stream_ctx->echo_length)
-            != 0) {
+        if (cnx->quic->F_log != NULL) {
+            fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
+            fprintf(cnx->quic->F_log, "Server CB, Stream: %" PRIu64 ", Processing command: %s\n",
+                stream_id, strip_endofline(buf, sizeof(buf), (char*)& stream_ctx->frame));
+        }
+
+        if (stream_ctx->method == 0){
+            if (demo_server_parse_path(stream_ctx->ps.hq.path, stream_ctx->ps.hq.path_length, &stream_ctx->echo_length)) {
+                is_not_found = 1;
+            }
+        }
+        else if (stream_ctx->method == 1) {
+            if (stream_ctx->post_received == 0) {
+                int path_item = picohttp_find_path_item(stream_ctx->ps.hq.path, stream_ctx->ps.hq.path_length, app_ctx->path_table, app_ctx->path_table_nb);
+                if (path_item >= 0) {
+                    /* TODO-POST: move this code to post-fin callback.*/
+                    stream_ctx->path_callback = app_ctx->path_table[path_item].path_callback;
+                    stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post, stream_ctx);
+                }
+            }
+
+            if (stream_ctx->path_callback != NULL) {
+                stream_ctx->response_length = stream_ctx->path_callback(cnx, post_response, sizeof(post_response), picohttp_callback_post_fin, stream_ctx);
+                if (stream_ctx->response_length == 0) {
+                    is_bad_request = 1;
+                }
+            }
+            else {
+                /* Prepare generic POST response */
+                (void)picoquic_sprintf((char*)post_response, sizeof(post_response), &stream_ctx->response_length, demo_server_post_response_page, (int)stream_ctx->post_received);
+            }
+            stream_ctx->echo_length = 0;
+        }
+        else {
+            is_bad_request = 1;
+        }
+
+        if (is_bad_request || is_not_found) {
+            /* If this is HTTP1, send an HTTP1 OK message, with the appropriate content type */
+            if (stream_ctx->ps.hq.proto != 0) {
+                size_t header_length = 0;
+
+                picoquic_sprintf(buf, sizeof(buf), &header_length, "%s\r\n\r\n",
+                    (is_not_found) ? "404 Not Found" : "400 Bad Request");
+                picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t *)buf, header_length, 0, (void*)stream_ctx);
+            }
+
             if (cnx->quic->F_log != NULL) {
                 fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
                 fprintf(cnx->quic->F_log, "Server CB, Stream: %" PRIu64 ", Reply with bad request message after command: %s\n",
-                    stream_id, strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->frame));
+                    stream_id, strip_endofline(buf, sizeof(buf), (char*)& stream_ctx->frame));
             }
 
             stream_ctx->response_length = strlen(bad_request_message);
-            (void)picoquic_add_to_stream_with_ctx(cnx, stream_ctx->stream_id, (const uint8_t *)bad_request_message,
-                stream_ctx->response_length, 1, (void *)stream_ctx);
+            (void)picoquic_add_to_stream_with_ctx(cnx, stream_ctx->stream_id, (const uint8_t*)bad_request_message,
+                stream_ctx->response_length, 1, (void*)stream_ctx);
         } else {
-            if (cnx->quic->F_log != NULL) {
-                fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
-                fprintf(cnx->quic->F_log, "Server CB, Stream: %" PRIu64 ", Processing command: %s\n",
-                    stream_id, strip_endofline(buf, sizeof(buf), (char*)&stream_ctx->frame));
+            /* If this is HTTP1, send an HTTP1 OK message, with the appropriate content type */
+            if (stream_ctx->ps.hq.proto != 0) {
+                size_t header_length = 0;
+
+                picoquic_sprintf(buf, sizeof(buf), &header_length, "200 OK\r\nContent-Type:%s\r\n\r\n",
+                    (stream_ctx->echo_length == 0 || stream_ctx->method == 1) ? "text/plain" : "test/html");
+                picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t *)buf, header_length, 0, (void*)stream_ctx);
             }
-            if (stream_ctx->echo_length > 0) {
-                picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, (void *)stream_ctx);
-            }
-            else if (stream_ctx->method == 1) {
-                uint8_t post_response[512];
-
-                if (stream_ctx->path_callback != NULL) {
-                    /* TODO-POST: Process the response to a POST.
-                     * We have to distinguish three scenarios:
-                     * - Something went wrong => return an error.
-                     * - Large response => support callbacks for read. By convention, ret = 0?
-                     * - Short response => provide it now.
-                     */
-                    ret = stream_ctx->path_callback(cnx, post_response, sizeof(post_response), picohttp_callback_post_fin, stream_ctx->path_callback_ctx, stream_ctx);
-                    if (ret < 0) {
-                        /* TODO-POST: process an error */
-                    }
-                    else{
-                        /* TODO-POST: format the post response header -- get content type from plug in context */
-                        /* content length only present if known. */
-                        /* Push response header */
-
-                        if (ret > 0 && ret < sizeof(post_response)) {
-                            /* For short responses, post directly. 
-                             * TODO-POST: for long responses, we expect that the application
-                             * will have set a data provision shortcut. Verify that! */
-                            picoquic_add_to_stream_with_ctx(cnx, stream_id, post_response,
-                                stream_ctx->response_length, 1, (void*)stream_ctx);
-                        }
-                    }
-                }
-                else {
-                    /* Default processing, simple message with just a length received field. */
-                    (void)picoquic_sprintf((char *)post_response, sizeof(post_response), &stream_ctx->response_length, demo_server_post_response_page, (int)stream_ctx->post_received);
-
-                    picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t*)demo_server_post_response_header,
-                        strlen(demo_server_post_response_header), 0, (void*)stream_ctx);
-                    picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t*)post_response,
-                        stream_ctx->response_length, 1, (void*)stream_ctx);
-                }
-                if (cnx->quic->F_log != NULL) {
-                    fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
-                    fprintf(cnx->quic->F_log, "Server CB, Stream: %" PRIu64 ", %s, %d data received\n",
-                        stream_id, strip_endofline(buf, sizeof(buf), (char*)& stream_ctx->frame), (int)stream_ctx->post_received);
-                }
-
-            }
-            else {
+            
+            if (stream_ctx->response_length == 0 && stream_ctx->echo_length == 0) {
                 /* Send the canned index.html response */
                 stream_ctx->response_length = strlen(demo_server_default_page);
-                picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t *)demo_server_default_page,
-                    stream_ctx->response_length, 1, (void *)stream_ctx);
-            } 
+                picoquic_add_to_stream_with_ctx(cnx, stream_id, (uint8_t*)demo_server_default_page,
+                    stream_ctx->response_length, 1, (void*)stream_ctx);
+            }
+            else if (stream_ctx->echo_length == 0 && stream_ctx->response_length < sizeof(post_response)) {
+                /* For short responses, post directly.
+                 * TODO-POST: for long responses, we expect that the application
+                 * will have set a data provision shortcut. Verify that! */
+                picoquic_add_to_stream_with_ctx(cnx, stream_id, post_response,
+                    stream_ctx->response_length, 1, (void*)stream_ctx);
+            }
+            else {
+                picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, stream_ctx);
+            }
         }
     }
     else if (stream_ctx->response_length == 0 && stream_ctx->echo_length == 0 && stream_ctx->method == 0) {
         char buf[256];
-        stream_ctx->frame[stream_ctx->command_length] = 0;
+        stream_ctx->frame[stream_ctx->ps.hq.command_length] = 0;
         if (cnx->quic->F_log != NULL) {
             fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
             fprintf(cnx->quic->F_log, "Server CB, Stream: %" PRIu64 ", Partial command: %s\n",
@@ -976,34 +1029,13 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
     }
 
     if (stream_ctx == NULL) {
-        stream_ctx = ctx->first_stream;
-
-        /* if stream is already present, check its state. New bytes? */
-        while (stream_ctx != NULL && stream_ctx->stream_id != stream_id) {
-            stream_ctx = stream_ctx->next_stream;
-        }
-
-        if (stream_ctx == NULL) {
-            stream_ctx = (picohttp_server_stream_ctx_t*)
-                malloc(sizeof(picohttp_server_stream_ctx_t));
-            if (stream_ctx == NULL) {
-                /* Could not handle this stream */
-                picoquic_reset_stream(cnx, stream_id, 500);
-                return 0;
-            }
-            else {
-                memset(stream_ctx, 0, sizeof(picohttp_server_stream_ctx_t));
-                stream_ctx->next_stream = ctx->first_stream;
-                ctx->first_stream = stream_ctx;
-                stream_ctx->stream_id = stream_id;
-            }
-        }
+        stream_ctx = picohttp_find_or_create_stream(cnx, stream_id, &ctx->first_stream, 1, 0);
     }
 
     switch (fin_or_event) {
     case picoquic_callback_stop_sending:
         /* TODO-POST: notify callback. */
-        stream_ctx->status = picohttp_server_stream_status_finished;
+        stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, 0);
         if (cnx->quic->F_log != NULL) {
             printf("%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
@@ -1013,7 +1045,7 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
         return 0;
     case picoquic_callback_stream_reset:
         /* TODO-POST: notify callback. */
-        stream_ctx->status = picohttp_server_stream_status_finished;
+        stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, 0);
         if (cnx->quic->F_log != NULL) {
             fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
@@ -1029,8 +1061,13 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
                 return 0;
             }
             else {
-                /* TODO-POST: notify callback. */
-                return demo_client_prepare_to_send((void*)bytes, length, stream_ctx->echo_length, &stream_ctx->echo_sent);
+                if (stream_ctx->path_callback != NULL) {
+                    return stream_ctx->path_callback(cnx, bytes, length, picohttp_callback_provide_data, stream_ctx);
+                }
+                else {
+                    /* TODO-POST: notify callback. */
+                    return demo_client_prepare_to_send((void*)bytes, length, stream_ctx->echo_length, &stream_ctx->echo_sent);
+                }
             }
     default:
         break;
@@ -1038,7 +1075,7 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
 
     if (fin_or_event == picoquic_callback_stream_gap) {
         /* We do not support this, yet */
-        stream_ctx->status = picohttp_server_stream_status_finished;
+        stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION);
         if (cnx->quic->F_log != NULL) {
             fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
@@ -1048,13 +1085,13 @@ int picoquic_h09_server_callback(picoquic_cnx_t* cnx,
     }
     else if (fin_or_event == picoquic_callback_stream_data || fin_or_event == picoquic_callback_stream_fin) {
         /* Data processing includes setting up post/get callback if needed */
-        if (picoquic_h09_server_process_data(cnx, stream_id, bytes, length, fin_or_event, stream_ctx)) {
+        if (picoquic_h09_server_process_data(cnx, stream_id, bytes, length, fin_or_event, ctx, stream_ctx)) {
             /* something bad happened. */
         }
     } else {
         /* Unknown event */
         /* TODO-POST: notify callback. */
-        stream_ctx->status = picohttp_server_stream_status_finished;
+        stream_ctx->ps.hq.status = picohttp_server_stream_status_finished;
         picoquic_reset_stream(cnx, stream_id, PICOQUIC_TRANSPORT_INTERNAL_ERROR);
         if (cnx->quic->F_log != NULL) {
             fprintf(cnx->quic->F_log, "%" PRIx64 ": ", picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)));
@@ -1095,14 +1132,6 @@ int picoquic_demo_server_callback(picoquic_cnx_t* cnx,
     return ret;
 }
 
-/* Handling of post callback */
-void picohttp_set_post_callback(picohttp_server_stream_ctx_t* stream_ctx,
-    picohttp_post_data_cb_fn callback_fn, void* callback_ctx)
-{
-    stream_ctx->path_callback = callback_fn;
-    stream_ctx->path_callback_ctx = callback_ctx;
-}
-
 /* Sample callback used for demonstrating the callback API.
  * The transaction returns the MD5 of the posted data */
 
@@ -1113,10 +1142,10 @@ typedef struct st_picohttp_demo_post_sha256_ctx_t {
 
 int picohttp_demo_post_sha256_callback(picoquic_cnx_t* cnx,
     uint8_t* bytes, size_t length,
-    picohttp_call_back_event_t event, void* post_ctx, picohttp_server_stream_ctx_t * stream_ctx)
+    picohttp_call_back_event_t event, picohttp_server_stream_ctx_t * stream_ctx)
 {
     int ret = 0;
-    picohttp_demo_post_ctx_t* ctx = (picohttp_demo_post_ctx_t*)post_ctx;
+    picohttp_demo_post_ctx_t* ctx = (picohttp_demo_post_ctx_t*)stream_ctx->path_callback_ctx;
 
     switch (event) {
     case picohttp_callback_get: /* Received a get command */
@@ -1131,7 +1160,8 @@ int picohttp_demo_post_sha256_callback(picoquic_cnx_t* cnx,
             else {
                 memset(ctx->buf, 0, PICOQUIC_HASH_SIZE_MAX);
                 ctx->hash_context = picoquic_hash_create("SHA256");
-                picohttp_set_post_callback(stream_ctx, picohttp_demo_post_sha256_callback, ctx);
+                stream_ctx->path_callback = picohttp_demo_post_sha256_callback;
+                stream_ctx->path_callback_ctx = ctx;
             }
         }
         else {
@@ -1163,7 +1193,9 @@ int picohttp_demo_post_sha256_callback(picoquic_cnx_t* cnx,
         ret = -1;
         break;
     case picohttp_callback_reset: /* stream is abandoned */
-        picohttp_set_post_callback(stream_ctx, NULL, NULL);
+        stream_ctx->path_callback = NULL;
+        stream_ctx->path_callback_ctx = NULL;
+
         if (ctx != NULL){
             if (ctx->hash_context != NULL) {
                 picoquic_hash_finalize(ctx->buf, ctx->hash_context);

--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -147,11 +147,6 @@ Picoquic HTTP 3 service\
 <h1>Enjoy!</h1>\r\n\
 </BODY></HTML>\r\n";
 
-static char const * demo_server_post_response_header = "\
-200 OK\r\n\
-Content-Type: text/html\r\n\
-\r\n";
-
 static char const * demo_server_post_response_page = "\
 <!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n<HTML>\r\n<HEAD>\r\n<TITLE>\
 Picoquic POST Response\
@@ -488,7 +483,7 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
 {
     int ret = 0;
     h3zero_server_callback_ctx_t* ctx = NULL;
-    picohttp_server_stream_ctx_t* stream_ctx = NULL; (picohttp_server_stream_ctx_t*)v_stream_ctx;
+    picohttp_server_stream_ctx_t* stream_ctx = (picohttp_server_stream_ctx_t*)v_stream_ctx;
 
     if (callback_ctx == NULL || callback_ctx == picoquic_get_default_callback_context(cnx->quic)) {
         ctx = h3zero_server_callback_create_context((picohttp_server_parameters_t *)callback_ctx);

--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -56,6 +56,7 @@ static picohttp_server_stream_ctx_t * picohttp_find_or_create_stream(
             stream_ctx->next_stream = *p_first_stream;
             *p_first_stream = stream_ctx;
             stream_ctx->stream_id = stream_id;
+            stream_ctx->is_h3 = is_h3;
         }
     }
 
@@ -799,7 +800,9 @@ int picoquic_h09_server_process_data(picoquic_cnx_t* cnx,
             int crlf_present = 0;
 
             while (processed < length && crlf_present == 0) {
-                if (bytes[processed] == '\r' || bytes[processed] == '\n') {
+                if (bytes[processed] == '\r') {
+                    /* Ignore \n, so end of header is either CRLF/CRLF, of just LF/LF, or maybe LF/CR/LF */
+                } else if (bytes[processed] == '\n') {
                     crlf_present = 1;
                 }
                 else if (stream_ctx->ps.hq.command_length < sizeof(stream_ctx->frame)) {

--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -57,7 +57,7 @@ struct st_picohttp_server_stream_ctx_t;
 
 typedef int (*picohttp_post_data_cb_fn)(picoquic_cnx_t* cnx,
     uint8_t* bytes, size_t length,
-    picohttp_call_back_event_t fin_or_event, void* callback_ctx, struct st_picohttp_server_stream_ctx_t* stream_ctx);
+    picohttp_call_back_event_t fin_or_event, struct st_picohttp_server_stream_ctx_t* stream_ctx);
 
 /* Define the table of special-purpose paths used for POST or REST queries */
 typedef struct st_picohttp_server_path_item_t {
@@ -89,10 +89,18 @@ typedef struct st_picohttp_server_stream_ctx_t {
     /* TODO-POST: identification of URL to process POST or GET? */
     /* TODO-POST: provide content-type */
     struct st_picohttp_server_stream_ctx_t* next_stream;
-    picohttp_server_stream_status_t status;
-    h3zero_data_stream_state_t stream_state;
+    int is_h3;
+    union {
+        h3zero_data_stream_state_t stream_state; /* h3 only */
+        struct {
+            picohttp_server_stream_status_t status; 
+            int proto; 
+            uint8_t* path; 
+            size_t path_length;
+            size_t command_length;
+        } hq; /* h09 only */
+    } ps; /* Protocol specific state */
     uint64_t stream_id;
-    size_t command_length;
     size_t response_length;
     size_t echo_length;
     size_t echo_sent;

--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -35,6 +35,9 @@
 #define PICOHTTP_FIRST_COMMAND_MAX 256
 #define PICOHTTP_RESPONSE_MAX (1 << 20)
 
+#define PICOHTTP_ALPN_H3_LATEST "h3-22"
+#define PICOHTTP_ALPN_HQ_LATEST "hq-22"
+
 
 
   /* Define the per URL callback used to implement POST and other
@@ -57,15 +60,20 @@ typedef int (*picohttp_post_data_cb_fn)(picoquic_cnx_t* cnx,
     picohttp_call_back_event_t fin_or_event, void* callback_ctx, struct st_picohttp_server_stream_ctx_t* stream_ctx);
 
 /* Define the table of special-purpose paths used for POST or REST queries */
-typedef struct st_picoquic_demoserver_path_item_t {
+typedef struct st_picohttp_server_path_item_t {
     char* path;
-    int path_length;
+    size_t path_length;
     picohttp_post_data_cb_fn path_callback;
-} picoquic_demoserver_path_item_t;
+} picohttp_server_path_item_t;
+
+typedef struct st_picohttp_server_parameters_t {
+    picohttp_server_path_item_t* path_table;
+    size_t path_table_nb;
+} picohttp_server_parameters_t;
 
 /* Identify the path item based on the incoming path in GET or POST */
 
-int picohttp_find_path_item(const uint8_t* path, size_t path_length, const picoquic_demoserver_path_item_t* path_table, size_t path_table_nb);
+int picohttp_find_path_item(const uint8_t* path, size_t path_length, const picohttp_server_path_item_t* path_table, size_t path_table_nb);
 
 /* Define stream context common to http 3 and http 09 callbacks
  */
@@ -101,7 +109,7 @@ typedef struct st_h3zero_server_callback_ctx_t {
     picohttp_server_stream_ctx_t* first_stream;
     size_t buffer_max;
     uint8_t* buffer;
-    picoquic_demoserver_path_item_t * path_table;
+    picohttp_server_path_item_t * path_table;
     size_t path_table_nb;
 } h3zero_server_callback_ctx_t;
 
@@ -115,7 +123,7 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
 
 typedef struct st_picoquic_h09_server_callback_ctx_t {
     picohttp_server_stream_ctx_t* first_stream;
-    picoquic_demoserver_path_item_t * path_table;
+    picohttp_server_path_item_t * path_table;
     size_t path_table_nb;
 } picoquic_h09_server_callback_ctx_t;
 

--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -44,6 +44,7 @@ typedef enum {
 } h3zero_server_stream_status_t;
 
 typedef struct st_h3zero_server_stream_ctx_t {
+    /* TODO: identification of URL to process POST or GET? */
     struct st_h3zero_server_stream_ctx_t* next_stream;
     h3zero_data_stream_state_t stream_state;
     h3zero_server_stream_status_t status;
@@ -65,6 +66,20 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint8_t* bytes, size_t length,
     picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
 
+/* Define the per URL callback used to implement POSt and other
+ * REST-like interactions
+ */
+typedef enum {
+    picohttp_callback_get, /* Received a get command */
+    picohttp_callback_post, /* Received a post command */
+    picohttp_callback_post_data, /* Data received from peer on stream N */
+    picohttp_callback_post_fin, /* All posted data have been received */
+    picohttp_callback_reset /* Stream has been abandoned. */
+} picohttp_call_back_event_t;
+
+typedef int (*picohttp_post_data_cb_fn)(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picohttp_call_back_event_t fin_or_event, void* callback_ctx, void* stream_ctx);
 
 /* Defining then the Http 0.9 variant of the server
  */
@@ -81,6 +96,7 @@ typedef enum {
 } picoquic_h09_server_stream_status_t;
 
 typedef struct st_picoquic_h09_server_stream_ctx_t {
+    /* TODO: identification of URL to process POST or GET? */
     struct st_picoquic_h09_server_stream_ctx_t* next_stream;
     picoquic_h09_server_stream_status_t status;
     uint64_t stream_id;

--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -31,86 +31,92 @@
  /* Defining first the Http 3.0 variant of the server 
   */
 
-#define H3ZERO_SERVER_FRAME_MAX 4096
-#define H3ZERO_COMMAND_MAX 256
-#define H3ZERO_RESPONSE_MAX (1 << 20)
+#define PICOHTTP_SERVER_FRAME_MAX 4096
+#define PICOHTTP_FIRST_COMMAND_MAX 256
+#define PICOHTTP_RESPONSE_MAX (1 << 20)
 
-typedef enum {
-    h3zero_server_stream_status_none = 0,
-    h3zero_server_stream_status_receiving_frame,
-    h3zero_server_stream_status_receiving_request,
-    h3zero_server_stream_status_receiving_data,
-    h3zero_server_stream_status_finished
-} h3zero_server_stream_status_t;
 
-typedef struct st_h3zero_server_stream_ctx_t {
-    /* TODO: identification of URL to process POST or GET? */
-    struct st_h3zero_server_stream_ctx_t* next_stream;
-    h3zero_data_stream_state_t stream_state;
-    h3zero_server_stream_status_t status;
-    uint64_t stream_id;
-    size_t received_length;
-    size_t echo_length;
-    size_t echo_sent;
-    int is_post;
-    uint8_t frame[H3ZERO_SERVER_FRAME_MAX];
-} h3zero_server_stream_ctx_t;
 
-typedef struct st_h3zero_server_callback_ctx_t {
-    h3zero_server_stream_ctx_t* first_stream;
-    size_t buffer_max;
-    uint8_t* buffer;
-} h3zero_server_callback_ctx_t;
+  /* Define the per URL callback used to implement POST and other
+   * REST-like interactions
+   */
 
-int h3zero_server_callback(picoquic_cnx_t* cnx,
-    uint64_t stream_id, uint8_t* bytes, size_t length,
-    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
-
-/* Define the per URL callback used to implement POSt and other
- * REST-like interactions
- */
 typedef enum {
     picohttp_callback_get, /* Received a get command */
     picohttp_callback_post, /* Received a post command */
     picohttp_callback_post_data, /* Data received from peer on stream N */
     picohttp_callback_post_fin, /* All posted data have been received */
+    picohttp_callback_provide_data, /* Stack is ready to send chunk of response */
     picohttp_callback_reset /* Stream has been abandoned. */
 } picohttp_call_back_event_t;
 
+struct st_picohttp_server_stream_ctx_t;
+
 typedef int (*picohttp_post_data_cb_fn)(picoquic_cnx_t* cnx,
-    uint64_t stream_id, uint8_t* bytes, size_t length,
-    picohttp_call_back_event_t fin_or_event, void* callback_ctx, void* stream_ctx);
+    uint8_t* bytes, size_t length,
+    picohttp_call_back_event_t fin_or_event, void* callback_ctx, struct st_picohttp_server_stream_ctx_t* stream_ctx);
 
-/* Defining then the Http 0.9 variant of the server
+/* Define the table of special-purpose paths used for POST or REST queries */
+typedef struct st_picoquic_demoserver_path_item_t {
+    char* path;
+    int path_length;
+    picohttp_post_data_cb_fn path_callback;
+} picoquic_demoserver_path_item_t;
+
+/* Identify the path item based on the incoming path in GET or POST */
+
+int picohttp_find_path_item(const uint8_t* path, size_t path_length, const picoquic_demoserver_path_item_t* path_table, size_t path_table_nb);
+
+/* Define stream context common to http 3 and http 09 callbacks
  */
-
-#define PICOQUIC_FIRST_COMMAND_MAX 128
-#define PICOQUIC_FIRST_RESPONSE_MAX (10*(1 << 20))
-
 typedef enum {
-    picoquic_h09_server_stream_status_none = 0,
-    picoquic_h09_server_stream_status_header,
-    picoquic_h09_server_stream_status_crlf,
-    picoquic_h09_server_stream_status_receiving,
-    picoquic_h09_server_stream_status_finished
-} picoquic_h09_server_stream_status_t;
+    picohttp_server_stream_status_none = 0,
+    picohttp_server_stream_status_header,
+    picohttp_server_stream_status_crlf,
+    picohttp_server_stream_status_receiving,
+    picohttp_server_stream_status_finished
+} picohttp_server_stream_status_t;
 
-typedef struct st_picoquic_h09_server_stream_ctx_t {
-    /* TODO: identification of URL to process POST or GET? */
-    struct st_picoquic_h09_server_stream_ctx_t* next_stream;
-    picoquic_h09_server_stream_status_t status;
+typedef struct st_picohttp_server_stream_ctx_t {
+    /* TODO-POST: identification of URL to process POST or GET? */
+    /* TODO-POST: provide content-type */
+    struct st_picohttp_server_stream_ctx_t* next_stream;
+    picohttp_server_stream_status_t status;
+    h3zero_data_stream_state_t stream_state;
     uint64_t stream_id;
     size_t command_length;
     size_t response_length;
     size_t echo_length;
     size_t echo_sent;
     size_t post_received;
-    uint8_t command[PICOQUIC_FIRST_COMMAND_MAX];
+    uint8_t frame[PICOHTTP_SERVER_FRAME_MAX];
     int method;
-} picoquic_h09_server_stream_ctx_t;
+    picohttp_post_data_cb_fn path_callback;
+    void* path_callback_ctx;
+} picohttp_server_stream_ctx_t;
+
+/* Define the H3Zero server callback */
+
+typedef struct st_h3zero_server_callback_ctx_t {
+    picohttp_server_stream_ctx_t* first_stream;
+    size_t buffer_max;
+    uint8_t* buffer;
+    picoquic_demoserver_path_item_t * path_table;
+    size_t path_table_nb;
+} h3zero_server_callback_ctx_t;
+
+int h3zero_server_callback(picoquic_cnx_t* cnx,
+    uint64_t stream_id, uint8_t* bytes, size_t length,
+    picoquic_call_back_event_t fin_or_event, void* callback_ctx, void* v_stream_ctx);
+
+
+/* Defining then the Http 0.9 variant of the server
+ */
 
 typedef struct st_picoquic_h09_server_callback_ctx_t {
-    picoquic_h09_server_stream_ctx_t* first_stream;
+    picohttp_server_stream_ctx_t* first_stream;
+    picoquic_demoserver_path_item_t * path_table;
+    size_t path_table_nb;
 } picoquic_h09_server_callback_ctx_t;
 
 int picoquic_h09_server_callback(picoquic_cnx_t* cnx,

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -51,7 +51,8 @@ static const picoquic_test_def_t test_table[] = {
     { "h3zero_server", h3zero_server_test },
     { "h09_server", h09_server_test },
     { "generic_server", generic_server_test},
-    { "esni", esni_test }
+    { "esni", esni_test },
+    { "h3zero_post", h3zero_post_test}
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -52,7 +52,8 @@ static const picoquic_test_def_t test_table[] = {
     { "h09_server", h09_server_test },
     { "generic_server", generic_server_test},
     { "esni", esni_test },
-    { "h3zero_post", h3zero_post_test}
+    { "h3zero_post", h3zero_post_test},
+    { "h09_post", h09_post_test}
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(picoquic_test_def_t);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -570,6 +570,10 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
     struct sockaddr_storage * p_addr_to, int * to_len, struct sockaddr_storage * p_addr_from, int * from_len);
 
+/* Associate stream with app context */
+int picoquic_set_app_stream_ctx(picoquic_cnx_t* cnx,
+    uint64_t stream_id, void* app_stream_ctx);
+
 /* Mark stream as active, or not.
  * If a stream is active, it will be polled for data when the transport
  * is ready to send. The polling will only start after all currently

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -250,7 +250,7 @@ typedef enum {
     picoquic_callback_almost_ready, /* Data can be sent, but the connection is not fully established */
     picoquic_callback_ready, /* Data can be sent and received, connection migration can be initiated */
     picoquic_callback_datagram, /* Datagram frame has been received */
-    picoquic_callback_version_negotiation
+    picoquic_callback_version_negotiation /* version negotiation requested */
 } picoquic_call_back_event_t;
 
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -69,6 +69,19 @@ static picoquic_stream_head_t* picoquic_find_stream_for_writing(picoquic_cnx_t* 
     return stream;
 }
 
+int picoquic_set_app_stream_ctx(picoquic_cnx_t* cnx,
+    uint64_t stream_id, void* app_stream_ctx)
+{
+    int ret = 0;
+    picoquic_stream_head_t* stream = picoquic_find_stream_for_writing(cnx, stream_id, &ret);
+
+    if (ret == 0) {
+        stream->app_stream_ctx = app_stream_ctx;
+    }
+
+    return ret;
+}
+
 int picoquic_mark_active_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, int is_active, void * app_stream_ctx)
 {

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -2552,15 +2552,9 @@ size_t picoquic_hash_get_length(char const* algorithm_name) {
 }
 
 void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context) {
-    ((ptls_hash_context_t * )hash_context)->update(ctx, input, input_length);
+    ((ptls_hash_context_t * )hash_context)->update((ptls_hash_context_t*)hash_context, input, input_length);
 }
 
-size_t picoquic_hash_finalize(uint8_t* output, void* hash_context) {
-    ((ptls_hash_context_t*)hash_context)->final(ctx, output, PTLS_HASH_FINAL_MODE_FREE);
+void picoquic_hash_finalize(uint8_t* output, void* hash_context) {
+    ((ptls_hash_context_t*)hash_context)->final((ptls_hash_context_t*)hash_context, output, PTLS_HASH_FINAL_MODE_FREE);
 }
-
-void picoquic_hash_free(void* hash_context) {
-
-}
-
-ptls_hash_context_t* ctx;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -2516,3 +2516,51 @@ uint8_t * picoquic_esni_nonce(picoquic_cnx_t * cnx)
 {
     return(((picoquic_tls_ctx_t*)cnx->tls_ctx)->esni_nonce);
 }
+
+/* Export hash functions so applications do not need to access picotls */
+
+void* picoquic_hash_create(char const* algorithm_name) {
+    ptls_hash_context_t* ctx;
+
+    if (strcmp(algorithm_name, "SHA256") == 0) {
+        ctx = ptls_minicrypto_sha256.create();
+    }
+    else if (strcmp(algorithm_name, "SHA384") == 0) {
+        ctx = ptls_minicrypto_sha384.create();
+    }
+    else {
+        ctx = NULL;
+    }
+
+    return (void*)ctx;
+}
+
+size_t picoquic_hash_get_length(char const* algorithm_name) {
+    size_t len;
+
+    if (strcmp(algorithm_name, "SHA256") == 0) {
+        len = ptls_minicrypto_sha256.digest_size;
+    }
+    else if (strcmp(algorithm_name, "SHA384") == 0) {
+        len = ptls_minicrypto_sha384.digest_size;
+    }
+    else {
+        len = 0;
+    }
+
+    return len;
+}
+
+void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context) {
+    ((ptls_hash_context_t * )hash_context)->update(ctx, input, input_length);
+}
+
+size_t picoquic_hash_finalize(uint8_t* output, void* hash_context) {
+    ((ptls_hash_context_t*)hash_context)->final(ctx, output, PTLS_HASH_FINAL_MODE_FREE);
+}
+
+void picoquic_hash_free(void* hash_context) {
+
+}
+
+ptls_hash_context_t* ctx;

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -151,4 +151,11 @@ struct st_ptls_esni_secret_t * picoquic_esni_secret(picoquic_cnx_t * cnx);
 uint16_t picoquic_esni_version(picoquic_cnx_t * cnx);
 uint8_t * picoquic_esni_nonce(picoquic_cnx_t * cnx);
 
+/* Define hash functions here so applications don't need to directly interface picotls */
+#define PICOQUIC_HASH_SIZE_MAX 64
+void * picoquic_hash_create(char const * algorithm_name);
+size_t picoquic_hash_get_length(char const* algorithm_name);
+void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context);
+size_t picoquic_hash_finalize(uint8_t* output, void* hash_context);
+
 #endif /* TLS_API_H */

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -156,6 +156,6 @@ uint8_t * picoquic_esni_nonce(picoquic_cnx_t * cnx);
 void * picoquic_hash_create(char const * algorithm_name);
 size_t picoquic_hash_get_length(char const* algorithm_name);
 void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context);
-size_t picoquic_hash_finalize(uint8_t* output, void* hash_context);
+void picoquic_hash_finalize(uint8_t* output, void* hash_context);
 
 #endif /* TLS_API_H */

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -975,7 +975,7 @@ typedef struct st_hzero_post_echo_ctx_t {
 
 int h3zero_test_ping_callback(picoquic_cnx_t* cnx,
     uint8_t* bytes, size_t length,
-    picohttp_call_back_event_t event, void* post_ctx, picohttp_server_stream_ctx_t* stream_ctx)
+    picohttp_call_back_event_t event, picohttp_server_stream_ctx_t* stream_ctx)
 {
     int ret = 0;
     hzero_post_echo_ctx_t* ctx = (hzero_post_echo_ctx_t*)stream_ctx->path_callback_ctx;
@@ -1020,7 +1020,7 @@ int h3zero_test_ping_callback(picoquic_cnx_t* cnx,
             if (ctx->nb_echo <= length) {
                 memcpy(bytes, ctx->buf, ctx->nb_echo);
             }
-            ret = ctx->nb_echo;
+            ret = (int)ctx->nb_echo;
         }
         else {
             ret = -1;
@@ -1054,7 +1054,9 @@ int h3zero_test_ping_callback(picoquic_cnx_t* cnx,
         }
         break;
     case picohttp_callback_reset: /* stream is abandoned */
-        picohttp_set_post_callback(stream_ctx, NULL, NULL);
+        stream_ctx->path_callback = NULL;
+        stream_ctx->path_callback_ctx = NULL;
+       
         if (ctx != NULL) {
             free(ctx);
         }
@@ -1090,4 +1092,9 @@ static size_t const post_test_stream_length[] = { 2345 };
 int h3zero_post_test()
 {
     return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, (void *) &ping_test_param, 0, post_test_scenario, nb_post_test_scenario, post_test_stream_length);
+}
+
+int h09_post_test()
+{
+    return demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, (void*)& ping_test_param, 0, post_test_scenario, nb_post_test_scenario, post_test_stream_length);
 }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -181,6 +181,7 @@ int stream_splay_test();
 int stream_output_test();
 int stream_rank_test();
 int not_before_cnxid_test();
+int h3zero_post_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -182,6 +182,7 @@ int stream_output_test();
 int stream_rank_test();
 int not_before_cnxid_test();
 int h3zero_post_test();
+int h09_post_test();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add feature to picohttp server, so a URL can be associated with a callback. Post to the URL are passed as data to the callback. Output produced by the callback is sent as response to POST.

This PR does not address client side processing.

The work is not fully complete. Another PR should add processing of GET arguments (as in Get /some-url?specific&arguments"), and also add a way to specify the content type returned by the POST command.