### PR TITLE
picoquicdemo server provides retry token

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -929,9 +929,9 @@ int picoquic_incoming_client_initial(
 
     /* Logic to test the retry token.
      * TODO: this should probably be implemented as a callback */
-    if (((*pcnx)->quic->flags&picoquic_context_check_token) &&
+    if (((*pcnx)->quic->check_token) &&
         (*pcnx)->cnx_state == picoquic_state_server_init &&
-        ((*pcnx)->quic->flags&picoquic_context_server_busy) == 0) {
+        !(*pcnx)->quic->server_busy) {
         if (picoquic_verify_retry_token((*pcnx)->quic, addr_from, current_time,
             &(*pcnx)->original_cnxid, ph->token_bytes, ph->token_length) != 0) {
             uint8_t token_buffer[256];
@@ -967,7 +967,7 @@ int picoquic_incoming_client_initial(
         }
 
         if ((*pcnx)->cnx_state == picoquic_state_server_init && 
-            (*pcnx)->quic->flags & picoquic_context_server_busy) {
+            (*pcnx)->quic->server_busy) {
             (*pcnx)->local_error = PICOQUIC_TRANSPORT_SERVER_BUSY;
             (*pcnx)->cnx_state = picoquic_state_handshake_failure;
         }
@@ -1721,7 +1721,8 @@ int picoquic_incoming_encrypted(
                 ret = picoquic_tls_stream_process(cnx);
             }
 
-            if (ret == 0) {
+            if (ret == 0 && (cnx->pkt_ctx[picoquic_packet_context_application].send_sequence < PICOQUIC_LOG_PACKET_MAX_SEQUENCE ||
+                cnx->quic->use_long_log)) {
                 picoquic_cc_dump(cnx, current_time);
             }
         }

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -502,11 +502,16 @@ typedef struct st_picoquic_quic_t {
     picoquic_stored_ticket_t * p_first_ticket;
     picoquic_stored_token_t * p_first_token;
     uint32_t mtu_max;
-    uint32_t flags;
     uint32_t padding_multiple_default;
     uint32_t padding_minsize_default;
     uint32_t sequence_hole_pseudo_period; /* Optimistic ack defense */
     picoquic_spinbit_version_enum default_spin_policy;
+    /* Flags */
+    unsigned int check_token : 1;
+    unsigned int provide_token : 1;
+    unsigned int unconditional_cnx_id : 1;
+    unsigned int client_zero_share : 1;
+    unsigned int server_busy : 1;
 
     picoquic_stateless_packet_t* pending_stateless_packet;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -262,7 +262,7 @@ picoquic_quic_t* picoquic_create(uint32_t nb_connections,
         quic->padding_minsize_default = PICOQUIC_RESET_PACKET_MIN_SIZE;
 
         if (cnx_id_callback != NULL) {
-            quic->flags |= picoquic_context_unconditional_cnx_id;
+            quic->unconditional_cnx_id = 1;
         }
 
         if (ticket_file_name != NULL) {
@@ -474,11 +474,19 @@ void picoquic_set_null_verifier(picoquic_quic_t* quic) {
 
 void picoquic_set_cookie_mode(picoquic_quic_t* quic, int cookie_mode)
 {
-    if (cookie_mode) {
-        quic->flags |= picoquic_context_check_token;
+    if (cookie_mode&1) {
+        quic->check_token = 1;
         picoquic_crypto_random(quic, quic->retry_seed, PICOQUIC_RETRY_SECRET_SIZE);
     } else {
-        quic->flags &= ~picoquic_context_check_token;
+        quic->check_token = 0;
+    }
+
+    if (cookie_mode & 2) {
+        quic->provide_token = 1;
+        picoquic_crypto_random(quic, quic->retry_seed, PICOQUIC_RETRY_SECRET_SIZE);
+    }
+    else {
+        quic->provide_token = 0;
     }
 }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1572,8 +1572,7 @@ int picoquic_initialize_tls_stream(picoquic_cnx_t* cnx, uint64_t current_time)
 
     /* No resumption if no alpn specified upfront, because it would make the negotiation and
      * the handling of 0-RTT way too messy */
-    if (cnx->sni != NULL && cnx->alpn != NULL &&
-        (cnx->quic->flags & picoquic_context_client_zero_share) == 0) {
+    if (cnx->sni != NULL && cnx->alpn != NULL && !cnx->quic->client_zero_share) {
         uint8_t* ticket = NULL;
         uint16_t ticket_length = 0;
 
@@ -1590,7 +1589,7 @@ int picoquic_initialize_tls_stream(picoquic_cnx_t* cnx, uint64_t current_time)
         }
     }
 
-    if ((cnx->quic->flags&picoquic_context_client_zero_share) != 0 &&
+    if (cnx->quic->client_zero_share &&
         cnx->cnx_state == picoquic_state_client_init)
     {
         ctx->handshake_properties.client.negotiate_before_key_exchange = 1;
@@ -1934,7 +1933,7 @@ int picoquic_tls_stream_process(picoquic_cnx_t* cnx)
                         cnx->cnx_state = picoquic_state_server_false_start;
 
                         /* On a server that does address validation, send a NEW TOKEN frame */
-                        if (cnx->client_mode == 0 && (cnx->quic->flags&picoquic_context_check_token) != 0) {
+                        if (!cnx->client_mode && (cnx->quic->check_token||cnx->quic->provide_token)) {
                             uint8_t token_buffer[256];
                             size_t token_size;
                             picoquic_connection_id_t n_cid = picoquic_null_connection_id;

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -164,7 +164,7 @@ static void picoquic_set_key_log_file_from_env(picoquic_quic_t* quic)
 
 int quic_server(const char* server_name, int server_port,
     const char* pem_cert, const char* pem_key,
-    int just_once, int do_hrr, picoquic_connection_id_cb_fn cnx_id_callback,
+    int just_once, int do_retry, picoquic_connection_id_cb_fn cnx_id_callback,
     void* cnx_id_callback_ctx, uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE],
     int dest_if, int mtu_max, uint32_t proposed_version, 
     const char * esni_key_file_name, const char * esni_rr_file_name,
@@ -214,8 +214,11 @@ int quic_server(const char* server_name, int server_port,
             ret = -1;
         } else {
             picoquic_set_alpn_select_fn(qserver, picoquic_demo_server_callback_select_alpn);
-            if (do_hrr != 0) {
+            if (do_retry != 0) {
                 picoquic_set_cookie_mode(qserver, 1);
+            }
+            else {
+                picoquic_set_cookie_mode(qserver, 2);
             }
             qserver->mtu_max = mtu_max;
 
@@ -589,7 +592,7 @@ int quic_client(const char* ip_address_text, int server_port,
             }
 
             if (force_zero_share) {
-                qclient->flags |= picoquic_context_client_zero_share;
+                qclient->client_zero_share = 1;
             }
             qclient->mtu_max = mtu_max;
 
@@ -1131,7 +1134,7 @@ int main(int argc, char** argv)
     uint32_t proposed_version = 0;
     int is_client = 0;
     int just_once = 0;
-    int do_hrr = 0;
+    int do_retry = 0;
     int force_zero_share = 0;
     int force_migration = 0;
     int large_client_hello = 0;
@@ -1193,7 +1196,7 @@ int main(int argc, char** argv)
             just_once = 1;
             break;
         case 'r':
-            do_hrr = 1;
+            do_retry = 1;
             break;
         case 's':
             if (optind + 1 > argc) {
@@ -1339,10 +1342,10 @@ int main(int argc, char** argv)
         }
 
         /* Run as server */
-        printf("Starting Picoquic server (v%s) on port %d, server name = %s, just_once = %d, hrr= %d\n",
-            PICOQUIC_VERSION, server_port, server_name, just_once, do_hrr);
+        printf("Starting Picoquic server (v%s) on port %d, server name = %s, just_once = %d, do_retry = %d\n",
+            PICOQUIC_VERSION, server_port, server_name, just_once, do_retry);
         ret = quic_server(server_name, server_port,
-            server_cert_file, server_key_file, just_once, do_hrr,
+            server_cert_file, server_key_file, just_once, do_retry,
             (cnx_id_cbdata == NULL) ? NULL : picoquic_connection_id_callback,
             (cnx_id_cbdata == NULL) ? NULL : (void*)cnx_id_cbdata,
             (uint8_t*)reset_seed, dest_if, mtu_max, proposed_version,

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -850,7 +850,7 @@ int tls_api_init_ctx(picoquic_test_tls_api_ctx_t** pctx, uint32_t proposed_versi
                 /* Apply the zero share parameter if required */
                 if (force_zero_share != 0)
                 {
-                    test_ctx->qclient->flags |= picoquic_context_client_zero_share;
+                    test_ctx->qclient->client_zero_share = 1;
                 }
 
                 /* Create a client connection */
@@ -2021,7 +2021,7 @@ int tls_api_bad_server_reset_test()
 
 static char const* token_file_name = "retry_tests_tokens.bin";
 
-int tls_retry_token_test()
+int tls_retry_token_test_one(int token_mode)
 {
     uint64_t simulated_time = 0;
     uint64_t loss_mask = 0;
@@ -2035,8 +2035,8 @@ int tls_retry_token_test()
     }
 
     if (ret == 0) {
-        /* Set the server in HRR/Cookies mode */
-        picoquic_set_cookie_mode(test_ctx->qserver, 1);
+        /* Set the server in requested token mode -- either check or merely provide */
+        picoquic_set_cookie_mode(test_ctx->qserver, token_mode);
         /* Try the connection */
         ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
     }
@@ -2094,6 +2094,24 @@ int tls_retry_token_test()
     if (test_ctx != NULL) {
         tls_api_delete_ctx(test_ctx);
         test_ctx = NULL;
+    }
+
+    return ret;
+}
+
+int tls_retry_token_test()
+{
+    int ret = tls_retry_token_test_one(1);
+
+    if (ret != 0) {
+        DBG_PRINTF("Retry token test returns %d", ret);
+    }
+    else {
+        ret = tls_retry_token_test_one(2);
+
+        if (ret != 0) {
+            DBG_PRINTF("Provide token test returns %d", ret);
+        }
     }
 
     return ret;
@@ -4905,7 +4923,7 @@ int server_busy_test()
     int ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 0, 0);
 
     if (ret == 0) {
-        test_ctx->qserver->flags |= picoquic_context_server_busy;
+        test_ctx->qserver->server_busy = 1;
         (void) tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
 
         if (test_ctx->cnx_server != NULL &&
@@ -4925,7 +4943,7 @@ int server_busy_test()
     }
 
     if (ret == 0) {
-        test_ctx->qserver->flags &= ~picoquic_context_server_busy;
+        test_ctx->qserver->server_busy = 0;
 
         if (test_ctx->cnx_server != NULL) {
             picoquic_delete_cnx(test_ctx->cnx_server);

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2050,13 +2050,17 @@ int tls_retry_token_test_one(int token_mode)
         ret = tls_api_attempt_to_close(test_ctx, &simulated_time);
     }
 
-    /* Now we remove the client connection and create a new one */
+    /* Now we remove the client connection and create a new one.
+     * Force the retry token flag, in case it was not set before, to ensure token retry mode.
+     */
     if (ret == 0) {
         picoquic_delete_cnx(test_ctx->cnx_client);
         if (test_ctx->cnx_server != NULL) {
             picoquic_delete_cnx(test_ctx->cnx_server);
             test_ctx->cnx_server = NULL;
         }
+
+        test_ctx->qserver->check_token = 1;
 
         test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient,
             picoquic_null_connection_id, picoquic_null_connection_id,
@@ -6198,6 +6202,7 @@ int packet_trace_test()
      * current working directory, and run a basic test scenario */
     if (ret == 0) {
         picoquic_set_binlog(test_ctx->qserver, PACKET_TRACE_BIN);
+        test_ctx->qserver->use_long_log = 1;
         ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
             test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 20000, 1000000);
     }


### PR DESCRIPTION
Providing the client with retry token allows for automatic validation of IP addresses in periods of stress.