### PR TITLE
Fix alpn strcmp vs memcmp bug.

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -84,7 +84,8 @@ picoquic_alpn_enum picoquic_parse_alpn_nz(char const* alpn, size_t len)
 
     if (alpn != NULL) {
         for (size_t i = 0; i < nb_alpn_list; i++) {
-            if (memcmp(alpn, alpn_list[i].alpn_val, len) == 0) {
+            if (memcmp(alpn, alpn_list[i].alpn_val, len) == 0 &&
+                alpn_list[i].alpn_val[len] == 0) {
                 code = alpn_list[i].alpn_code;
                 break;
             }

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -78,6 +78,22 @@ picoquic_alpn_enum picoquic_parse_alpn(char const* alpn)
     return code;
 }
 
+picoquic_alpn_enum picoquic_parse_alpn_nz(char const* alpn, size_t len)
+{
+    picoquic_alpn_enum code = picoquic_alpn_undef;
+
+    if (alpn != NULL) {
+        for (size_t i = 0; i < nb_alpn_list; i++) {
+            if (memcmp(alpn, alpn_list[i].alpn_val, len) == 0) {
+                code = alpn_list[i].alpn_code;
+                break;
+            }
+        }
+    }
+
+    return code;
+}
+
 void picoquic_demo_client_set_alpn_from_tickets(picoquic_cnx_t* cnx, picoquic_demo_callback_ctx_t* ctx, uint64_t current_time)
 {
     const char* sni = cnx->sni;

--- a/picohttp/democlient.h
+++ b/picohttp/democlient.h
@@ -88,6 +88,7 @@ typedef struct st_picoquic_demo_client_callback_ctx_t {
 } picoquic_demo_callback_ctx_t;
 
 picoquic_alpn_enum picoquic_parse_alpn(char const * alpn);
+picoquic_alpn_enum picoquic_parse_alpn_nz(char const* alpn, size_t len);
 
 void picoquic_demo_client_set_alpn_from_tickets(picoquic_cnx_t* cnx, picoquic_demo_callback_ctx_t* ctx, uint64_t current_time);
 

--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -1245,7 +1245,7 @@ size_t picoquic_demo_server_callback_select_alpn(picoquic_quic_t* quic, ptls_iov
     size_t ret = count;
 
     for (size_t i = 0; i < count; i++) {
-        if (picoquic_parse_alpn((const char *)list[i].base) != picoquic_alpn_undef) {
+        if (picoquic_parse_alpn_nz((const char *)list[i].base, list[i].len) != picoquic_alpn_undef) {
             ret = i;
             break;
         }

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -1400,7 +1400,7 @@ void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* c
     uint8_t * bytes,
     uint64_t sequence_number,
     size_t length,
-    uint8_t* send_buffer, size_t send_length)
+    uint8_t* send_buffer, size_t send_length, size_t pn_length)
 {
     picoquic_cnx_t* pcnx = cnx;
     picoquic_packet_header ph;
@@ -1423,8 +1423,8 @@ void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* c
     ph.pn = (uint32_t)ph.pn64;
     if (ph.ptype != picoquic_packet_retry) {
         if (ph.pn_offset != 0) {
-            ph.offset = ph.pn_offset + 4; /* todo: should provide the actual length */
-            ph.payload_length -= 4;
+            ph.offset = ph.pn_offset + pn_length;
+            ph.payload_length -= pn_length;
         }
     }
     if (ph.ptype != picoquic_packet_version_negotiation) {

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -767,7 +767,7 @@ int picoquic_prepare_version_negotiation(
         if (quic->F_log != NULL) {
             picoquic_log_outgoing_segment(quic->F_log, 1, NULL,
                 bytes, 0, sp->length,
-                bytes, sp->length);
+                bytes, sp->length, 0);
         }
 
         picoquic_queue_stateless_packet(quic, sp);
@@ -892,7 +892,7 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
         if (cnx->quic->F_log != NULL) {
             picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
                 bytes, 0, sp->length,
-                bytes, sp->length);
+                bytes, sp->length, pn_length);
         }
 
         picoquic_queue_stateless_packet(cnx->quic, sp);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1016,7 +1016,7 @@ void picoquic_log_outgoing_segment(void* F_log, int log_cnxid, picoquic_cnx_t* c
     uint8_t * bytes,
     uint64_t sequence_number,
     size_t length,
-    uint8_t* send_buffer, size_t send_length);
+    uint8_t* send_buffer, size_t send_length, size_t pn_length);
 
 void picoquic_log_packet_address(FILE* F, uint64_t log_cnxid64, picoquic_cnx_t* cnx,
     struct sockaddr* addr_peer, int receiving, size_t length, uint64_t current_time);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -650,7 +650,7 @@ static size_t picoquic_protect_packet(picoquic_cnx_t* cnx,
     if (cnx->quic->F_log != NULL && (cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || cnx->quic->use_long_log)) {
         picoquic_log_outgoing_segment(cnx->quic->F_log, 1, cnx,
             bytes, sequence_number, length,
-            send_buffer, send_length);
+            send_buffer, send_length, pn_length);
     }
     if (cnx->quic->f_binlog != NULL && (cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE || cnx->quic->use_long_log)) {
         binlog_outgoing_packet(cnx->quic->f_binlog, cnx,

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -414,6 +414,7 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
 
         for (size_t i = 0; i < params->negotiated_protocols.count; i++) {
             if (params->negotiated_protocols.list[i].len == len && memcmp(params->negotiated_protocols.list[i].base, quic->default_alpn, len) == 0) {
+                DBG_PRINTF("ALPN[%d] matches default alpn (%s)", (int)i, quic->default_alpn);
                 alpn_found = 1;
                 ptls_set_negotiated_protocol(tls, quic->default_alpn, len);
                 break;
@@ -422,6 +423,8 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
     }
     else if (quic->alpn_select_fn != NULL) {
         size_t selected = quic->alpn_select_fn(quic, params->negotiated_protocols.list, params->negotiated_protocols.count);
+
+        DBG_PRINTF("ALPN Selection call back selects %d (out of %d)", (int)selected, (int)params->negotiated_protocols.count);
 
         if (selected < params->negotiated_protocols.count) {
             alpn_found = 1;
@@ -433,6 +436,8 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
     if (alpn_found == 0) {
         ret = PTLS_ALERT_NO_APPLICATION_PROTOCOL;
     }
+
+    DBG_PRINTF("Client Hello call back returns %d (0x%x)", ret, ret);
 
     return ret;
 }


### PR DESCRIPTION
There was a bug in the ALPN parser. The Client Hello did a callback to the app, passing the list of proposed ALPN as a list of (base, length) tuples. The code was calling strcmp(base, alpn), which only works if the byte following the proposed ALPN happens to be null. Failure symptoms included picking the last proposed value instead of the first matching one, or failing to pick a value if the ALPN was not the last extension in the list...