### PR TITLE
Integrate WSAStartUp into picosocks

### DIFF
--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -284,6 +284,8 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
 SOCKET_TYPE picoquic_open_client_socket(int af)
 {
 #ifdef _WINDOWS
+    WSADATA wsaData = { 0 };
+    WSA_START(MAKEWORD(2, 2), &wsaData);
     SOCKET_TYPE sd = WSASocket(af, SOCK_DGRAM, IPPROTO_UDP, NULL, 0, WSA_FLAG_OVERLAPPED);
 #else
     SOCKET_TYPE sd = socket(af, SOCK_DGRAM, IPPROTO_UDP);
@@ -308,6 +310,14 @@ SOCKET_TYPE picoquic_open_client_socket(int af)
 int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port)
 {
     int ret = 0;
+
+#ifdef _WINDOWS
+    WSADATA wsaData = { 0 };
+    if (WSA_START(MAKEWORD(2, 2), &wsaData)) {
+        ret = -1;
+    }
+#endif
+
     const int sock_af[] = { AF_INET6, AF_INET };
 
     for (int i = 0; i < PICOQUIC_NB_SERVER_SOCKETS; i++) {

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -37,12 +37,6 @@
 #ifndef SOCKET_CLOSE
 #define SOCKET_CLOSE(x) closesocket(x)
 #endif
-#ifndef WSA_START_DATA
-#define WSA_START_DATA WSADATA
-#endif
-#ifndef WSA_START
-#define WSA_START(x, y) WSAStartup((x), (y))
-#endif
 #ifndef WSA_LAST_ERROR
 #define WSA_LAST_ERROR(x) WSAGetLastError()
 #endif
@@ -1186,10 +1180,6 @@ int main(int argc, char** argv)
     char default_server_key_file[512];
     char * client_scenario = NULL;
     FILE* F_log = NULL;
-
-#ifdef _WINDOWS
-    WSADATA wsaData;
-#endif
     int ret = 0;
 
     /* HTTP09 test */
@@ -1351,16 +1341,6 @@ int main(int argc, char** argv)
     if (optind < argc) {
         usage();
     }
-
-#ifdef _WINDOWS
-    // Init WSA.
-    if (ret == 0) {
-        if (WSA_START(MAKEWORD(2, 2), &wsaData)) {
-            fprintf(stderr, "Cannot init WSA\n");
-            ret = -1;
-        }
-    }
-#endif
 
     if (log_file != NULL) {
         if (strcmp(log_file, "-") == 0) {

--- a/picoquictest/socket_test.c
+++ b/picoquictest/socket_test.c
@@ -137,24 +137,50 @@ static int socket_test_one(char const* addr_text, int server_port, int should_be
     return ret;
 }
 
+int socket_test_port(picoquic_server_sockets_t* server_sockets, int test_port)
+{
+    int ret = 0;
+
+    /* For a series of server addresses, do a ping pong test */
+    if (socket_test_one("127.0.0.1", test_port, 0, server_sockets) != 0) {
+        ret = -1;
+    }
+    else if (socket_test_one("::1", test_port, 0, server_sockets) != 0) {
+        ret = -1;
+    }
+    else if (socket_test_one("localhost", test_port, 1, server_sockets) != 0) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
 int socket_test()
 {
     int ret = 0;
     int test_port = 12345;
-    picoquic_server_sockets_t server_sockets;
+    int test_port2 = 1234;
 
     /* Open server sockets */
+    picoquic_server_sockets_t server_sockets;
     ret = picoquic_open_server_sockets(&server_sockets, test_port);
 
     if (ret == 0) {
-        /* For a series of server addresses, do a ping pong test */
-        if (socket_test_one("127.0.0.1", test_port, 0, &server_sockets) != 0) {
-            ret = -1;
-        } else if (socket_test_one("::1", test_port, 0, &server_sockets) != 0) {
-            ret = -1;
-        } else if (socket_test_one("localhost", test_port, 1, &server_sockets) != 0) {
-            ret = -1;
+
+        /* Test with one server socket */
+        ret = socket_test_port(&server_sockets, test_port);
+
+        if (ret == 0) {
+            /* Test with two server sockets */
+            picoquic_server_sockets_t server_sockets2;
+            ret = picoquic_open_server_sockets(&server_sockets2, test_port2);
+
+            if (ret == 0) {
+                ret = socket_test_port(&server_sockets2, test_port2);
+                picoquic_close_server_sockets(&server_sockets2);
+            }
         }
+
         /* Close the sockets */
         picoquic_close_server_sockets(&server_sockets);
     }

--- a/picoquictest/socket_test.c
+++ b/picoquictest/socket_test.c
@@ -142,14 +142,7 @@ int socket_test()
     int ret = 0;
     int test_port = 12345;
     picoquic_server_sockets_t server_sockets;
-#ifdef _WINDOWS
-    WSADATA wsaData;
 
-    if (WSA_START(MAKEWORD(2, 2), &wsaData)) {
-        DBG_PRINTF("Cannot init WSA\n");
-        ret = -1;
-    }
-#endif
     /* Open server sockets */
     ret = picoquic_open_server_sockets(&server_sockets, test_port);
 
@@ -208,14 +201,7 @@ int socket_ecn_test_one(int af_domain)
 int socket_ecn_test()
 {
     int ret;
-#ifdef _WINDOWS
-    WSADATA wsaData;
 
-    if (WSA_START(MAKEWORD(2, 2), &wsaData)) {
-        DBG_PRINTF("Cannot init WSA\n");
-        return -1;
-    }
-#endif
     ret = socket_ecn_test_one(AF_INET);
 
     if (ret == 0) {

--- a/quicwind/quicwind.cpp
+++ b/quicwind/quicwind.cpp
@@ -36,7 +36,6 @@ WCHAR szWindowClass[MAX_LOADSTRING];            // the main window class name
 picoquic_quic_t * qclient = NULL;               // the quic client context.
 HANDLE qclient_thread = NULL;
 DWORD dw_qclient_thread_id = 0;
-WSADATA wsaData;
 HWND hWndEdit = NULL;
 #define IDC_EDITBOX 100
 
@@ -56,9 +55,6 @@ int APIENTRY wWinMain(_In_ HINSTANCE hInstance,
 {
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
-
-    // Init windows sockets
-    (void)WSAStartup(MAKEWORD(2, 2), &wsaData);
 
     // Initialize global strings
     LoadStringW(hInstance, IDS_APP_TITLE, szTitle, MAX_LOADSTRING);

--- a/quicwind/quicwind_proc.c
+++ b/quicwind/quicwind_proc.c
@@ -21,18 +21,6 @@
 #ifndef SOCKET_TYPE
 #define SOCKET_TYPE SOCKET
 #endif
-#ifndef SOCKET_CLOSE
-#define SOCKET_CLOSE(x) closesocket(x)
-#endif
-#ifndef WSA_START_DATA
-#define WSA_START_DATA WSADATA
-#endif
-#ifndef WSA_START
-#define WSA_START(x, y) WSAStartup((x), (y))
-#endif
-#ifndef WSA_LAST_ERROR
-#define WSA_LAST_ERROR(x) WSAGetLastError()
-#endif
 #ifndef socklen_t
 #define socklen_t int
 #endif


### PR DESCRIPTION
Add WSAStartUp to picosocks.c and remove indicidual initialization from picoquicdemo and tests.

That helps users of picoquic to avoid debugging Windows-related network issues.