### PR TITLE
Satellite test harder

### DIFF
--- a/picoquic/cc_common.c
+++ b/picoquic/cc_common.c
@@ -81,6 +81,7 @@ int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measur
 
             if (rtt_track->sample_min > rtt_track->rtt_filtered_min) {
                 delta_rtt = rtt_track->sample_min - rtt_track->rtt_filtered_min;
+                rtt_track->past_threshold = 1;
                 if (delta_rtt * 4 > rtt_track->rtt_filtered_min ||
                     (rtt_track->rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT && delta_rtt > 256 * packet_time)) {
                     rtt_track->nb_rtt_excess++;

--- a/picoquic/cc_common.c
+++ b/picoquic/cc_common.c
@@ -63,7 +63,7 @@ void picoquic_filter_rtt_min_max(picoquic_min_max_rtt_t * rtt_track, uint64_t rt
     }
 }
 
-int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t current_time)
+int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time)
 {
     int ret = 0;
 
@@ -82,7 +82,7 @@ int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measur
             if (rtt_track->sample_min > rtt_track->rtt_filtered_min) {
                 delta_rtt = rtt_track->sample_min - rtt_track->rtt_filtered_min;
                 if (delta_rtt * 4 > rtt_track->rtt_filtered_min ||
-                    delta_rtt * 4 > PICOQUIC_TARGET_RENO_RTT) {
+                    (rtt_track->rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT && delta_rtt > 256 * packet_time)) {
                     rtt_track->nb_rtt_excess++;
                     if (rtt_track->nb_rtt_excess >= PICOQUIC_MIN_MAX_RTT_SCOPE) {
                         /* RTT increased too much, get out of slow start! */

--- a/picoquic/cc_common.h
+++ b/picoquic/cc_common.h
@@ -30,6 +30,7 @@ typedef struct st_picoquic_min_max_rtt_t {
     int nb_rtt_excess;
     int sample_current;
     int is_init;
+    int past_threshold;
     uint64_t sample_min;
     uint64_t sample_max;
     uint64_t samples[PICOQUIC_MIN_MAX_RTT_SCOPE];

--- a/picoquic/cc_common.h
+++ b/picoquic/cc_common.h
@@ -41,7 +41,7 @@ uint64_t picoquic_cc_get_ack_number(picoquic_cnx_t* cnx);
 
 void picoquic_filter_rtt_min_max(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt);
 
-int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t current_time);
+int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time);
 
 int picoquic_cc_was_cwin_blocked(picoquic_cnx_t* cnx, uint64_t last_sequence_blocked);
 

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -253,7 +253,7 @@ static void picoquic_cubic_notify(
                 break;
             case picoquic_congestion_notification_rtt_measurement:
                 /* Using RTT increases as signal to get out of initial slow start */
-                if (cubic_state->ssthresh == (uint64_t)((int64_t)-1) && picoquic_hystart_test(&cubic_state->rtt_filter, rtt_measurement, current_time)) {
+                if (cubic_state->ssthresh == (uint64_t)((int64_t)-1) && picoquic_hystart_test(&cubic_state->rtt_filter, rtt_measurement, cnx->path[0]->pacing_packet_time_microsec, current_time)) {
                     /* RTT increased too much, get out of slow start! */
                     cubic_state->ssthresh = path_x->cwin;
                     cubic_state->W_max = (double)path_x->cwin / (double)path_x->send_mtu;

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -223,7 +223,7 @@ static void picoquic_cubic_notify(
             switch (notification) {
             case picoquic_congestion_notification_acknowledgement:
                 if (picoquic_cc_was_cwin_blocked(cnx, cubic_state->last_sequence_blocked)) {
-                    if (path_x->smoothed_rtt <= PICOQUIC_TARGET_RENO_RTT) {
+                    if (path_x->smoothed_rtt <= PICOQUIC_TARGET_RENO_RTT || cubic_state->rtt_filter.past_threshold) {
                         path_x->cwin += nb_bytes_acknowledged;
                     }
                     else {
@@ -255,6 +255,12 @@ static void picoquic_cubic_notify(
                 /* Using RTT increases as signal to get out of initial slow start */
                 if (cubic_state->ssthresh == (uint64_t)((int64_t)-1) && picoquic_hystart_test(&cubic_state->rtt_filter, rtt_measurement, cnx->path[0]->pacing_packet_time_microsec, current_time)) {
                     /* RTT increased too much, get out of slow start! */
+                    if (cubic_state->rtt_filter.rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT) {
+                        double correction = (double)PICOQUIC_TARGET_RENO_RTT / (double)cubic_state->rtt_filter.rtt_filtered_min;
+                        uint64_t base_window = (uint64_t)(correction * (double)path_x->cwin);
+                        uint64_t delta_window = path_x->cwin - base_window;
+                        path_x->cwin -= (delta_window / 2);
+                    }
                     cubic_state->ssthresh = path_x->cwin;
                     cubic_state->W_max = (double)path_x->cwin / (double)path_x->send_mtu;
                     cubic_state->W_last_max = cubic_state->W_max;

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -160,7 +160,7 @@ static void picoquic_newreno_notify(
             /* Using RTT increases as signal to get out of initial slow start */
             if (nr_state->alg_state == picoquic_newreno_alg_slow_start &&
                 nr_state->ssthresh == (uint64_t)((int64_t)-1) &&
-                picoquic_hystart_test(&nr_state->rtt_filter, rtt_measurement, current_time)) {
+                picoquic_hystart_test(&nr_state->rtt_filter, rtt_measurement, cnx->path[0]->pacing_packet_time_microsec, current_time)) {
                 /* RTT increased too much, get out of slow start! */
                 nr_state->ssthresh = path_x->cwin;
                 nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -694,6 +694,9 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t * cnx, uint64_t stream_id, co
 int picoquic_reset_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, uint16_t local_stream_error);
 
+/* Open the flow control for receiving the expected data on a stream */
+int picoquic_open_flow_control(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t expected_data_size);
+
 /* Obtain the next available stream ID in the local category */
 uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1068,6 +1068,8 @@ int picoquic_prepare_required_max_stream_data_frames(picoquic_cnx_t* cnx,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
 int picoquic_prepare_max_data_frame(picoquic_cnx_t* cnx, uint64_t maxdata_increase,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
+int picoquic_prepare_max_stream_data_frame(picoquic_stream_head_t* stream,
+    uint8_t* bytes, size_t bytes_max, uint64_t new_max_data, size_t* consumed);
 uint64_t picoquic_cc_increased_window(picoquic_cnx_t* cnx, uint64_t previous_window);
 void picoquic_update_max_stream_ID_local(picoquic_cnx_t* cnx, picoquic_stream_head_t* stream);
 int picoquic_prepare_max_streams_frame_if_needed(picoquic_cnx_t* cnx,

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -660,6 +660,10 @@ int picoquic_is_sending_authorized_by_pacing(picoquic_path_t * path_x, uint64_t 
 {
     int ret = 1;
 
+    if (current_time >= 4559392 && path_x->pacing_packet_time_microsec < 30) {
+        ret = 1;
+    }
+
     picoquic_update_pacing_bucket(path_x, current_time);
 
     if (path_x->pacing_bucket_nanosec <= 0) {

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -157,6 +157,7 @@ typedef struct st_picoquic_test_tls_api_ctx_t {
     size_t stream0_sent;
     size_t stream0_received;
     int stream0_test_option;
+    int stream0_flow_release;
 
     int sum_data_received_at_server;
     int sum_data_received_at_client;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -6094,7 +6094,7 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, uint64_t 
 
         if (ret == 0) {
             ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
-                test_scenario_q_and_r, sizeof(test_scenario_q_and_r), 100000000, (has_loss) ? 0x10000000:0, 0, 5 * latency, max_completion_time);
+                test_scenario_q_and_r, sizeof(test_scenario_q_and_r), 100000000, (has_loss) ? 0x10000000:0, 0, 2 * latency, max_completion_time);
         }
     }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -452,6 +452,9 @@ static int test_api_callback(picoquic_cnx_t* cnx,
                 }
             }
         }
+        if (ctx->stream0_received == 0 && length > 0 && ctx->stream0_flow_release) {
+            (void)picoquic_open_flow_control(cnx, stream_id, ctx->stream0_target);
+        }
         ctx->stream0_received += length;
         if (ctx->streams_finished && ctx->stream0_received >= ctx->stream0_target) {
             ctx->test_finished = 1;
@@ -6088,6 +6091,7 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, uint64_t 
         test_ctx->s_to_c_link->microsec_latency = latency;
         test_ctx->s_to_c_link->picosec_per_byte = picoseq_per_byte_3; 
         test_ctx->s_to_c_link->jitter = jitter;
+        test_ctx->stream0_flow_release = 1;
 
         picoquic_set_cc_log(test_ctx->qclient, ".");
         ret = picoquic_open_cc_dump(test_ctx->cnx_client);


### PR DESCRIPTION
Add API to open flow control, diminish reliance on automatic increases.
Set satellite link buffers to 2*BDP size specified for test.
Limit aggressiveness of slow start algorithm.