### PR TITLE
Add extern "C" to util.h

### DIFF
--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -26,6 +26,10 @@
 #include <inttypes.h>
 #include "picoquic.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifdef WIN32
 #define PRIst "Iu"
 #ifndef PRIu64
@@ -109,4 +113,7 @@ int picoquic_get_input_path(char * target_file_path, size_t file_path_max, const
 FILE* picoquic_file_open_ex(char const * file_name, char const * flags, int * last_err);
 FILE * picoquic_file_open(char const * file_name, char const * flags);
 
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
```
Previously, util.h, unlike most other picoquic header files,
did not have an extern "C" linkage specification, which caused
subtle linker issues when referring to C functions from it from
C++ code.
```
