### PR TITLE
Satellite test

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -964,6 +964,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(satellite_basic)
+        {
+            int ret = satellite_basic_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(cid_length)
         {
             int ret = cid_length_test();

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -649,7 +649,6 @@ void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, 
 {
     picoquic_remove_cnx_from_wake_list(cnx);
     cnx->next_wake_time = next_time;
-    SET_LAST_WAKE(cnx->quic, PICOQUIC_QUICCTX);
     picoquic_insert_cnx_by_wake_time(quic, cnx);
 }
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -173,6 +173,7 @@ static const picoquic_test_def_t test_table[] = {
     { "fastcc", fastcc_test },
     { "fastcc_jitter", fastcc_jitter_test },
     { "long_rtt", long_rtt_test },
+    { "satellite_basic", satellite_basic_test },
     { "cid_length", cid_length_test },
     { "optimistic_ack", optimistic_ack_test },
     { "optimistic_hole", optimistic_hole_test },

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -277,7 +277,7 @@ int quic_server(const char* server_name, int server_port,
             delta_t, &current_time);
 
         nb_loops++;
-        if (nb_loops > 10000) {
+        if (nb_loops >= 10000) {
             uint64_t loop_delta = current_time - loop_count_time;
             loop_count_time = current_time;
             fprintf(F_log, "Looped %d times in %llu microsec, file: %d, line: %d\n", 

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -157,6 +157,7 @@ int ready_to_send_test();
 int split_stream_frame_test();
 int cubic_test();
 int cubic_jitter_test();
+int satellite_basic_test();
 int long_rtt_test();
 int cid_length_test();
 int initial_server_close_test();


### PR DESCRIPTION
This is the first step in the satellite transmission experiment. The current performance are nominal -- a bit less than 7 seconds for sending a 10MB file over a 100 Mbps satellite link. If working at full speed, this should be less than1 second, so there is clearly some work to do, such as a better slow start, and also maybe IW10.

The full satellite tests should include a lossy link, but this requires developing code to distinguish "random" losses from congestion losses. 