### PR TITLE
Nat fast rebind

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -692,6 +692,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(fast_nat_rebinding)
+        {
+            int ret = fast_nat_rebinding_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(test_spin_bit)
         {
             int ret = spin_bit_test();

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3327,7 +3327,7 @@ uint8_t* picoquic_decode_path_response_frame(picoquic_cnx_t* cnx, uint8_t* bytes
                     }
                 }
                 if (found_challenge) {
-                    if (cnx->path[i]->alt_challenge_required) {
+                    if (cnx->path[i]->alt_challenge_required && !cnx->path[i]->challenge_verified) {
                         /* Promote the alt address to valid address */
                         cnx->path[i]->peer_addr_len = picoquic_store_addr(&cnx->path[i]->peer_addr, (struct sockaddr*) & cnx->path[i]->alt_peer_addr);
                         cnx->path[i]->local_addr_len = picoquic_store_addr(&cnx->path[i]->local_addr, (struct sockaddr*) & cnx->path[i]->alt_local_addr);

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3327,23 +3327,27 @@ uint8_t* picoquic_decode_path_response_frame(picoquic_cnx_t* cnx, uint8_t* bytes
                     }
                 }
                 if (found_challenge) {
-                    /* Promote the alt address to valid address */
-                    cnx->path[i]->peer_addr_len = picoquic_store_addr(&cnx->path[i]->peer_addr, (struct sockaddr*) & cnx->path[i]->alt_peer_addr);
-                    cnx->path[i]->local_addr_len = picoquic_store_addr(&cnx->path[i]->local_addr, (struct sockaddr*) & cnx->path[i]->alt_local_addr);
-                    memset(&cnx->path[i]->alt_peer_addr, 0, sizeof(cnx->path[i]->alt_peer_addr));
-                    memset(&cnx->path[i]->alt_local_addr, 0, sizeof(cnx->path[i]->alt_local_addr));
-                    cnx->path[i]->challenge_response = cnx->path[i]->alt_challenge_response;
-                    cnx->path[i]->response_required = cnx->path[i]->alt_response_required;
-                    cnx->path[i]->alt_peer_addr_len = 0;
-                    cnx->path[i]->alt_local_addr_len = 0;
-                    cnx->path[i]->alt_challenge_timeout = 0;
-                    cnx->path[i]->challenge_verified = 1;
-                    cnx->path[i]->alt_challenge_required = 0;
-                    cnx->path[i]->alt_response_required = 0;
-                    cnx->path[i]->alt_challenge_response = 0;
-
+                    if (cnx->path[i]->alt_challenge_required) {
+                        /* Promote the alt address to valid address */
+                        cnx->path[i]->peer_addr_len = picoquic_store_addr(&cnx->path[i]->peer_addr, (struct sockaddr*) & cnx->path[i]->alt_peer_addr);
+                        cnx->path[i]->local_addr_len = picoquic_store_addr(&cnx->path[i]->local_addr, (struct sockaddr*) & cnx->path[i]->alt_local_addr);
+                        memset(&cnx->path[i]->alt_peer_addr, 0, sizeof(cnx->path[i]->alt_peer_addr));
+                        memset(&cnx->path[i]->alt_local_addr, 0, sizeof(cnx->path[i]->alt_local_addr));
+                        cnx->path[i]->challenge_response = cnx->path[i]->alt_challenge_response;
+                        cnx->path[i]->response_required = cnx->path[i]->alt_response_required;
+                        cnx->path[i]->alt_peer_addr_len = 0;
+                        cnx->path[i]->alt_local_addr_len = 0;
+                        cnx->path[i]->alt_challenge_timeout = 0;
+                        cnx->path[i]->challenge_verified = 1;
+                        cnx->path[i]->alt_challenge_required = 0;
+                        cnx->path[i]->alt_response_required = 0;
+                        cnx->path[i]->alt_challenge_response = 0;
+                    }
+                    else {
+                        DBG_PRINTF("Repeated challenge: %16llx\n", (unsigned long long)response);
+                    }
                     break;
-                }
+                }  
             }
         }
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -130,6 +130,7 @@ static const picoquic_test_def_t test_table[] = {
     { "bad_client_certificate", bad_client_certificate_test },
     { "nat_rebinding", nat_rebinding_test },
     { "nat_rebinding_loss", nat_rebinding_loss_test },
+    { "fast_nat_rebinding", fast_nat_rebinding_test},
     { "spin_bit", spin_bit_test},
     { "client_error", client_error_test },
     { "packet_enc_dec", packet_enc_dec_test},

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -289,12 +289,19 @@ int quic_server(const char* server_name, int server_port,
                     cnx_server = picoquic_get_first_cnx(qserver);
                     memset(&client_from, 0, sizeof(client_from));
                     memcpy(&client_from, &addr_from, from_length);
+                    if (client_from.ss_family == AF_INET) {
+                        struct sockaddr_in* addr = (struct sockaddr_in*) & client_from;
+                        addr->sin_port = ntohs(addr->sin_port);
+                    }
+                    else {
+                        struct sockaddr_in6* addr = (struct sockaddr_in6*) & client_from;
+                        addr->sin6_port = ntohs(addr->sin6_port);
+                    }
                     if (F_log != NULL) {
-                        fprintf(F_log, "%llx: ", (unsigned long long)picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx_server)));
+                        fprintf(F_log, "%16llx: ", (unsigned long long)picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx_server)));
                         picoquic_log_time(F_log, cnx_server, picoquic_current_time(), "", " : ");
                         fprintf(F_log, "Connection established, state = %d, from length: %d\n",
                             picoquic_get_cnx_state(picoquic_get_first_cnx(qserver)), from_length);
-
                         print_address(F_log, (struct sockaddr*)&client_from, "Client address:",
                             picoquic_get_logging_cnxid(cnx_server));
                         picoquic_log_transport_extension(F_log, cnx_server, 1);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -188,6 +188,7 @@ int h09_post_test();
 int fastcc_test();
 int fastcc_jitter_test();
 int large_client_hello_test();
+int fast_nat_rebinding_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -140,6 +140,7 @@ typedef struct st_picoquic_test_tls_api_ctx_t {
     picoquic_cnx_t* cnx_server;
     int client_use_nat;
     int server_use_multiple_addresses;
+    int client_use_multiple_addresses;
     int do_bad_coalesce_test;
     struct sockaddr_in client_addr;
     struct sockaddr_in server_addr;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3349,13 +3349,8 @@ int nat_rebinding_loss_test()
 int fast_nat_rebinding_test()
 {
     uint64_t simulated_time = 0;
-    uint64_t next_time = 0;
     uint64_t loss_mask = 0;
-    uint64_t initial_challenge = 0;
-    uint64_t client_challenge = 0;
-    int nb_inactive = 0;
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
-    /*picoquic_tp_t client_params;*/
     int ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1,
         PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 0, 0);
 
@@ -3383,6 +3378,9 @@ int fast_nat_rebinding_test()
         int switched = 0;
         int nb_switched = 0;
 
+        test_ctx->client_use_nat = 1;
+        test_ctx->client_use_multiple_addresses = 1;
+
         while (ret == 0 && nb_trials < max_trials && nb_inactive < 256 && simulated_time < next_time && TEST_CLIENT_READY && TEST_SERVER_READY) {
             int was_active = 0;
 
@@ -3407,8 +3405,6 @@ int fast_nat_rebinding_test()
                     else if (simulated_time >= switch_time) {
                         /* Change the client address */
                         test_ctx->client_addr.sin_port ^= 17;
-                        test_ctx->client_use_nat = 1;
-                        test_ctx->client_use_multiple_addresses = 1;
                         switched = 1;
                         nb_switched++;
                     }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -954,7 +954,9 @@ int tls_api_one_sim_round(picoquic_test_tls_api_ctx_t* test_ctx,
 
             /* Check the destination address  before submitting the packet */
             if (picoquic_compare_addr((struct sockaddr *)&test_ctx->client_addr,
-                (struct sockaddr *)&packet->addr_to) == 0) {
+                (struct sockaddr *)&packet->addr_to) == 0 ||
+                (packet->addr_to.ss_family == test_ctx->client_addr.sin_family &&
+                    test_ctx->client_use_multiple_addresses)){
                 ret = picoquic_incoming_packet(test_ctx->qclient, packet->bytes, (uint32_t)packet->length,
                     (struct sockaddr*)&packet->addr_from,
                     (struct sockaddr*)&packet->addr_to, 0, 0,
@@ -3336,6 +3338,116 @@ int nat_rebinding_loss_test()
     uint64_t loss_mask = 0x2412;
 
     return nat_rebinding_test_one(loss_mask);
+}
+
+/*
+* Fast NAT Rebinding test. The client is unaware of the migration,
+* and is programmed to not support migration. The NAT alternates
+* between ports based on time, or packet counts.
+*/
+
+int fast_nat_rebinding_test()
+{
+    uint64_t simulated_time = 0;
+    uint64_t next_time = 0;
+    uint64_t loss_mask = 0;
+    uint64_t initial_challenge = 0;
+    uint64_t client_challenge = 0;
+    int nb_inactive = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    /*picoquic_tp_t client_params;*/
+    int ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1,
+        PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 0, 0);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = PICOQUIC_ERROR_MEMORY;
+    }
+
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+    }
+
+    if (ret == 0) {
+        ret = test_api_init_send_recv_scenario(test_ctx, test_scenario_sustained, sizeof(test_scenario_sustained));
+    }
+
+    /* Perform a data sending loop */
+    if (ret == 0) {
+        uint64_t delta_t = (test_ctx->c_to_s_link->microsec_latency + test_ctx->s_to_c_link->microsec_latency);
+        uint64_t next_time = simulated_time + 200000000;
+        int ret = 0;
+        int nb_trials = 0;
+        int nb_inactive = 0;
+        int max_trials = 1000000;
+        uint64_t switch_time = simulated_time;
+        int switched = 0;
+        int nb_switched = 0;
+
+        while (ret == 0 && nb_trials < max_trials && nb_inactive < 256 && simulated_time < next_time && TEST_CLIENT_READY && TEST_SERVER_READY) {
+            int was_active = 0;
+
+            nb_trials++;
+
+            ret = tls_api_one_sim_round(test_ctx, &simulated_time, next_time, &was_active);
+
+            if (ret < 0)
+            {
+                break;
+            }
+
+            if (ret == 0 && test_ctx->cnx_server != NULL && test_ctx->cnx_server->cnx_state == picoquic_state_ready) {
+                if (((struct sockaddr_in*) & test_ctx->cnx_server->path[0]->peer_addr)->sin_port == 0) {
+                    DBG_PRINTF("Client address out of sync, port: %d", ((struct sockaddr_in*) & test_ctx->cnx_server->path[0]->peer_addr)->sin_port);
+                }
+                else if (((struct sockaddr_in*) & test_ctx->cnx_server->path[0]->peer_addr)->sin_port == test_ctx->client_addr.sin_port) {
+                    if (switched) {
+                        switch_time = simulated_time + delta_t;
+                        switched = 0;
+                    }
+                    else if (simulated_time >= switch_time) {
+                        /* Change the client address */
+                        test_ctx->client_addr.sin_port ^= 17;
+                        test_ctx->client_use_nat = 1;
+                        test_ctx->client_use_multiple_addresses = 1;
+                        switched = 1;
+                        nb_switched++;
+                    }
+                }
+            }
+
+            if (was_active) {
+                nb_inactive = 0;
+            }
+            else {
+                nb_inactive++;
+
+                if (nb_inactive == 254) {
+                    DBG_PRINTF("Almost stalled after %d trials, %d inactive, %d switches", nb_trials, nb_inactive, nb_switched);
+                }
+            }
+
+            if (test_ctx->test_finished) {
+                if (picoquic_is_cnx_backlog_empty(test_ctx->cnx_client) && picoquic_is_cnx_backlog_empty(test_ctx->cnx_server)) {
+                    break;
+                }
+            }
+        }
+
+        DBG_PRINTF("Exit after %d trials, %d inactive, %d switches", nb_trials, nb_inactive, nb_switched);
+
+    }
+
+    /* verify that the transmission was complete */
+    if (ret == 0) {
+        ret = tls_api_one_scenario_verify(test_ctx);
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
 }
 
 /*


### PR DESCRIPTION
Close #696 

@kenmcmil I think this fixes the root cause of the issue that you found. When a NAT challenge was accepted, the NAT address was promoted and the old value was erased. But in case of repeated response, the old value was promoted again...