### PR TITLE
Remove all dependencies on the picotls minicrypto binding

### DIFF
--- a/cmake/FindPTLS.cmake
+++ b/cmake/FindPTLS.cmake
@@ -1,7 +1,7 @@
 # - Try to find Picotls
 
 find_path(PTLS_INCLUDE_DIR
-    NAMES picotls/minicrypto.h
+    NAMES picotls/openssl.h
     HINTS ${CMAKE_SOURCE_DIR}/../picotls/include
           ${CMAKE_BINARY_DIR}/../picotls/include
           ../picotls/include/ )
@@ -9,7 +9,6 @@ find_path(PTLS_INCLUDE_DIR
 set(PTLS_HINTS ${CMAKE_BINARY_DIR}/../picotls ../picotls)
 
 find_library(PTLS_CORE_LIBRARY picotls-core HINTS ${PTLS_HINTS})
-find_library(PTLS_MINICRYPTO_LIBRARY picotls-minicrypto HINTS ${PTLS_HINTS})
 find_library(PTLS_OPENSSL_LIBRARY picotls-openssl HINTS ${PTLS_HINTS})
 
 include(FindPackageHandleStandardArgs)
@@ -17,13 +16,11 @@ include(FindPackageHandleStandardArgs)
 # if all listed variables are TRUE
 find_package_handle_standard_args(PTLS REQUIRED_VARS
     PTLS_CORE_LIBRARY
-    PTLS_MINICRYPTO_LIBRARY
     PTLS_OPENSSL_LIBRARY
     PTLS_INCLUDE_DIR)
 
 if(PTLS_FOUND)
-    set(PTLS_LIBRARIES
-        ${PTLS_CORE_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY} ${PTLS_OPENSSL_LIBRARY})
+    set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY})
     set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
 endif()
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -26,7 +26,6 @@
 #include "picotls.h"
 #include "picoquic_internal.h"
 #include "picotls/openssl.h"
-#include "picotls/minicrypto.h"
 #include "picotls/ffx.h"
 #include "tls_api.h"
 #include <openssl/pem.h>
@@ -1033,14 +1032,14 @@ void picoquic_crypto_context_free(picoquic_crypto_context_t * ctx)
 
 /* Definition of supported key exchange algorithms */
 
-ptls_key_exchange_algorithm_t *picoquic_key_exchanges[] = { &ptls_openssl_secp256r1, &ptls_minicrypto_x25519, NULL };
+ptls_key_exchange_algorithm_t *picoquic_key_exchanges[] = { &ptls_openssl_secp256r1, &ptls_openssl_x25519, NULL };
 ptls_cipher_suite_t *picoquic_cipher_suites[] = { 
     &ptls_openssl_aes128gcmsha256,
     &ptls_openssl_aes256gcmsha384,
 #ifdef PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
     &ptls_openssl_chacha20poly1305sha256,
 #else
-    &ptls_minicrypto_chacha20poly1305sha256,
+    &ptls_openssl_chacha20poly1305sha256,
 #endif
     NULL };
 
@@ -2649,10 +2648,10 @@ void* picoquic_hash_create(char const* algorithm_name) {
     ptls_hash_context_t* ctx;
 
     if (strcmp(algorithm_name, "SHA256") == 0) {
-        ctx = ptls_minicrypto_sha256.create();
+        ctx = ptls_openssl_sha256.create();
     }
     else if (strcmp(algorithm_name, "SHA384") == 0) {
-        ctx = ptls_minicrypto_sha384.create();
+        ctx = ptls_openssl_sha384.create();
     }
     else {
         ctx = NULL;
@@ -2665,10 +2664,10 @@ size_t picoquic_hash_get_length(char const* algorithm_name) {
     size_t len;
 
     if (strcmp(algorithm_name, "SHA256") == 0) {
-        len = ptls_minicrypto_sha256.digest_size;
+        len = ptls_openssl_sha256.digest_size;
     }
     else if (strcmp(algorithm_name, "SHA384") == 0) {
-        len = ptls_minicrypto_sha384.digest_size;
+        len = ptls_openssl_sha384.digest_size;
     }
     else {
         len = 0;

--- a/picoquictest/cleartext_aead_test.c
+++ b/picoquictest/cleartext_aead_test.c
@@ -27,7 +27,6 @@
 #include "picoquic_utils.h"
 #include "picotls.h"
 #include "picotls/openssl.h"
-#include "picotls/minicrypto.h"
 #include <string.h>
 #include "picoquictest_internal.h"
 


### PR DESCRIPTION
There are still references to minicrypto in the various `.vcxproj` files which you will need to do something about manually.