### PR TITLE
Restore call to WSAStartup in Picoquic demo

### DIFF
--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -1183,8 +1183,8 @@ int picoquic_get_server_address(const char* ip_address_text, int server_port,
         hints.ai_socktype = SOCK_DGRAM;
         hints.ai_protocol = IPPROTO_UDP;
 
-        if (getaddrinfo(ip_address_text, NULL, &hints, &result) != 0) {
-            fprintf(stderr, "Cannot get IP address for %s\n", ip_address_text);
+        if ((ret = getaddrinfo(ip_address_text, NULL, &hints, &result)) != 0) {
+            fprintf(stderr, "Cannot get IP address for %s, err = %d (0x%x)\n", ip_address_text, ret, ret);
             ret = -1;
         } else {
             *is_name = 1;

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -1038,7 +1038,6 @@ int quic_client(const char* ip_address_text, int server_port,
         SOCKET_CLOSE(fd);
     }
 
-
     if (client_scenario_text != NULL && client_sc != NULL) {
         demo_client_delete_scenario_desc(client_sc_nb, client_sc);
         client_sc = NULL;
@@ -1182,7 +1181,10 @@ int main(int argc, char** argv)
     FILE* F_log = NULL;
     int ret = 0;
 
-    /* HTTP09 test */
+#ifdef _WINDOWS
+    WSADATA wsaData = { 0 };
+    WSA_START(MAKEWORD(2, 2), &wsaData);
+#endif
 
     /* Get the parameters */
     int opt;


### PR DESCRIPTION
Turns out that there are many more calls to Winsock than just socket creation -- name resolution, for example. The picoquicdemo.exe was broken.