### PR TITLE
Improve robust handshake

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2069,6 +2069,10 @@ void picoquic_update_path_rtt(picoquic_cnx_t* cnx, picoquic_path_t * old_path, u
             old_path->max_ack_delay = ack_delay;
         }
 
+        if (rtt_estimate > 2000000) {
+            DBG_PRINTF("Measured RTT = %llu", (unsigned long long)rtt_estimate);
+        }
+
         if (old_path->smoothed_rtt == PICOQUIC_INITIAL_RTT && old_path->rtt_variant == 0) {
             old_path->smoothed_rtt = rtt_estimate;
             old_path->rtt_variant = rtt_estimate / 2;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -935,6 +935,7 @@ typedef struct st_picoquic_cnx_t {
     unsigned int is_pmtud_required : 1; /* Force PMTU discovery */
     unsigned int is_ack_frequency_negotiated : 1; /* Ack Frequency extension negotiated */
     unsigned int is_ack_frequency_updated : 1; /* Should send an ack frequency frame asap. */
+    unsigned int recycle_sooner_needed : 1; /* There may be a need to recycle "sooner" packets */
 
     /* Spin bit policy */
     picoquic_spinbit_version_enum spin_policy;
@@ -1068,6 +1069,9 @@ typedef struct st_picoquic_cnx_t {
     uint64_t ack_frequency_sequence_remote;
     uint64_t ack_gap_remote;
     uint64_t ack_delay_remote;
+    /* Copies of packets received too soon */
+    picoquic_packet_t* first_sooner;
+    picoquic_packet_t* last_sooner;
 } picoquic_cnx_t;
 
 /* Load the stash of retry tokens. */
@@ -1415,6 +1419,9 @@ int picoquic_decode_closing_frames(uint8_t* bytes, size_t bytes_max, int* closin
 
 uint64_t picoquic_decode_transport_param_stream_id(uint64_t rank, int extension_mode, int stream_type);
 uint64_t picoquic_prepare_transport_param_stream_id(uint64_t stream_id);
+
+void picoquic_process_sooner_packets(picoquic_cnx_t* cnx, uint64_t current_time);
+void picoquic_delete_sooner_packets(picoquic_cnx_t* cnx);
 
 /* handling of transport extensions.
  */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -288,6 +288,7 @@ typedef struct st_picoquic_stateless_packet_t {
 
     uint64_t cnxid_log64;
     picoquic_connection_id_t initial_cid;
+    picoquic_packet_type_enum ptype;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquic_stateless_packet_t;
@@ -1070,8 +1071,8 @@ typedef struct st_picoquic_cnx_t {
     uint64_t ack_gap_remote;
     uint64_t ack_delay_remote;
     /* Copies of packets received too soon */
-    picoquic_packet_t* first_sooner;
-    picoquic_packet_t* last_sooner;
+    picoquic_stateless_packet_t* first_sooner;
+    picoquic_stateless_packet_t* last_sooner;
 } picoquic_cnx_t;
 
 /* Load the stash of retry tokens. */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2885,6 +2885,19 @@ int picoquic_start_key_rotation(picoquic_cnx_t* cnx)
     return ret;
 }
 
+void picoquic_delete_sooner_packets(picoquic_cnx_t* cnx)
+{
+    picoquic_packet_t* packet = cnx->first_sooner;
+
+    while (packet != NULL) {
+        picoquic_packet_t* next_packet = packet->next_packet;
+        picoquic_recycle_packet(cnx->quic, packet);
+        packet = next_packet;
+    }
+    cnx->first_sooner = NULL;
+    cnx->last_sooner = NULL;
+}
+
 void picoquic_delete_cnx(picoquic_cnx_t* cnx)
 {
     picoquic_cnxid_stash_t* stashed_cnxid;
@@ -2915,6 +2928,8 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
             free(cnx->retry_token);
             cnx->retry_token = NULL;
         }
+
+        picoquic_delete_sooner_packets(cnx);
 
         picoquic_remove_cnx_from_list(cnx);
         picoquic_remove_cnx_from_wake_list(cnx);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2887,15 +2887,14 @@ int picoquic_start_key_rotation(picoquic_cnx_t* cnx)
 
 void picoquic_delete_sooner_packets(picoquic_cnx_t* cnx)
 {
-    picoquic_packet_t* packet = cnx->first_sooner;
+    picoquic_stateless_packet_t* packet = cnx->first_sooner;
 
     while (packet != NULL) {
-        picoquic_packet_t* next_packet = packet->next_packet;
-        picoquic_recycle_packet(cnx->quic, packet);
+        picoquic_stateless_packet_t* next_packet = packet->next_packet;
+        picoquic_delete_stateless_packet(packet);
         packet = next_packet;
     }
     cnx->first_sooner = NULL;
-    cnx->last_sooner = NULL;
 }
 
 void picoquic_delete_cnx(picoquic_cnx_t* cnx)

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3516,7 +3516,7 @@ static int picoquic_check_idle_timer(picoquic_cnx_t* cnx, uint64_t* next_wake_ti
     int ret = 0;
     uint64_t idle_timer = 0;
 
-    if (cnx->cnx_state >= picoquic_state_ready) {
+    if (cnx->cnx_state >= picoquic_state_client_ready_start) {
         uint64_t rto = picoquic_current_retransmit_timer(cnx, picoquic_packet_context_application);
         idle_timer = cnx->idle_timeout;
         if (idle_timer < 3 * rto) {
@@ -3925,6 +3925,10 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     uint64_t next_wake_time = cnx->latest_progress_time + 2*PICOQUIC_MICROSEC_SILENCE_MAX;
 
     SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+
+    if (cnx->recycle_sooner_needed) {
+        picoquic_process_sooner_packets(cnx, current_time);
+    }
 
     memset(&addr_to_log, 0, sizeof(addr_to_log));
     *send_length = 0;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3516,7 +3516,7 @@ static int picoquic_check_idle_timer(picoquic_cnx_t* cnx, uint64_t* next_wake_ti
     int ret = 0;
     uint64_t idle_timer = 0;
 
-    if (cnx->cnx_state >= picoquic_state_client_ready_start) {
+    if (cnx->cnx_state >= picoquic_state_ready) {
         uint64_t rto = picoquic_current_retransmit_timer(cnx, picoquic_packet_context_application);
         idle_timer = cnx->idle_timeout;
         if (idle_timer < 3 * rto) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2152,7 +2152,6 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
         epoch = picoquic_epoch_handshake;
         pc = picoquic_packet_context_handshake;
         packet_type = picoquic_packet_handshake;
-        epoch = picoquic_epoch_handshake;
     }
 
     send_buffer_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : send_buffer_max;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -751,7 +751,7 @@ static int picoquic_update_traffic_key_callback(ptls_update_traffic_key_t * self
 #endif
 
     int ret = picoquic_set_key_from_secret(cipher, is_enc, 0, &cnx->crypto_context[epoch], secret);
-    if (cnx->client_mode && cnx->cnx_state < picoquic_state_ready) {
+    if (cnx->cnx_state < picoquic_state_ready) {
         cnx->recycle_sooner_needed = 1;
     }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -751,6 +751,9 @@ static int picoquic_update_traffic_key_callback(ptls_update_traffic_key_t * self
 #endif
 
     int ret = picoquic_set_key_from_secret(cipher, is_enc, 0, &cnx->crypto_context[epoch], secret);
+    if (cnx->client_mode && cnx->cnx_state < picoquic_state_ready) {
+        cnx->recycle_sooner_needed = 1;
+    }
 
     if (ret == 0 && epoch == 3) {
         memcpy((is_enc) ? tls_ctx->app_secret_enc : tls_ctx->app_secret_dec, secret, cipher->hash->digest_size);

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -7645,7 +7645,7 @@ static int connection_drop_test_one(picoquic_state_enum target_client_state, pic
 int connection_drop_test()
 {
     int ret = 0;
-    picoquic_state_enum target_state[11] = {
+    picoquic_state_enum target_state[9] = {
         picoquic_state_client_init_sent,
         picoquic_state_client_renegotiate,
         picoquic_state_client_init_resent,
@@ -7653,11 +7653,13 @@ int connection_drop_test()
         picoquic_state_server_handshake,
         picoquic_state_client_handshake_start,
         picoquic_state_server_false_start,
-        picoquic_state_server_almost_ready};
-    int target_is_client[] = {
-        1, 1, 1, 0, 0, 1, 0, 0 };
+        picoquic_state_server_almost_ready,
+        picoquic_state_client_almost_ready
+    };
+    int target_is_client[9] = {
+        1, 1, 1, 0, 0, 1, 0, 0, 1 };
 
-    for (int i = 0; ret == 0 && i < 11; i++) {
+    for (int i = 0; ret == 0 && i < 9; i++) {
         picoquic_state_enum c_state = (target_is_client[i]) ? target_state[i] : picoquic_state_ready;
         picoquic_state_enum s_state = (target_is_client[i]) ? picoquic_state_ready : target_state[i];
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -7652,13 +7652,10 @@ int connection_drop_test()
         picoquic_state_server_init,
         picoquic_state_server_handshake,
         picoquic_state_client_handshake_start,
-        picoquic_state_client_handshake_progress,
-        picoquic_state_client_almost_ready,
         picoquic_state_server_false_start,
-        picoquic_state_server_almost_ready,
-        picoquic_state_client_ready_start };
+        picoquic_state_server_almost_ready};
     int target_is_client[] = {
-        1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0 };
+        1, 1, 1, 0, 0, 1, 0, 0 };
 
     for (int i = 0; ret == 0 && i < 11; i++) {
         picoquic_state_enum c_state = (target_is_client[i]) ? target_state[i] : picoquic_state_ready;


### PR DESCRIPTION
Accept out of order packets during handshake. For example, if an Handshake packet arrives before the handshake key is available, store it locally and resubmit it as soon as the key is available.