### PR TITLE
First cut at direct receive API

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1140,6 +1140,11 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(direct_receive) {
+            int ret = direct_receive_test();
+
+            Assert::AreEqual(ret, 0);
+        }
 
         TEST_METHOD(stress)
         {

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -576,6 +576,8 @@ typedef struct st_picoquic_stream_head_t {
     uint64_t sent_offset; /* Amount of data sent in the stream */
     picoquic_stream_data_node_t* send_queue; /* if the stream is not "active", list of data segments ready to send */
     void * app_stream_ctx;
+    picoquic_stream_direct_receive_fn direct_receive_fn; /* direct receive function, if not NULL */
+    void* direct_receive_ctx; /* direct receive context */
     picoquic_sack_item_t first_sack_item; /* Track which parts of the stream were acknowledged by the peer */
     /* Flags describing the state of the stream */
     unsigned int is_active : 1; /* The application is actively managing data sending through callbacks */

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -201,6 +201,7 @@ static const picoquic_test_def_t test_table[] = {
     { "send_stream_blocked", send_stream_blocked_test },
     { "queue_network_input", queue_network_input_test },
     { "pacing_update", pacing_update_test },
+    { "direct_receive", direct_receive_test },
     { "stress", stress_test },
     { "fuzz", fuzz_test },
     { "fuzz_initial", fuzz_initial_test}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -194,9 +194,6 @@ int stream_rank_test();
 int not_before_cnxid_test();
 int send_stream_blocked_test();
 int queue_network_input_test();
-
-int h3zero_post_test();
-int h09_post_test(); 
 int fastcc_test();
 int fastcc_jitter_test();
 int bbr_test();
@@ -211,7 +208,10 @@ int blackhole_test();
 int no_ack_frequency_test();
 int connection_drop_test();
 int pacing_update_test();
+int direct_receive_test();
 
+int h3zero_post_test();
+int h09_post_test();
 int demo_file_sanitize_test();
 int demo_file_access_test();
 int demo_server_file_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -57,6 +57,12 @@ typedef struct st_test_api_stream_desc_t {
     size_t r_len;
 } test_api_stream_desc_t;
 
+typedef struct st_test_api_stream_hole_t {
+    struct st_test_api_stream_hole_t* next_hole;
+    uint64_t offset;
+    uint64_t last_offset;
+} test_api_stream_hole_t;
+
 typedef struct st_test_api_stream_t {
     uint64_t stream_id;
     uint64_t previous_stream_id;
@@ -68,6 +74,9 @@ typedef struct st_test_api_stream_t {
     size_t q_recv_nb;
     size_t r_len;
     size_t r_recv_nb;
+    uint64_t next_direct_offset;
+    struct st_test_api_stream_hole_t* first_direct_hole;
+    int direct_fin_received;
     uint8_t* q_src;
     uint8_t* q_rcv;
     uint8_t* r_src;


### PR DESCRIPTION
This is a first implementation of the "direct receive" API, which will allow an application to receive out-of-order data. The target is "real time" streams, e.g. audio or video. In the test, we simply fill up a memory blob with data received out of order.

The API works, as shown by the test. But I find it a little clumsy. It defines a separate callback function and a separate callback context for each stream. Implementing the test callback showed a fair bit of common code with the the global callback function set in the connection context. I am seeking feedback on these two questions:

1) I could remove the need for a separate "direct receive callback" by adding an event type for direct receive, but I would need to also add an "offset" parameter to the signature of `picoquic_stream_data_cb_fn`. I am concerned that this would require updates in the existing implementations.

2) The current procedure defines a specific stream context for the direct receive function. We also use a stream context parameter for the stream callbacks in `picoquic_stream_data_cb_fn`. I think these should be unified, but I am worried about possible interactions between read and write paths.

When writing the direct receive callbacks, I had to write code to manage the "holes" left by out of order arrivals, and possibly filled later by re-transmissions. That kind of thing is cumbersome and can easily become a performance bottleneck. I wonder whether this should be handled by the stack. That would require changing the API to have separate notifications, such as:

* Notification that data that is arriving in sequence
* Notification of a hole or gap in the data
* Notification that incoming data fills an existing gap

I would like feedback on that!