### PR TITLE
Simplify server

### DIFF
--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -1556,12 +1556,17 @@ void picoquic_log_transport_extension_content(FILE* F, int log_cnxid, uint64_t c
     }
 }
 
-void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int log_cnxid)
+void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int received, int log_cnxid, uint8_t* bytes, size_t bytes_max)
 {
-    uint8_t* bytes = NULL;
-    size_t bytes_max = 0;
-    int ext_received_return = 0;
-    int client_mode = 1;
+    uint64_t cnx_id_64 = (log_cnxid) ? picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)) : 0;
+
+    picoquic_log_prefix_initial_cid64(F, cnx_id_64);
+    fprintf(F, "%s transport parameter TLS extension (%d bytes):\n", (received)?"Received":"Sending", (uint32_t)bytes_max);
+    picoquic_log_transport_extension_content(F, log_cnxid, cnx_id_64, bytes, bytes_max);
+}
+
+void picoquic_log_transport_ids(FILE* F, picoquic_cnx_t* cnx, int log_cnxid)
+{
     char const* sni = picoquic_tls_get_sni(cnx);
     char const* alpn = picoquic_tls_get_negotiated_alpn(cnx);
     uint64_t cnx_id64 = (log_cnxid) ? picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)) : 0;
@@ -1578,25 +1583,6 @@ void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int log_cnxi
         fprintf(F, "ALPN not received.\n");
     } else {
         fprintf(F, "Received ALPN: %s\n", alpn);
-    }
-
-    picoquic_provide_received_transport_extensions(cnx,
-        &bytes, &bytes_max, &ext_received_return, &client_mode);
-
-    if (bytes_max == 0) {
-        picoquic_log_prefix_initial_cid64(F, cnx_id64);
-        fprintf(F, "Did not receive transport parameter TLS extension.\n");
-    }
-    else {
-        picoquic_log_prefix_initial_cid64(F, cnx_id64);
-        fprintf(F, "Received transport parameter TLS extension (%d bytes):\n", (uint32_t)bytes_max);
-        
-        picoquic_log_transport_extension_content(F, log_cnxid,
-            picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx)), bytes, bytes_max);
-    }
-
-    if (log_cnxid == 0) {
-        fprintf(F, "\n");
     }
 }
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -659,6 +659,10 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
     struct sockaddr_storage * p_addr_to, int * to_len, struct sockaddr_storage * p_addr_from, int * from_len);
 
+int picoquic_prepare_next_packet(picoquic_quic_t* quic,
+    uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
+    struct sockaddr_storage* p_addr_to, int* to_len, struct sockaddr_storage* p_addr_from, int* from_len, int * if_index);
+
 /* Associate stream with app context */
 int picoquic_set_app_stream_ctx(picoquic_cnx_t* cnx,
     uint64_t stream_id, void* app_stream_ctx);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1025,7 +1025,8 @@ void picoquic_log_prefix_initial_cid64(FILE* F, uint64_t log_cnxid64);
 
 void picoquic_log_error_packet(FILE* F, uint8_t* bytes, size_t bytes_max, int ret);
 void picoquic_log_processing(FILE* F, picoquic_cnx_t* cnx, size_t length, int ret);
-void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int log_cnxid);
+void picoquic_log_transport_ids(FILE* F, picoquic_cnx_t* cnx, int log_cnxid);
+void picoquic_log_transport_extension(FILE* F, picoquic_cnx_t* cnx, int received, int log_cnxid, uint8_t* bytes, size_t bytes_max);
 void picoquic_log_congestion_state(FILE* F, picoquic_cnx_t* cnx, uint64_t current_time);
 void picoquic_log_picotls_ticket(FILE* F, picoquic_connection_id_t cnx_id,
     uint8_t* ticket, uint16_t ticket_length);

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -445,6 +445,10 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
     else {
         picoformat_16(bytes_param_start, (uint16_t)(bytes - bytes_param_start - 2));
         *consumed = bytes - bytes_zero;
+
+        if (cnx->quic->F_log) {
+            picoquic_log_transport_extension(cnx->quic->F_log, cnx, 0, 1, bytes_zero, *consumed);
+        }
     }
 
     return ret;
@@ -486,6 +490,10 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
 
     cnx->remote_parameters_received = 1;
     picoquic_clear_transport_extensions(cnx);
+
+    if (cnx->quic->F_log) {
+        picoquic_log_transport_extension(cnx->quic->F_log, cnx, 1, 1, bytes, bytes_max);
+    }
 
     if (byte_index + 2 > bytes_max) {
         ret = picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0);

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -188,7 +188,6 @@ int quic_server(const char* server_name, int server_port,
     int64_t delay_max = 10000000;
     int connection_done = 0;
     picohttp_server_parameters_t picoquic_file_param;
-    uint64_t server_next_time = 0;
     uint64_t loop_count_time = 0;
     int nb_loops = 0;
     int first_connection_seen = 0;
@@ -253,7 +252,6 @@ int quic_server(const char* server_name, int server_port,
     /* Wait for packets */
     while (ret == 0 && (!just_once || !connection_done)) {
         int64_t delta_t = picoquic_get_next_wake_delay(qserver, current_time, delay_max);
-        uint64_t time_before = current_time;
         unsigned char received_ecn;
 
         from_length = to_length = sizeof(struct sockaddr_storage);


### PR DESCRIPTION
Reduce the amount of code in the "quic_server" demo code, hopefully to make it more approachable.

Close #761 
Close #762 

@bkchr the simpler API may be easier to match in Rust. However, I did not remove the older API, so there should not be any need to change your code.

@steschu77 I would like to further simplify the logging of transport parameters, but I am concerned about breaking `binlog_transport_extension`