### PR TITLE
Qlog script readiness

### DIFF
--- a/picolog/picolog.c
+++ b/picolog/picolog.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <inttypes.h>
+#include <errno.h>
 
 #include "picoquic_internal.h"
 #include "bytestream.h"
@@ -464,7 +465,7 @@ int convert_svg(const picoquic_connection_id_t * cid, void * ptr)
     while (fgets(line, sizeof(line), appctx->f_template) != NULL) /* read a line */ {
         if (strcmp(line, "#\n") != 0) {
             /* Copy the template to the SVG file */
-            fprintf(svg.f_txtlog, line);
+            fprintf(svg.f_txtlog, "%s", line);
         } else {
             ret = binlog_convert(appctx->f_binlog, cid, &ctx);
         }

--- a/picolog/picolog.c
+++ b/picolog/picolog.c
@@ -160,12 +160,7 @@ int main(int argc, char ** argv)
                 ret = cidset_iterate(cids, convert_svg, &appctx);
             }
         } else if (strcmp(appctx.out_format, "qlog") == 0) {
-            if (appctx.f_template == NULL) {
-                fprintf(stderr, "The qlog format conversion requires a template file specified by parameter -t\n");
-                ret = -1;
-            } else {
-                ret = cidset_iterate(cids, convert_qlog, &appctx);
-            }
+            ret = cidset_iterate(cids, convert_qlog, &appctx);
         } else {
             fprintf(stderr, "Invalid output format '%s'. Valid formats are\n\n", appctx.out_format);
             usage_formats();

--- a/picolog/picolog.c
+++ b/picolog/picolog.c
@@ -198,9 +198,10 @@ int usage()
 
 void usage_formats()
 {
-    fprintf(stderr, "                        -f csv : generate CC csv file\n");
-    fprintf(stderr, "                        -f svg : generate svg packet flow diagram.\n");
-    fprintf(stderr, "                                 requires a template specified by -t\n");
+    fprintf(stderr, "                        -f csv  : generate CC csv file\n");
+    fprintf(stderr, "                        -f svg  : generate svg packet flow diagram.\n");
+    fprintf(stderr, "                                  requires a template specified by -t\n");
+    fprintf(stderr, "                        -f qlog : generate IETF QLOG file\n");
 }
 
 FILE * open_outfile(const char * cid_name, const char * binlog_name, const char * out_dir, const char * out_ext)

--- a/picolog/picolog.vcxproj
+++ b/picolog/picolog.vcxproj
@@ -72,19 +72,15 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>picoquic_log2svg</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>picoquic_log2svg</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>picoquic_log2svg</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>picoquic_log2svg</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -619,6 +619,8 @@ void binlog_close_connection(picoquic_cnx_t * cnx)
 
     (void)fwrite(bytestream_data(head), bytestream_length(head), 1, f);
     (void)fwrite(bytestream_data(msg), bytestream_length(msg), 1, f);
+
+    fflush(f);
 }
 
 int binlog_open(picoquic_quic_t * quic, char const * binlog_file)


### PR DESCRIPTION
Final tweaks for QLOG conversion

* Flush binary log when connections close
* Enable output on `stdout` if no output directory is specified on picolog
* Fix executable name for picolog in Visual Studio
* Remove template parameter requirement for QLOG conversion