### PR TITLE
Use shorter retransmission timers 

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -58,6 +58,7 @@ extern "C" {
 #define PICOQUIC_INITIAL_RTT 250000ull /* 250 ms */
 #define PICOQUIC_TARGET_RENO_RTT 100000ull /* 100 ms */
 #define PICOQUIC_INITIAL_RETRANSMIT_TIMER 1000000ull /* one second */
+#define PICOQUIC_MAX_RETRANSMIT_TIMER 2000000ull /* two seconds */
 #define PICOQUIC_MIN_RETRANSMIT_TIMER 50000ull /* 50 ms */
 #define PICOQUIC_ACK_DELAY_MAX 10000ull /* 10 ms */
 #define PICOQUIC_ACK_DELAY_MAX_DEFAULT 25000ull /* 25 ms, per protocol spec */

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1061,8 +1061,10 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
     else
     {
         /* There has not been any higher packet acknowledged, thus we fall back on timer logic. */
-        uint64_t rto = (cnx->pkt_ctx[pc].nb_retransmit == 0) ?
-            cnx->path[0]->retransmit_timer : (1000000ull << (cnx->pkt_ctx[pc].nb_retransmit - 1));
+        uint64_t rto = cnx->path[0]->retransmit_timer << cnx->pkt_ctx[pc].nb_retransmit;
+        if (rto > PICOQUIC_MAX_RETRANSMIT_TIMER) {
+            rto = PICOQUIC_MAX_RETRANSMIT_TIMER;
+        }
         retransmit_time = p->send_time + rto;
         is_timer_based = 1;
     }


### PR DESCRIPTION
instead of defaulting to 1 second after repeat. New code is closer to the recovery spec.