### PR TITLE
Remove pre draft-21 connection id parsing in packet header

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -34,29 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-int picoquic_is_header_version_supported(uint32_t version)
-{
-    int ret = 0; /* return 1 if version is supported */
-
-    if ((version & 0xFFFF0000) == 0) {
-        /* Final versions (0x0001-0xFFFF) and version negotiation (0x0) */
-        ret = 1;
-    } else if ((version & 0xFFFFFF00) == 0xFF000000 && (version & 0xFF) > 20) {
-        /* Draft versions before #20 use the old invariants */
-        ret = 1;
-    } else if ((version & 0x0F0F0F0F) == 0x0A0A0A0A) {
-        /* version greasing, i.e. force version negotiation */
-        ret = 1;
-    } else if (
-        version == PICOQUIC_INTERNAL_TEST_VERSION_1 ||
-        version == PICOQUIC_INTERNAL_TEST_VERSION_2) {
-        /* Internal versions use the new invariants */
-        ret = 1;
-    }
-
-    return ret;
-}
-
 int picoquic_parse_long_packet_header(
     picoquic_quic_t* quic,
     uint8_t* bytes,
@@ -74,191 +51,186 @@ int picoquic_parse_long_packet_header(
     else {
         /* The bytes at position 1..4 describe the version */
         ph->vn = PICOPARSE_32(bytes + 1);
-        if (!picoquic_is_header_version_supported(ph->vn)) {
+        uint8_t l_dest_id = 0;
+        uint8_t l_srce_id = 0;
+        uint32_t i_srce_id = 0;
+
+        l_dest_id = bytes[5];
+        if ((size_t)6 + l_dest_id + (size_t)1 > length) {
+            l_srce_id = 255;
+            i_srce_id = (uint32_t)length;
+        }
+        else {
+            l_srce_id = bytes[(size_t)6 + l_dest_id];
+            i_srce_id = (size_t)6 + l_dest_id + (size_t)1;
+        }
+        /* Required length: at least one length byte and at least one seqnum byte
+            * after the srce id*/
+        if (i_srce_id + l_srce_id + 2 > (int)length) {
+            /* malformed packet */
             ret = -1;
         }
         else {
-            uint8_t l_dest_id = 0;
-            uint8_t l_srce_id = 0;
-            uint32_t i_srce_id = 0;
+            (void)picoquic_parse_connection_id(bytes + 6, l_dest_id, &ph->dest_cnx_id);
+            (void)picoquic_parse_connection_id(bytes + i_srce_id, l_srce_id, &ph->srce_cnx_id);
+            ph->offset = (size_t)i_srce_id + l_srce_id;
 
-            l_dest_id = bytes[5];
-            if ((size_t)6 + l_dest_id + (size_t)1 > length) {
-                l_srce_id = 255;
-                i_srce_id = (uint32_t)length;
-            }
-            else {
-                l_srce_id = bytes[(size_t)6 + l_dest_id];
-                i_srce_id = (size_t)6 + l_dest_id + (size_t)1;
-            }
-            /* Required length: at least one length byte and at least one seqnum byte
-             * after the srce id*/
-            if (i_srce_id + l_srce_id + 2 > (int)length) {
-                /* malformed packet */
-                ret = -1;
-            }
-            else {
-                (void)picoquic_parse_connection_id(bytes + 6, l_dest_id, &ph->dest_cnx_id);
-                (void)picoquic_parse_connection_id(bytes + i_srce_id, l_srce_id, &ph->srce_cnx_id);
-                ph->offset = (size_t)i_srce_id + l_srce_id;
+            if (ph->vn == 0) {
+                /* VN = zero identifies a version negotiation packet */
+                ph->ptype = picoquic_packet_version_negotiation;
+                ph->pc = picoquic_packet_context_initial;
+                ph->payload_length = (uint16_t)((length > ph->offset) ? length - ph->offset : 0);
+                ph->pl_val = ph->payload_length; /* saving the value found in the packet */
 
-                if (ph->vn == 0) {
-                    /* VN = zero identifies a version negotiation packet */
-                    ph->ptype = picoquic_packet_version_negotiation;
-                    ph->pc = picoquic_packet_context_initial;
-                    ph->payload_length = (uint16_t)((length > ph->offset) ? length - ph->offset : 0);
-                    ph->pl_val = ph->payload_length; /* saving the value found in the packet */
+                if (*pcnx == NULL && quic != NULL) {
+                    /* The version negotiation should always include the cnx-id sent by the client */
+                    if (ph->dest_cnx_id.id_len > 0) {
+                        *pcnx = picoquic_cnx_by_id(quic, ph->dest_cnx_id);
+                    }
+                    else {
+                        *pcnx = picoquic_cnx_by_net(quic, addr_from);
 
-                    if (*pcnx == NULL && quic != NULL) {
-                        /* The version negotiation should always include the cnx-id sent by the client */
-                        if (ph->dest_cnx_id.id_len > 0) {
-                            *pcnx = picoquic_cnx_by_id(quic, ph->dest_cnx_id);
-                        }
-                        else {
-                            *pcnx = picoquic_cnx_by_net(quic, addr_from);
-
-                            if (*pcnx != NULL && (*pcnx)->path[0]->local_cnxid.id_len != 0) {
-                                *pcnx = NULL;
-                            }
+                        if (*pcnx != NULL && (*pcnx)->path[0]->local_cnxid.id_len != 0) {
+                            *pcnx = NULL;
                         }
                     }
                 }
-                else {
-                    char context_by_addr = 0;
-                    uint64_t payload_length = 0;
-                    uint32_t var_length = 0;
+            }
+            else {
+                char context_by_addr = 0;
+                uint64_t payload_length = 0;
+                uint32_t var_length = 0;
 
-                    ph->version_index = picoquic_get_version_index(ph->vn);
+                ph->version_index = picoquic_get_version_index(ph->vn);
 
-                    if (ph->version_index >= 0) {
-                        /* If the version is supported now, the format field in the version table
-                        * describes the encoding. */
-                        switch (picoquic_supported_versions[ph->version_index].version_header_encoding) {
-                        case picoquic_version_header_17:
-                            ph->spin = 0;
-                            ph->has_spin_bit = 0;
-                            switch ((bytes[0] >> 4) & 7) {
-                            case 4: /* Initial */
-                            {
-                                /* special case of the initial packets. They contain a retry token between the header
-                                * and the encrypted payload */
-                                uint64_t tok_len = 0;
-                                size_t l_tok_len = picoquic_varint_decode(bytes + ph->offset, length - ph->offset, &tok_len);
+                if (ph->version_index >= 0) {
+                    /* If the version is supported now, the format field in the version table
+                    * describes the encoding. */
+                    switch (picoquic_supported_versions[ph->version_index].version_header_encoding) {
+                    case picoquic_version_header_17:
+                        ph->spin = 0;
+                        ph->has_spin_bit = 0;
+                        switch ((bytes[0] >> 4) & 7) {
+                        case 4: /* Initial */
+                        {
+                            /* special case of the initial packets. They contain a retry token between the header
+                            * and the encrypted payload */
+                            uint64_t tok_len = 0;
+                            size_t l_tok_len = picoquic_varint_decode(bytes + ph->offset, length - ph->offset, &tok_len);
 
-                                ph->ptype = picoquic_packet_initial;
-                                ph->pc = picoquic_packet_context_initial;
-                                ph->epoch = 0;
-                                if (l_tok_len == 0) {
-                                    /* packet is malformed */
-                                    ph->offset = length;
-                                    ph->ptype = picoquic_packet_error;
-                                    ph->pc = 0;
-                                }
-                                else {
-                                    ph->token_length = (size_t)tok_len;
-                                    ph->token_bytes = bytes + ph->offset + l_tok_len;
-                                    ph->offset += l_tok_len + (size_t)tok_len;
-                                }
-
-                                break;
-                            }
-                            case 5: /* 0-RTT Protected */
-                                ph->ptype = picoquic_packet_0rtt_protected;
-                                ph->pc = picoquic_packet_context_application;
-                                ph->epoch = 1;
-                                break;
-                            case 6: /* Handshake */
-                                ph->ptype = picoquic_packet_handshake;
-                                ph->pc = picoquic_packet_context_handshake;
-                                ph->epoch = 2;
-                                break;
-                            case 7: /* Retry */
-                                ph->ptype = picoquic_packet_retry;
-                                ph->pc = picoquic_packet_context_initial;
-                                ph->epoch = 0;
-                                break;
-                            default: /* Not a valid packet type */
-                                DBG_PRINTF("Packet type is not recognized: 0x%02x\n", bytes[0]);
+                            ph->ptype = picoquic_packet_initial;
+                            ph->pc = picoquic_packet_context_initial;
+                            ph->epoch = 0;
+                            if (l_tok_len == 0) {
+                                /* packet is malformed */
+                                ph->offset = length;
                                 ph->ptype = picoquic_packet_error;
-                                ph->version_index = -1;
                                 ph->pc = 0;
-                                break;
                             }
+                            else {
+                                ph->token_length = (size_t)tok_len;
+                                ph->token_bytes = bytes + ph->offset + l_tok_len;
+                                ph->offset += l_tok_len + (size_t)tok_len;
+                            }
+
                             break;
-                        default:
-                            /* version is not supported */
-                            DBG_PRINTF("Version (%x) is recognized but encoding not supported\n", ph->vn);
+                        }
+                        case 5: /* 0-RTT Protected */
+                            ph->ptype = picoquic_packet_0rtt_protected;
+                            ph->pc = picoquic_packet_context_application;
+                            ph->epoch = 1;
+                            break;
+                        case 6: /* Handshake */
+                            ph->ptype = picoquic_packet_handshake;
+                            ph->pc = picoquic_packet_context_handshake;
+                            ph->epoch = 2;
+                            break;
+                        case 7: /* Retry */
+                            ph->ptype = picoquic_packet_retry;
+                            ph->pc = picoquic_packet_context_initial;
+                            ph->epoch = 0;
+                            break;
+                        default: /* Not a valid packet type */
+                            DBG_PRINTF("Packet type is not recognized: 0x%02x\n", bytes[0]);
                             ph->ptype = picoquic_packet_error;
                             ph->version_index = -1;
                             ph->pc = 0;
                             break;
                         }
+                        break;
+                    default:
+                        /* version is not supported */
+                        DBG_PRINTF("Version (%x) is recognized but encoding not supported\n", ph->vn);
+                        ph->ptype = picoquic_packet_error;
+                        ph->version_index = -1;
+                        ph->pc = 0;
+                        break;
                     }
+                }
 
-                    if (ph->ptype == picoquic_packet_retry) {
-                        /* No segment length or sequence number in retry packets */
-                        if (length > ph->offset) {
-                            payload_length = (uint16_t)length - ph->offset;
-                        }
-                        else {
-                            payload_length = 0;
-                            ph->ptype = picoquic_packet_error;
-                        }
+                if (ph->ptype == picoquic_packet_retry) {
+                    /* No segment length or sequence number in retry packets */
+                    if (length > ph->offset) {
+                        payload_length = (uint16_t)length - ph->offset;
                     }
                     else {
-                        if (ph->offset < length) {
-                            var_length = (uint32_t)picoquic_varint_decode(bytes + ph->offset,
-                                length - ph->offset, &payload_length);
+                        payload_length = 0;
+                        ph->ptype = picoquic_packet_error;
+                    }
+                }
+                else {
+                    if (ph->offset < length) {
+                        var_length = (uint32_t)picoquic_varint_decode(bytes + ph->offset,
+                            length - ph->offset, &payload_length);
+                    }
+
+                    if (var_length <= 0 || ph->offset + var_length + payload_length > length ||
+                        ph->version_index < 0) {
+                        ph->ptype = picoquic_packet_error;
+                        ph->payload_length = (uint16_t)((length > ph->offset) ? length - ph->offset : 0);
+                        ph->pl_val = ph->payload_length;
+                    }
+                }
+
+                if (ph->ptype != picoquic_packet_error)
+                {
+                    ph->pl_val = (uint16_t)payload_length;
+                    ph->payload_length = (uint16_t)payload_length;
+                    ph->offset += var_length;
+                    ph->pn_offset = ph->offset;
+
+                    /* Retrieve the connection context */
+                    if (*pcnx == NULL) {
+                        if (ph->dest_cnx_id.id_len != 0) {
+                            *pcnx = picoquic_cnx_by_id(quic, ph->dest_cnx_id);
                         }
 
-                        if (var_length <= 0 || ph->offset + var_length + payload_length > length ||
-                            ph->version_index < 0) {
-                            ph->ptype = picoquic_packet_error;
-                            ph->payload_length = (uint16_t)((length > ph->offset) ? length - ph->offset : 0);
-                            ph->pl_val = ph->payload_length;
+                        /* TODO: something for the case of client initial, e.g. source IP + initial CNX_ID */
+                        if (*pcnx == NULL) {
+                            *pcnx = picoquic_cnx_by_net(quic, addr_from);
+
+                            if (*pcnx != NULL)
+                            {
+                                context_by_addr = 1;
+                            }
                         }
                     }
 
-                    if (ph->ptype != picoquic_packet_error)
+                    /* If the context was found by using `addr_from`, but the packet type
+                        * does not allow that, reset the context to NULL. */
+                    if (context_by_addr)
                     {
-                        ph->pl_val = (uint16_t)payload_length;
-                        ph->payload_length = (uint16_t)payload_length;
-                        ph->offset += var_length;
-                        ph->pn_offset = ph->offset;
-
-                        /* Retrieve the connection context */
-                        if (*pcnx == NULL) {
-                            if (ph->dest_cnx_id.id_len != 0) {
-                                *pcnx = picoquic_cnx_by_id(quic, ph->dest_cnx_id);
-                            }
-
-                            /* TODO: something for the case of client initial, e.g. source IP + initial CNX_ID */
-                            if (*pcnx == NULL) {
-                                *pcnx = picoquic_cnx_by_net(quic, addr_from);
-
-                                if (*pcnx != NULL)
-                                {
-                                    context_by_addr = 1;
-                                }
+                        if ((*pcnx)->client_mode) {
+                            if ((*pcnx)->path[0]->local_cnxid.id_len != 0) {
+                                *pcnx = NULL;
                             }
                         }
-
-                        /* If the context was found by using `addr_from`, but the packet type
-                         * does not allow that, reset the context to NULL. */
-                        if (context_by_addr)
+                        else if (ph->ptype != picoquic_packet_initial && ph->ptype != picoquic_packet_0rtt_protected)
                         {
-                            if ((*pcnx)->client_mode) {
-                                if ((*pcnx)->path[0]->local_cnxid.id_len != 0) {
-                                    *pcnx = NULL;
-                                }
-                            }
-                            else if (ph->ptype != picoquic_packet_initial && ph->ptype != picoquic_packet_0rtt_protected)
-                            {
-                                *pcnx = NULL;
-                            }
-                            else if (picoquic_compare_connection_id(&(*pcnx)->initial_cnxid, &ph->dest_cnx_id) != 0) {
-                                *pcnx = NULL;
-                            }
+                            *pcnx = NULL;
+                        }
+                        else if (picoquic_compare_connection_id(&(*pcnx)->initial_cnxid, &ph->dest_cnx_id) != 0) {
+                            *pcnx = NULL;
                         }
                     }
                 }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -328,43 +328,6 @@ void picoquic_update_payload_length(
     }
 }
 
-static int picoquic_is_sending_old_invariant(
-    picoquic_cnx_t* cnx,
-    picoquic_packet_type_enum packet_type)
-{
-    int use_old_invariants;
-    uint32_t vn;
-
-    if ((cnx->cnx_state == picoquic_state_client_init || cnx->cnx_state == picoquic_state_client_init_sent) && packet_type == picoquic_packet_initial) {
-        vn = cnx->proposed_version;
-    }
-    else {
-        vn = picoquic_supported_versions[cnx->version_index].version;
-    }
-
-    /* Check whether to use old or new version of the invariants */
-    if ((vn & 0xFFFFFF00) == 0xFF000000) {
-        /* Draft versions before #20 use the old invariants */
-        int draft_nb = vn & 0xFF;
-        use_old_invariants = (draft_nb <= 20) ? 1 : 0;
-    }
-    else if ((vn & 0xFFFFFFF0) == 0 ||
-        vn == PICOQUIC_INTERNAL_TEST_VERSION_1 ||
-        vn == PICOQUIC_INTERNAL_TEST_VERSION_2) {
-        /* Final versions and internal versions use the new invariants */
-        use_old_invariants = 0;
-    }
-    else if ((vn & 0xF0000000) == 0) {
-        /* greasing version, number starts with 0 */
-        use_old_invariants = 1;
-    }
-    else {
-        use_old_invariants = 0;
-    }
-
-    return use_old_invariants;
-}
-
 size_t picoquic_create_packet_header(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
@@ -426,18 +389,11 @@ size_t picoquic_create_packet_header(
         }
         length += 4;
 
-        if (picoquic_is_sending_old_invariant(cnx, packet_type)) {
-            bytes[length++] = picoquic_create_packet_header_cnxid_lengths(dest_cnx_id.id_len, local_cnxid->id_len);
+        bytes[length++] = dest_cnx_id.id_len;
+        length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, dest_cnx_id);
+        bytes[length++] = local_cnxid->id_len;
+        length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, *local_cnxid);
 
-            length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, dest_cnx_id);
-            length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, *local_cnxid);
-        }
-        else {
-            bytes[length++] = dest_cnx_id.id_len;
-            length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, dest_cnx_id);
-            bytes[length++] = local_cnxid->id_len;
-            length += picoquic_format_connection_id(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, *local_cnxid);
-        }
         /* Special case of packet initial -- encode token as part of header */
         if (packet_type == picoquic_packet_initial) {
             length += picoquic_varint_encode(&bytes[length], PICOQUIC_MAX_PACKET_SIZE - length, cnx->retry_token_length);
@@ -485,12 +441,7 @@ size_t picoquic_predict_packet_header_length(
     }
     else {
         /* Compute length of a long packet header */
-        if (picoquic_is_sending_old_invariant(cnx, packet_type)) {
-            header_length = 1 + /* version */ 4 + /* cnx_id prefix */ 1;
-        }
-        else {
-            header_length = 1 + /* version */ 4 + /* cnx_id length bytes  */ 2;
-        }
+        header_length = 1 + /* version */ 4 + /* cnx_id length bytes */ 2;
 
         /* add dest-id length */
         if (cnx->client_mode && (packet_type == picoquic_packet_initial ||

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -267,15 +267,6 @@ uint8_t picoquic_create_packet_header_cnxid_lengths(uint8_t dest_len, uint8_t sr
     return ret;
 }
 
-void picoquic_parse_packet_header_cnxid_lengths(uint8_t l_byte, uint8_t *dest_len, uint8_t *srce_len)
-{
-    uint8_t h1 = (l_byte>>4);
-    uint8_t h2 = (l_byte & 0x0F);
-
-    *dest_len = (h1 == 0) ? 0 : h1 + 3;
-    *srce_len = (h2 == 0) ? 0 : h2 + 3;
-}
-
 uint8_t picoquic_format_connection_id(uint8_t* bytes, size_t bytes_max, picoquic_connection_id_t cnx_id)
 {
     uint8_t copied = cnx_id.id_len;

--- a/picoquic/util.h
+++ b/picoquic/util.h
@@ -65,7 +65,6 @@ void picoquic_set64_connection_id(picoquic_connection_id_t * cnx_id, uint64_t va
 uint8_t picoquic_parse_connection_id_hexa(char const * hex_input, size_t input_length, picoquic_connection_id_t * cnx_id);
 int picoquic_print_connection_id_hexa(char* buf, size_t buf_len, const picoquic_connection_id_t* cnxid);
 uint8_t picoquic_create_packet_header_cnxid_lengths(uint8_t dest_len, uint8_t srce_len);
-void picoquic_parse_packet_header_cnxid_lengths(uint8_t l_byte, uint8_t *dest_len, uint8_t *srce_len);
 
 int picoquic_compare_addr(const struct sockaddr * expected, const struct sockaddr * actual);
 int picoquic_store_addr(struct sockaddr_storage * stored_addr, const struct sockaddr * addr);


### PR DESCRIPTION
I've deleted the old invariant connection id parsing in the packet header.

That required a functional change in the way the version for packet header parsing is evaluated. I tried to stay close to the current QUIC specification.

I had to change test_tls_api_version_negotiation, which was using the old invariant. Now it also uses the new invariant. A version of ?A?A?A?A was causing picoquic to send packets with the old invariant. I deleted that code as well.