### PR TITLE
Cubic 1wd

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -971,6 +971,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(satellite_loss)
+        {
+            int ret = satellite_loss_test();
+
+            Assert::AreEqual(ret, 0);
+        }
         TEST_METHOD(cid_length)
         {
             int ret = cid_length_test();

--- a/picoquic/cc_common.c
+++ b/picoquic/cc_common.c
@@ -63,7 +63,7 @@ void picoquic_filter_rtt_min_max(picoquic_min_max_rtt_t * rtt_track, uint64_t rt
     }
 }
 
-int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time)
+int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time, int is_one_way_delay_enabled)
 {
     int ret = 0;
 
@@ -83,7 +83,8 @@ int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measur
                 delta_rtt = rtt_track->sample_min - rtt_track->rtt_filtered_min;
                 rtt_track->past_threshold = 1;
                 if (delta_rtt * 4 > rtt_track->rtt_filtered_min ||
-                    (rtt_track->rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT && delta_rtt > 256 * packet_time)) {
+                    (rtt_track->rtt_filtered_min > ((is_one_way_delay_enabled)?(PICOQUIC_TARGET_RENO_RTT/2): PICOQUIC_TARGET_RENO_RTT)
+                        && delta_rtt > 256 * packet_time)) {
                     rtt_track->nb_rtt_excess++;
                     if (rtt_track->nb_rtt_excess >= PICOQUIC_MIN_MAX_RTT_SCOPE) {
                         /* RTT increased too much, get out of slow start! */

--- a/picoquic/cc_common.h
+++ b/picoquic/cc_common.h
@@ -42,7 +42,7 @@ uint64_t picoquic_cc_get_ack_number(picoquic_cnx_t* cnx);
 
 void picoquic_filter_rtt_min_max(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt);
 
-int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time);
+int picoquic_hystart_test(picoquic_min_max_rtt_t* rtt_track, uint64_t rtt_measurement, uint64_t packet_time, uint64_t current_time, int is_one_way_delay_enabled);
 
 int picoquic_cc_was_cwin_blocked(picoquic_cnx_t* cnx, uint64_t last_sequence_blocked);
 

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -381,6 +381,198 @@ static void picoquic_cubic_notify(
     }
 }
 
+
+/*
+ * Define delay-based Cubic, dcubic, and alternative congestion control protocol similar to Cubic but 
+ * using delay measurements instead of reacting to packet losses. This is a quic hack, intended for
+ * trials of a lossy satellite networks.
+ */
+static void picoquic_dcubic_notify(
+    picoquic_cnx_t* cnx, picoquic_path_t* path_x,
+    picoquic_congestion_notification_t notification,
+    uint64_t rtt_measurement,
+    uint64_t one_way_delay,
+    uint64_t nb_bytes_acknowledged,
+    uint64_t lost_packet_number,
+    uint64_t current_time)
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(rtt_measurement);
+    UNREFERENCED_PARAMETER(lost_packet_number);
+#endif
+    picoquic_cubic_state_t* cubic_state = (picoquic_cubic_state_t*)path_x->congestion_alg_state;
+
+    if (cubic_state != NULL) {
+        switch (cubic_state->alg_state) {
+        case picoquic_cubic_alg_slow_start:
+            switch (notification) {
+            case picoquic_congestion_notification_acknowledgement:
+                /* Same as Cubic */
+                if (picoquic_cc_was_cwin_blocked(cnx, cubic_state->last_sequence_blocked)) {
+                    if (path_x->smoothed_rtt <= PICOQUIC_TARGET_RENO_RTT || cubic_state->rtt_filter.past_threshold) {
+                        path_x->cwin += nb_bytes_acknowledged;
+                    }
+                    else {
+                        double delta = ((double)path_x->smoothed_rtt) / ((double)PICOQUIC_TARGET_RENO_RTT);
+                        delta *= (double)nb_bytes_acknowledged;
+                        path_x->cwin += (uint64_t)delta;
+                    }
+                    /* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
+                    if (path_x->cwin >= cubic_state->ssthresh) {
+                        cubic_state->W_reno = ((double)path_x->cwin) / 2.0;
+                        picoquic_cubic_enter_avoidance(cubic_state, current_time);
+                    }
+                }
+                break;
+            case picoquic_congestion_notification_ecn_ec:
+            case picoquic_congestion_notification_repeat:
+            case picoquic_congestion_notification_timeout:
+                /* In contrast to Cubic, do nothing here */
+                break;
+            case picoquic_congestion_notification_spurious_repeat:
+                /* Unlike Cubic, losses have no effect so do nothing here */
+                break;
+            case picoquic_congestion_notification_rtt_measurement:
+                /* Using RTT increases as congestion signal. This is used
+                 * for getting out of slow start, but also for ending a cycle
+                 * during congestion avoidance */
+                if (picoquic_hystart_test(&cubic_state->rtt_filter, (cnx->is_one_way_delay_enabled) ? one_way_delay : rtt_measurement,
+                    cnx->path[0]->pacing_packet_time_microsec, current_time, cnx->is_one_way_delay_enabled)) {
+                    if (cubic_state->ssthresh == (uint64_t)((int64_t)-1)) {
+                        if (cubic_state->rtt_filter.rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT) {
+                            double correction = (double)PICOQUIC_TARGET_RENO_RTT / (double)cubic_state->rtt_filter.rtt_filtered_min;
+                            uint64_t base_window = (uint64_t)(correction * (double)path_x->cwin);
+                            uint64_t delta_window = path_x->cwin - base_window;
+                            path_x->cwin -= (delta_window / 2);
+                        }
+
+                        cubic_state->ssthresh = path_x->cwin;
+                        cubic_state->W_max = (double)path_x->cwin / (double)path_x->send_mtu;
+                        cubic_state->W_last_max = cubic_state->W_max;
+                        cubic_state->W_reno = ((double)path_x->cwin);
+                        picoquic_cubic_enter_avoidance(cubic_state, current_time);
+                        /* apply a correction to enter the test phase immediately */
+                        uint64_t K_micro = (uint64_t)(cubic_state->K * 1000000.0);
+                        if (K_micro > current_time) {
+                            cubic_state->K = ((double)current_time) / 1000000.0;
+                            cubic_state->start_of_epoch = 0;
+                        }
+                        else {
+                            cubic_state->start_of_epoch = current_time - K_micro;
+                        }
+                    } else {
+                        if (current_time - cubic_state->start_of_epoch > path_x->smoothed_rtt ||
+                            cubic_state->recovery_sequence <= picoquic_cc_get_ack_number(cnx)) {
+                            /* re-enter recovery if this is a new event */
+                            picoquic_cubic_enter_recovery(cnx, path_x, notification, cubic_state, current_time);
+                        }
+                        break;
+                    }
+                }
+                break;
+            case picoquic_congestion_notification_cwin_blocked:
+                cubic_state->last_sequence_blocked = picoquic_cc_get_sequence_number(cnx);
+                break;
+            default:
+                /* ignore */
+                break;
+            }
+            break;
+        case picoquic_cubic_alg_recovery:
+            /* If the notification is coming less than 1RTT after start,
+             * ignore it, unless it is a spurious retransmit detection */
+            switch (notification) {
+            case picoquic_congestion_notification_acknowledgement:
+                /* exit recovery, move to CA or SS, depending on CWIN */
+                cubic_state->alg_state = picoquic_cubic_alg_slow_start;
+                path_x->cwin += nb_bytes_acknowledged;
+                /* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
+                if (path_x->cwin >= cubic_state->ssthresh) {
+                    cubic_state->alg_state = picoquic_cubic_alg_congestion_avoidance;
+                }
+                break;
+            case picoquic_congestion_notification_spurious_repeat:
+                /* DO nothing */
+                break;
+            case picoquic_congestion_notification_ecn_ec:
+            case picoquic_congestion_notification_repeat:
+            case picoquic_congestion_notification_timeout:
+                /* do nothing */
+            case picoquic_congestion_notification_rtt_measurement:
+                if (picoquic_hystart_test(&cubic_state->rtt_filter, (cnx->is_one_way_delay_enabled) ? one_way_delay : rtt_measurement,
+                    cnx->path[0]->pacing_packet_time_microsec, current_time, cnx->is_one_way_delay_enabled)) {
+                    if (current_time - cubic_state->start_of_epoch > path_x->smoothed_rtt ||
+                        cubic_state->recovery_sequence <= picoquic_cc_get_ack_number(cnx)) {
+                        /* re-enter recovery if this is a new event */
+                        picoquic_cubic_enter_recovery(cnx, path_x, notification, cubic_state, current_time);
+                    }
+                }
+                break;
+            case picoquic_congestion_notification_cwin_blocked:
+                cubic_state->last_sequence_blocked = picoquic_cc_get_sequence_number(cnx);
+                break;
+            default:
+                /* ignore */
+                break;
+            }
+            break;
+
+        case picoquic_cubic_alg_congestion_avoidance:
+            switch (notification) {
+            case picoquic_congestion_notification_acknowledgement:
+                if (picoquic_cc_was_cwin_blocked(cnx, cubic_state->last_sequence_blocked)) {
+                    /* Compute the cubic formula */
+                    double W_cubic = picoquic_cubic_W_cubic(cubic_state, current_time);
+                    uint64_t win_cubic = (uint64_t)(W_cubic * (double)path_x->send_mtu);
+                    /* Also compute the Reno formula */
+                    cubic_state->W_reno += ((double)nb_bytes_acknowledged) * ((double)path_x->send_mtu) / cubic_state->W_reno;
+
+                    /* Pick the largest */
+                    if (win_cubic > cubic_state->W_reno) {
+                        /* if cubic is larger than threshold, switch to cubic mode */
+                        path_x->cwin = win_cubic;
+                    }
+                    else {
+                        path_x->cwin = (uint64_t)cubic_state->W_reno;
+                    }
+                }
+                break;
+            case picoquic_congestion_notification_ecn_ec:
+            case picoquic_congestion_notification_repeat:
+            case picoquic_congestion_notification_timeout:
+                /* Do nothing */
+                break;
+            case picoquic_congestion_notification_spurious_repeat:
+                /* Do nothing */
+                break;
+            case picoquic_congestion_notification_cwin_blocked:
+                cubic_state->last_sequence_blocked = picoquic_cc_get_sequence_number(cnx);
+                break;
+            case picoquic_congestion_notification_rtt_measurement:
+                if (picoquic_hystart_test(&cubic_state->rtt_filter, (cnx->is_one_way_delay_enabled) ? one_way_delay : rtt_measurement,
+                    cnx->path[0]->pacing_packet_time_microsec, current_time, cnx->is_one_way_delay_enabled)) {
+                    if (current_time - cubic_state->start_of_epoch > path_x->smoothed_rtt ||
+                        cubic_state->recovery_sequence <= picoquic_cc_get_ack_number(cnx)) {
+                        /* re-enter recovery */
+                        picoquic_cubic_enter_recovery(cnx, path_x, notification, cubic_state, current_time);
+                    }
+                }
+                break;
+            default:
+                /* ignore */
+                break;
+            }
+            break;
+        default:
+            break;
+        }
+
+        /* Compute pacing data */
+        picoquic_update_pacing_data(path_x);
+    }
+}
+
+
 /* Release the state of the congestion control algorithm */
 static void picoquic_cubic_delete(picoquic_path_t* path_x)
 {
@@ -393,6 +585,7 @@ static void picoquic_cubic_delete(picoquic_path_t* path_x)
 /* Definition record for the Cubic algorithm */
 
 #define picoquic_cubic_ID 0x43424942 /* CBIC */
+#define picoquic_dcubic_ID 0x44424942 /* DBIC */
 
 picoquic_congestion_algorithm_t picoquic_cubic_algorithm_struct = {
     picoquic_cubic_ID,
@@ -401,4 +594,12 @@ picoquic_congestion_algorithm_t picoquic_cubic_algorithm_struct = {
     picoquic_cubic_delete
 };
 
+picoquic_congestion_algorithm_t picoquic_dcubic_algorithm_struct = {
+    picoquic_dcubic_ID,
+    picoquic_cubic_init,
+    picoquic_dcubic_notify,
+    picoquic_cubic_delete
+};
+
 picoquic_congestion_algorithm_t* picoquic_cubic_algorithm = &picoquic_cubic_algorithm_struct;
+picoquic_congestion_algorithm_t* picoquic_dcubic_algorithm = &picoquic_dcubic_algorithm_struct;

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -207,6 +207,7 @@ static void picoquic_cubic_notify(
     picoquic_cnx_t* cnx, picoquic_path_t* path_x,
     picoquic_congestion_notification_t notification,
     uint64_t rtt_measurement,
+    uint64_t one_way_delay,
     uint64_t nb_bytes_acknowledged,
     uint64_t lost_packet_number,
     uint64_t current_time)
@@ -253,7 +254,9 @@ static void picoquic_cubic_notify(
                 break;
             case picoquic_congestion_notification_rtt_measurement:
                 /* Using RTT increases as signal to get out of initial slow start */
-                if (cubic_state->ssthresh == (uint64_t)((int64_t)-1) && picoquic_hystart_test(&cubic_state->rtt_filter, rtt_measurement, cnx->path[0]->pacing_packet_time_microsec, current_time)) {
+                if (cubic_state->ssthresh == (uint64_t)((int64_t)-1) && 
+                    picoquic_hystart_test(&cubic_state->rtt_filter, (cnx->is_one_way_delay_enabled) ? one_way_delay : rtt_measurement,
+                        cnx->path[0]->pacing_packet_time_microsec, current_time, cnx->is_one_way_delay_enabled)) {
                     /* RTT increased too much, get out of slow start! */
                     if (cubic_state->rtt_filter.rtt_filtered_min > PICOQUIC_TARGET_RENO_RTT) {
                         double correction = (double)PICOQUIC_TARGET_RENO_RTT / (double)cubic_state->rtt_filter.rtt_filtered_min;

--- a/picoquic/fastcc.c
+++ b/picoquic/fastcc.c
@@ -118,6 +118,7 @@ void picoquic_fastcc_notify(
     picoquic_cnx_t* cnx, picoquic_path_t* path_x,
     picoquic_congestion_notification_t notification,
     uint64_t rtt_measurement,
+    uint64_t one_way_delay,
     uint64_t nb_bytes_acknowledged,
     uint64_t lost_packet_number,
     uint64_t current_time)

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2732,7 +2732,7 @@ int picoquic_prepare_ack_frame(picoquic_cnx_t* cnx, uint64_t current_time,
             /* Set the lowest acknowledged */
             lowest_acknowledged = pkt_ctx->first_sack_item.start_of_sack_range;
             /* Encode the ack blocks that fit in the allocated space */
-            while (num_block < 63 && next_sack != NULL) {
+            while (num_block < 32 && next_sack != NULL) {
                 size_t l_gap = 0;
                 size_t l_range = 0;
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -962,7 +962,7 @@ static int picoquic_queue_network_input(picoquic_cnx_t* cnx, picoquic_stream_hea
 
             if (next != NULL && next->offset < offset + length) {
                 /* the tail of the frame overlaps with the next frame received */
-                data_length = next->offset - offset - start;
+                data_length = (size_t)(next->offset - offset - start);
             }
 
             if (data_length > 0) {
@@ -993,7 +993,7 @@ static int picoquic_queue_network_input(picoquic_cnx_t* cnx, picoquic_stream_hea
             /* Check whether there may be some missing data after the next frame. */
             if (ret == 0 && start < length && next != NULL) {
                 if (offset + length > next->offset + next->length) {
-                    start = next->offset + next->length - offset;
+                    start = (size_t)(next->offset + next->length - offset);
                     /* Continue the loop with the next block */
                     next = (picoquic_stream_data_node_t*)picosplay_next(&previous->stream_data_node);
                 }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1946,7 +1946,7 @@ void picoquic_check_spurious_retransmission(picoquic_cnx_t* cnx,
 
                 if (cnx->congestion_alg != NULL ) {
                     cnx->congestion_alg->alg_notify(cnx, old_path, picoquic_congestion_notification_spurious_repeat,
-                        0, 0, p->sequence_number, current_time);
+                        0, 0, 0, p->sequence_number, current_time);
                 }
 
                 if (old_path->nb_losses_found > 0) {
@@ -2044,7 +2044,7 @@ void picoquic_update_path_rtt(picoquic_cnx_t* cnx, picoquic_path_t * old_path, u
         if (cnx->congestion_alg != NULL) {
             cnx->congestion_alg->alg_notify(cnx, old_path,
                 picoquic_congestion_notification_rtt_measurement,
-                rtt_estimate, 0, 0, current_time);
+                rtt_estimate, one_way_delay, 0, 0, current_time);
         }
     }
 }
@@ -2483,7 +2483,7 @@ static int picoquic_process_ack_range(
                     if (cnx->congestion_alg != NULL) {
                         cnx->congestion_alg->alg_notify(cnx, old_path,
                             picoquic_congestion_notification_acknowledgement,
-                            0, p->length, 0, current_time);
+                            0, 0, p->length, 0, current_time);
                     }
 
 
@@ -2622,7 +2622,7 @@ uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
 
             cnx->congestion_alg->alg_notify(cnx, cnx->path[0],
                 picoquic_congestion_notification_ecn_ec,
-                0, 0, cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range, current_time);
+                0, 0, 0, cnx->pkt_ctx[pc].first_sack_item.end_of_sack_range, current_time);
         }
     }
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -995,7 +995,7 @@ static int picoquic_queue_network_input(picoquic_cnx_t* cnx, picoquic_stream_hea
                 if (offset + length > next->offset + next->length) {
                     start = (size_t)(next->offset + next->length - offset);
                     /* Continue the loop with the next block */
-                    next = (picoquic_stream_data_node_t*)picosplay_next(&previous->stream_data_node);
+                    next = (picoquic_stream_data_node_t*)picosplay_next(&next->stream_data_node);
                 }
                 else {
                     start = length;

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -97,6 +97,7 @@ static void picoquic_newreno_notify(
     picoquic_path_t* path_x,
     picoquic_congestion_notification_t notification,
     uint64_t rtt_measurement,
+    uint64_t one_way_delay,
     uint64_t nb_bytes_acknowledged,
     uint64_t lost_packet_number,
     uint64_t current_time)
@@ -160,7 +161,9 @@ static void picoquic_newreno_notify(
             /* Using RTT increases as signal to get out of initial slow start */
             if (nr_state->alg_state == picoquic_newreno_alg_slow_start &&
                 nr_state->ssthresh == (uint64_t)((int64_t)-1) &&
-                picoquic_hystart_test(&nr_state->rtt_filter, rtt_measurement, cnx->path[0]->pacing_packet_time_microsec, current_time)) {
+                picoquic_hystart_test(&nr_state->rtt_filter, (cnx->is_one_way_delay_enabled)?one_way_delay:rtt_measurement, 
+                    cnx->path[0]->pacing_packet_time_microsec, current_time, 
+                    cnx->is_one_way_delay_enabled)) {
                 /* RTT increased too much, get out of slow start! */
                 nr_state->ssthresh = path_x->cwin;
                 nr_state->alg_state = picoquic_newreno_alg_congestion_avoidance;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -723,6 +723,7 @@ typedef void (*picoquic_congestion_algorithm_notify)(
     picoquic_path_t* path_x,
     picoquic_congestion_notification_t notification,
     uint64_t rtt_measurement,
+    uint64_t one_way_delay,
     uint64_t nb_bytes_acknowledged,
     uint64_t lost_packet_number,
     uint64_t current_time);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -738,6 +738,7 @@ typedef struct st_picoquic_congestion_algorithm_t {
 
 extern picoquic_congestion_algorithm_t* picoquic_newreno_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_cubic_algorithm;
+extern picoquic_congestion_algorithm_t* picoquic_dcubic_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_fastcc_algorithm;
 
 #define PICOQUIC_DEFAULT_CONGESTION_ALGORITHM picoquic_newreno_algorithm;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -368,11 +368,11 @@ typedef struct st_picoquic_sack_item_t {
 } picoquic_sack_item_t;
 
 /*
-    * Stream head.
-    * Stream contains bytes of data, which are not always delivered in order.
-    * When in order data is available, the application can read it,
-    * or a callback can be set.
-    */
+ * Stream head.
+ * Stream contains bytes of data, which are not always delivered in order.
+ * When in order data is available, the application can read it,
+ * or a callback can be set.
+ */
 
 typedef struct st_picoquic_stream_data_t {
     struct st_picoquic_stream_data_t* next_stream_data;
@@ -380,6 +380,15 @@ typedef struct st_picoquic_stream_data_t {
     size_t length;    /* Number of octets in "bytes" */
     uint8_t* bytes;
 } picoquic_stream_data_t;
+
+typedef struct st_picoquic_stream_data_node_t {
+    picosplay_node_t stream_data_node;
+    struct st_picoquic_stream_data_t* next_stream_data;
+    uint64_t offset;  /* Stream offset of the first octet in "bytes" */
+    size_t length;    /* Number of octets in "bytes" */
+    uint8_t* bytes;
+} picoquic_stream_data_node_t;
+
 
 typedef struct st_picoquic_stream_head_t {
     picosplay_node_t stream_node;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -374,16 +374,9 @@ typedef struct st_picoquic_sack_item_t {
  * or a callback can be set.
  */
 
-typedef struct st_picoquic_stream_data_t {
-    struct st_picoquic_stream_data_t* next_stream_data;
-    uint64_t offset;  /* Stream offset of the first octet in "bytes" */
-    size_t length;    /* Number of octets in "bytes" */
-    uint8_t* bytes;
-} picoquic_stream_data_t;
-
 typedef struct st_picoquic_stream_data_node_t {
     picosplay_node_t stream_data_node;
-    struct st_picoquic_stream_data_t* next_stream_data;
+    struct st_picoquic_stream_data_node_t* next_stream_data;
     uint64_t offset;  /* Stream offset of the first octet in "bytes" */
     size_t length;    /* Number of octets in "bytes" */
     uint8_t* bytes;
@@ -402,9 +395,9 @@ typedef struct st_picoquic_stream_head_t {
     uint32_t remote_error;
     uint32_t local_stop_error;
     uint32_t remote_stop_error;
-    picoquic_stream_data_t* stream_data;
+    picosplay_tree_t stream_data_tree;
     uint64_t sent_offset;
-    picoquic_stream_data_t* send_queue;
+    picoquic_stream_data_node_t* send_queue;
     void * app_stream_ctx;
     picoquic_sack_item_t first_sack_item;
     /* Flags describing the state of the stream */

--- a/picoquic/picosplay.c
+++ b/picoquic/picosplay.c
@@ -138,7 +138,8 @@ picosplay_node_t* picosplay_insert(picosplay_tree_t *tree, void *value) {
 }
 
 /* Find a node with the given value, splaying the tree. */
-picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value) {
+picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value)
+{
     picosplay_node_t *curr = tree->root;
     int found = 0;
     while(curr != NULL && !found) {
@@ -158,6 +159,30 @@ picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value) {
     if(curr != NULL)
         splay(tree, curr);
     return curr;
+}
+
+/* Find a node with the given value, splaying the tree. */
+picosplay_node_t* picosplay_find_previous(picosplay_tree_t* tree, void* value)
+{
+    picosplay_node_t* curr = tree->root;
+    picosplay_node_t* previous = NULL;
+    int found = 0;
+    while (curr != NULL && !found) {
+        int64_t relation = tree->comp(value, tree->node_value(curr));
+        if (relation == 0) {
+            found = 1;
+            previous = curr;
+        }
+        else if (relation < 0) {
+            curr = curr->left;
+        }
+        else {
+            previous = curr;
+            curr = curr->right;
+        }
+    }
+
+    return previous;
 }
 
 /* Remove a node with the given value, splaying the tree. */

--- a/picoquic/picosplay.h
+++ b/picoquic/picosplay.h
@@ -50,6 +50,7 @@ void picosplay_init_tree(picosplay_tree_t* tree, picosplay_comparator comp, pico
 picosplay_tree_t* picosplay_new_tree(picosplay_comparator comp, picosplay_create create, picosplay_delete_node delete_node, picosplay_node_value node_value);
 picosplay_node_t* picosplay_insert(picosplay_tree_t *tree, void *value);
 picosplay_node_t* picosplay_find(picosplay_tree_t *tree, void *value);
+picosplay_node_t* picosplay_find_previous(picosplay_tree_t* tree, void* value);
 picosplay_node_t* picosplay_first(picosplay_tree_t *tree);
 picosplay_node_t* picosplay_next(picosplay_node_t *node);
 picosplay_node_t* picosplay_last(picosplay_tree_t *tree);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1518,6 +1518,24 @@ int picoquic_create_probe(picoquic_cnx_t* cnx, const struct sockaddr* addr_to, c
     return ret;
 }
 
+/* stream data splay management */
+static int64_t picoquic_stream_data_node_compare(void* l, void* r)
+{
+    /* Offset values are from 0 to 2^62-1, which means we are not worried with rollover */
+    return ((picoquic_stream_data_node_t*)l)->offset - ((picoquic_stream_data_node_t*)r)->offset;
+}
+
+static picosplay_node_t* picoquic_stream_data_node_create(void* value)
+{
+    return &((picoquic_stream_data_node_t*)value)->stream_data_node;
+}
+
+
+static void* picoquic_stream_data_node_value(picosplay_node_t* node)
+{
+    return (void*)((char*)node - offsetof(struct st_picoquic_stream_data_node_t, stream_data_node));
+}
+
 /* Stream splay management */
 
 static int64_t picoquic_stream_node_compare(void *l, void *r)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1519,21 +1519,34 @@ int picoquic_create_probe(picoquic_cnx_t* cnx, const struct sockaddr* addr_to, c
 }
 
 /* stream data splay management */
-static int64_t picoquic_stream_data_node_compare(void* l, void* r)
+int64_t picoquic_stream_data_node_compare(void* l, void* r)
 {
     /* Offset values are from 0 to 2^62-1, which means we are not worried with rollover */
     return ((picoquic_stream_data_node_t*)l)->offset - ((picoquic_stream_data_node_t*)r)->offset;
 }
 
-static picosplay_node_t* picoquic_stream_data_node_create(void* value)
+picosplay_node_t* picoquic_stream_data_node_create(void* value)
 {
     return &((picoquic_stream_data_node_t*)value)->stream_data_node;
 }
 
 
-static void* picoquic_stream_data_node_value(picosplay_node_t* node)
+void* picoquic_stream_data_node_value(picosplay_node_t* node)
 {
     return (void*)((char*)node - offsetof(struct st_picoquic_stream_data_node_t, stream_data_node));
+}
+
+
+void picoquic_stream_data_node_delete(void* tree, picosplay_node_t* node)
+{
+    picoquic_stream_data_node_t* stream_data = (picoquic_stream_data_node_t*)picoquic_stream_data_node_value(node);
+
+    if (stream_data->bytes != NULL) {
+        free(stream_data->bytes);
+        stream_data->bytes = NULL;
+    }
+
+    free(stream_data);
 }
 
 /* Stream splay management */
@@ -1557,22 +1570,19 @@ static void * picoquic_stream_node_value(picosplay_node_t * node)
 
 void picoquic_clear_stream(picoquic_stream_head_t* stream)
 {
-    picoquic_stream_data_t** pdata[2];
-    pdata[0] = &stream->stream_data;
-    pdata[1] = &stream->send_queue;
+    picoquic_stream_data_node_t* ready = stream->send_queue;
+    picoquic_stream_data_node_t* next;
 
-    for (int i = 0; i < 2; i++) {
-        picoquic_stream_data_t* next;
+    while ((next = ready) != NULL) {
+        ready = next->next_stream_data;
 
-        while ((next = *pdata[i]) != NULL) {
-            *pdata[i] = next->next_stream_data;
-
-            if (next->bytes != NULL) {
-                free(next->bytes);
-            }
-            free(next);
+        if (next->bytes != NULL) {
+            free(next->bytes);
         }
+        free(next);
     }
+
+    picosplay_empty_tree(&stream->stream_data_tree);
 
     while (stream->first_sack_item.next_sack != NULL) {
         picoquic_sack_item_t * sack = stream->first_sack_item.next_sack;
@@ -1692,6 +1702,8 @@ picoquic_stream_head_t* picoquic_create_stream(picoquic_cnx_t* cnx, uint64_t str
                 stream->is_output_stream = 0;
             }
         }
+
+        picosplay_init_tree(&stream->stream_data_tree, picoquic_stream_data_node_compare, picoquic_stream_data_node_create, picoquic_stream_data_node_delete, picoquic_stream_data_node_value);
 
         picosplay_insert(&cnx->stream_tree, stream);
         if (stream->is_output_stream) {
@@ -1894,6 +1906,9 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
             cnx->tls_stream[epoch].remote_error = 0;
             cnx->tls_stream[epoch].maxdata_local = (uint64_t)((int64_t)-1);
             cnx->tls_stream[epoch].maxdata_remote = (uint64_t)((int64_t)-1);
+
+            picosplay_init_tree(&cnx->tls_stream[epoch].stream_data_tree, picoquic_stream_data_node_compare, picoquic_stream_data_node_create, picoquic_stream_data_node_delete, picoquic_stream_data_node_value);
+
             /* No need to reset the state flags, as they are not used for the crypto stream */
         }
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2675,6 +2675,9 @@ picoquic_congestion_algorithm_t const* picoquic_get_congestion_algorithm(char co
         else if (strcmp(alg_name, "cubic") == 0) {
             alg = picoquic_cubic_algorithm;
         }
+        else if (strcmp(alg_name, "dcubic") == 0) {
+            alg = picoquic_dcubic_algorithm;
+        }
         else if (strcmp(alg_name, "fast") == 0) {
             alg = picoquic_fastcc_algorithm;
         }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1287,7 +1287,7 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
                         if (cnx->congestion_alg != NULL) {
                             cnx->congestion_alg->alg_notify(cnx, old_path,
                                 (timer_based_retransmit == 0) ? picoquic_congestion_notification_repeat : picoquic_congestion_notification_timeout,
-                                0, 0, lost_packet_number, current_time);
+                                0, 0, 0, lost_packet_number, current_time);
                         }
                     }
 
@@ -1637,7 +1637,7 @@ void picoquic_implicit_handshake_ack(picoquic_cnx_t* cnx, picoquic_packet_contex
             if (cnx->congestion_alg != NULL) {
                 cnx->congestion_alg->alg_notify(cnx, old_path,
                     picoquic_congestion_notification_acknowledgement,
-                    0, p->length, 0, current_time);
+                    0, 0, p->length, 0, current_time);
             }
         }
         /* Update the number of bytes in transit and remove old packet from queue */
@@ -2735,7 +2735,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x,
                     if (cnx->congestion_alg != NULL) {
                         cnx->congestion_alg->alg_notify(cnx, path_x,
                             picoquic_congestion_notification_cwin_blocked,
-                            0, 0, 0, current_time);
+                            0, 0, 0, 0, current_time);
                     }
                 } else if (picoquic_is_sending_authorized_by_pacing(path_x, current_time, next_wake_time)) {
                     /* Check whether PMTU discovery is required. The call will return

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -144,7 +144,7 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
     }
 
     if (ret == 0 && length > 0) {
-        picoquic_stream_data_t* stream_data = (picoquic_stream_data_t*)malloc(sizeof(picoquic_stream_data_t));
+        picoquic_stream_data_node_t* stream_data = (picoquic_stream_data_node_t*)malloc(sizeof(picoquic_stream_data_node_t));
 
         if (stream_data == 0) {
             ret = -1;
@@ -156,8 +156,8 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
                 stream_data = NULL;
                 ret = -1;
             } else {
-                picoquic_stream_data_t** pprevious = &stream->send_queue;
-                picoquic_stream_data_t* next = stream->send_queue;
+                picoquic_stream_data_node_t** pprevious = &stream->send_queue;
+                picoquic_stream_data_node_t* next = stream->send_queue;
 
                 memcpy(stream_data->bytes, data, length);
                 stream_data->length = length;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -174,6 +174,7 @@ static const picoquic_test_def_t test_table[] = {
     { "fastcc_jitter", fastcc_jitter_test },
     { "long_rtt", long_rtt_test },
     { "satellite_basic", satellite_basic_test },
+    { "satellite_loss", satellite_loss_test },
     { "cid_length", cid_length_test },
     { "optimistic_ack", optimistic_ack_test },
     { "optimistic_hole", optimistic_hole_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -158,6 +158,7 @@ int split_stream_frame_test();
 int cubic_test();
 int cubic_jitter_test();
 int satellite_basic_test();
+int satellite_loss_test();
 int long_rtt_test();
 int cid_length_test();
 int initial_server_close_test();

--- a/picoquictest/splay_test.c
+++ b/picoquictest/splay_test.c
@@ -42,7 +42,7 @@ static int_node_t * new_int_node(int x) {
 }
 
 static int64_t compare_int(void *l, void *r) {
-    return ((int_node_t*)l)->v - ((int_node_t*)r)->v;
+    return (int64_t)((int_node_t*)l)->v - ((int_node_t*)r)->v;
 }
 
 static picosplay_node_t * create_int_node(void * value)
@@ -106,11 +106,13 @@ int splay_test() {
     int ret = 0;
     int count = 0;
     picosplay_tree_t *tree = picosplay_new_tree(&compare_int, create_int_node, delete_int_node, int_node_value);
-    int values[] = {3, 4, 1, 2, 8, 5, 7};
-    int values_first[] = { 3, 3, 1, 1, 1, 1, 1 };
-    int values_last[] = { 3, 4, 4, 4, 8, 8, 8 };
-    int value2_first[] = { 1, 1, 2, 5, 5, 7, 0 };
-    int value2_last[] = { 8, 8, 8, 8, 7, 7, 0 };
+    int values[] = {5, 7, 1, 3, 13, 9, 11};
+    int values_first[] = { 5, 5, 1, 1, 1, 1, 1 };
+    int values_last[] = { 5, 7, 7, 7, 13, 13, 13 };
+    int previous_test[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 };
+    int previous_value[] = { -1, 1, 1, 3, 3, 5, 5, 7, 7, 9, 9, 11, 11, 13, 13 };
+    int value2_first[] = { 1, 1, 3, 9, 9, 11, 0 };
+    int value2_last[] = { 13, 13, 13, 13, 11, 11, 0 };
 
     if (tree == NULL) {
         DBG_PRINTF("%s", "Cannot create tree.\n");
@@ -142,6 +144,68 @@ int splay_test() {
                     i, values[i],
                     values_last[i], ((int_node_t*)int_node_value(picosplay_last(tree)))->v);
                 ret = -1;
+            }
+        }
+
+        for (int i = 0; ret == 0 && i < 15; i++) {
+            int_node_t x;
+            picosplay_node_t* y;
+            
+            x.v = previous_test[i];
+            y = picosplay_find(tree, (void*)&x);
+
+            if (previous_value[i] == previous_test[i]) {
+                if (y == NULL) {
+                    DBG_PRINTF("Find v[%d] = %d, expected = %d, got NULL instead\n",
+                        i, previous_test[i], previous_value[i]);
+                    ret = -1;
+                }
+                else {
+                    int v = ((int_node_t*)int_node_value(y))->v;
+                    if (v != previous_value[i]) {
+                        DBG_PRINTF("Find v[%d] = %d, expected = %d, got %d instead\n",
+                            i, previous_test[i], previous_value[i], v);
+                        ret = -1;
+                    }
+                }
+            }
+            else {
+                if (y != NULL) {
+                    DBG_PRINTF("Find v[%d], expected NULL, got %d instead\n",
+                        i, ((int_node_t*)int_node_value(y))->v);
+                    ret = -1;
+                }
+            }
+        }
+
+        for (int i = 0; ret == 0 && i < 15; i++) {
+            int_node_t x;
+            picosplay_node_t* y;
+
+            x.v = previous_test[i];
+            y = picosplay_find_previous(tree, (void*)&x);
+
+            if (previous_value[i] >= 0) {
+                if (y == NULL) {
+                    DBG_PRINTF("Next v[%d] = %d, expected = %d, got NULL instead\n",
+                        i, previous_test[i], previous_value[i]);
+                    ret = -1;
+                }
+                else {
+                    int v = ((int_node_t*)int_node_value(y))->v;
+                    if (v != previous_value[i]) {
+                        DBG_PRINTF("next v[%d] = %d, expected = %d, got %d instead\n",
+                            i, previous_test[i], previous_value[i], v);
+                        ret = -1;
+                    }
+                }
+            }
+            else {
+                if (y != NULL) {
+                    DBG_PRINTF("Next v[%d], expected NULL, got %d instead\n",
+                        i, ((int_node_t*)int_node_value(y))->v);
+                    ret = -1;
+                }
             }
         }
 

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -275,6 +275,24 @@ static uint8_t tlsv0_45_overlap[] = {
     0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF /* Some random data */
 };
 
+static uint8_t tlsv0_550_overlap2[] = {
+    0x18,
+    0x05, /* Offset */
+    0x2d, /* length */
+    6, 7, 8, 9, 10, /* Some random data */
+    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+    31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+    41, 42, 43, 44, 45, 46, 47, 48, 49, 50
+};
+
+static uint8_t tlsv0_05[] = {
+    0x18,
+    0, /* One byte offset */
+    0x05, /* One byte length */
+    1, 2, 3, 4, 5, /* Some random data */
+};
+
 static struct packet tlslist_v1[] = {
     { tlsv0_1, sizeof(tlsv0_1), 0, 10, 0 },
     { tlsv0_2, sizeof(tlsv0_2), 10, 10, 0 },
@@ -303,10 +321,18 @@ static struct packet tlslist_v3[] = {
     { tlsv0_45_overlap, sizeof(tlsv0_45_overlap), 35, 10, 0 }
 };
 
+static struct packet tlslist_v4[] = {
+    { tlsv0_3, sizeof(tlsv0_3), 20, 10, 0 },
+    { tlsv0_4, sizeof(tlsv0_4), 30, 10, 0 },
+    { tlsv0_550_overlap2, sizeof(tlsv0_550_overlap2), 5, 45, 0 },
+    { tlsv0_05, sizeof(tlsv0_05), 0, 5, 0 }
+};
+
 static struct test_case_st tls_test_case[] = {
     { "tlstest_v1", tlslist_v1, sizeof(tlslist_v1) / sizeof(struct packet), 50 },
     { "tlstest_v2", tlslist_v2, sizeof(tlslist_v2) / sizeof(struct packet), 50 },
-    { "tlstest_v3", tlslist_v3, sizeof(tlslist_v3) / sizeof(struct packet), 50 }
+    { "tlstest_v3", tlslist_v3, sizeof(tlslist_v3) / sizeof(struct packet), 50 },
+    { "tlstest_v4", tlslist_v4, sizeof(tlslist_v4) / sizeof(struct packet), 50 }
 };
 
 static size_t const nb_tls_test_cases = sizeof(tls_test_case) / sizeof(struct test_case_st);

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -6226,6 +6226,11 @@ int satellite_basic_test()
     return satellite_test_one(picoquic_dcubic_algorithm, 8250000, 0, 0);
 }
 
+int satellite_loss_test()
+{
+    return satellite_test_one(picoquic_dcubic_algorithm, 11000000, 0, 1);
+}
+
 /* Test that different CID length are properly supported */
 int cid_length_test_one(uint8_t length)
 {

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -6223,7 +6223,7 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, uint64_t 
 
 int satellite_basic_test()
 {
-    return satellite_test_one(picoquic_cubic_algorithm, 8250000, 0, 0);
+    return satellite_test_one(picoquic_dcubic_algorithm, 8250000, 0, 0);
 }
 
 /* Test that different CID length are properly supported */


### PR DESCRIPTION
Add version of Cubic that relies on delays (one way if available) instead of losses. Verifies that it provides plausible results when testing in high random loss scenario. Fix CPU cost explosion on high random losses by using splay for managing partially received stream data.