### PR TITLE
picohash compare and hashing take constant pointers

### DIFF
--- a/picoquic/picohash.c
+++ b/picoquic/picohash.c
@@ -27,8 +27,8 @@
 #include <string.h>
 
 picohash_table* picohash_create(size_t nb_bin,
-    uint64_t (*picohash_hash)(void*),
-    int (*picohash_compare)(void*, void*))
+    uint64_t (*picohash_hash)(const void*),
+    int (*picohash_compare)(const void*, const void*))
 {
     picohash_table* t = (picohash_table*)malloc(sizeof(picohash_table));
     if (t != NULL) {
@@ -49,7 +49,7 @@ picohash_table* picohash_create(size_t nb_bin,
     return t;
 }
 
-picohash_item* picohash_retrieve(picohash_table* hash_table, void* key)
+picohash_item* picohash_retrieve(picohash_table* hash_table, const void* key)
 {
     uint64_t hash = hash_table->picohash_hash(key);
     uint32_t bin = (uint32_t)(hash % hash_table->nb_bin);
@@ -66,7 +66,7 @@ picohash_item* picohash_retrieve(picohash_table* hash_table, void* key)
     return item;
 }
 
-int picohash_insert(picohash_table* hash_table, void* key)
+int picohash_insert(picohash_table* hash_table, const void* key)
 {
     uint64_t hash = hash_table->picohash_hash(key);
     uint32_t bin = (uint32_t)(hash % hash_table->nb_bin);
@@ -104,7 +104,7 @@ void picohash_item_delete(picohash_table* hash_table, picohash_item* item, int d
         }
 
     if (delete_key_too) {
-        free(item->key);
+        free((void*)item->key);
     }
 
     free(item);

--- a/picoquic/picohash.h
+++ b/picoquic/picohash.h
@@ -36,7 +36,7 @@ extern "C" {
 typedef struct _picohash_item {
     uint64_t hash;
     struct _picohash_item* next_in_bin;
-    void* key;
+    const void* key;
 } picohash_item;
 
 typedef struct picohash_table {
@@ -44,17 +44,17 @@ typedef struct picohash_table {
     picohash_item** hash_bin;
     size_t nb_bin;
     size_t count;
-    uint64_t (*picohash_hash)(void*);
-    int (*picohash_compare)(void*, void*);
+    uint64_t (*picohash_hash)(const void*);
+    int (*picohash_compare)(const void*, const void*);
 } picohash_table;
 
 picohash_table* picohash_create(size_t nb_bin,
-    uint64_t (*picohash_hash)(void*),
-    int (*picohash_compute)(void*, void*));
+    uint64_t (*picohash_hash)(const void*),
+    int (*picohash_compute)(const void*, const void*));
 
-picohash_item* picohash_retrieve(picohash_table* hash_table, void* key);
+picohash_item* picohash_retrieve(picohash_table* hash_table, const void* key);
 
-int picohash_insert(picohash_table* hash_table, void* key);
+int picohash_insert(picohash_table* hash_table, const void* key);
 
 void picohash_item_delete(picohash_table* hash_table, picohash_item* item, int delete_key_too);
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -47,33 +47,33 @@ typedef struct st_picoquic_net_id_key_t {
 } picoquic_net_id_key_t;
 
 /* Hash and compare for CNX hash tables */
-static uint64_t picoquic_cnx_id_hash(void* key)
+static uint64_t picoquic_cnx_id_hash(const void* key)
 {
-    picoquic_cnx_id_key_t* cid = (picoquic_cnx_id_key_t*)key;
+    const picoquic_cnx_id_key_t* cid = (const picoquic_cnx_id_key_t*)key;
 
     /* TODO: should scramble the value for security and DOS protection */
     return picoquic_val64_connection_id(cid->cnx_id);
 }
 
-static int picoquic_cnx_id_compare(void* key1, void* key2)
+static int picoquic_cnx_id_compare(const void* key1, const void* key2)
 {
-    picoquic_cnx_id_key_t* cid1 = (picoquic_cnx_id_key_t*)key1;
-    picoquic_cnx_id_key_t* cid2 = (picoquic_cnx_id_key_t*)key2;
+    const picoquic_cnx_id_key_t* cid1 = (const picoquic_cnx_id_key_t*)key1;
+    const picoquic_cnx_id_key_t* cid2 = (const picoquic_cnx_id_key_t*)key2;
 
     return picoquic_compare_connection_id(&cid1->cnx_id, &cid2->cnx_id);
 }
 
-static uint64_t picoquic_net_id_hash(void* key)
+static uint64_t picoquic_net_id_hash(const void* key)
 {
-    picoquic_net_id_key_t* net = (picoquic_net_id_key_t*)key;
+    const picoquic_net_id_key_t* net = (const picoquic_net_id_key_t*)key;
 
     return picohash_bytes((uint8_t*)&net->saddr, sizeof(net->saddr));
 }
 
-static int picoquic_net_id_compare(void* key1, void* key2)
+static int picoquic_net_id_compare(const void* key1, const void* key2)
 {
-    picoquic_net_id_key_t* net1 = (picoquic_net_id_key_t*)key1;
-    picoquic_net_id_key_t* net2 = (picoquic_net_id_key_t*)key2;
+    const picoquic_net_id_key_t* net1 = (const picoquic_net_id_key_t*)key1;
+    const picoquic_net_id_key_t* net2 = (const picoquic_net_id_key_t*)key2;
 
     return memcmp(&net1->saddr, &net2->saddr, sizeof(net1->saddr));
 }

--- a/picoquictest/hashtest.c
+++ b/picoquictest/hashtest.c
@@ -29,17 +29,17 @@ struct hashtestkey {
     uint64_t x;
 };
 
-static uint64_t hashtest_hash(void* v)
+static uint64_t hashtest_hash(const void* v)
 {
-    struct hashtestkey* k = (struct hashtestkey*)v;
+    const struct hashtestkey* k = (const struct hashtestkey*)v;
     uint64_t hash = (k->x + 0xDEADBEEFull);
     return hash;
 }
 
-static int hashtest_compare(void* v1, void* v2)
+static int hashtest_compare(const void* v1, const void* v2)
 {
-    struct hashtestkey* k1 = (struct hashtestkey*)v1;
-    struct hashtestkey* k2 = (struct hashtestkey*)v2;
+    const struct hashtestkey* k1 = (const struct hashtestkey*)v1;
+    const struct hashtestkey* k2 = (const struct hashtestkey*)v2;
 
     return (k1->x == k2->x) ? 0 : -1;
 }


### PR DESCRIPTION
I couldn't use constant pointers for keys in picohash tables.