### PR TITLE
Add multi-file test

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1372,6 +1372,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(h3_multi_file) {
+            int ret = h3_multi_file_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(http_stress) {
             int ret = http_stress_test();
 

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -583,6 +583,7 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
         if (stream_ctx != NULL && stream_ctx->is_open) {
             if (!stream_ctx->is_file_open && ctx->no_disk == 0) {
                 ret = picoquic_demo_client_open_stream_file(cnx, ctx, stream_ctx);
+                stream_ctx->is_file_open = 1;
             }
             if (ret == 0 && length > 0) {
                 switch (ctx->alpn) {
@@ -777,7 +778,10 @@ static void picoquic_demo_client_delete_stream_context(picoquic_demo_callback_ct
         stream_ctx->f_name = NULL;
     }
 
-    stream_ctx->F = picoquic_file_close(stream_ctx->F);
+    if (stream_ctx->F != NULL) {
+        DBG_PRINTF("Stream %d, file open after %d bytes\n", stream_ctx->stream_id, stream_ctx->received_length);
+        stream_ctx->F = picoquic_file_close(stream_ctx->F);
+    }
 
     if (stream_ctx == ctx->first_stream) {
         ctx->first_stream = stream_ctx->next_stream;

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -581,21 +581,9 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
             stream_ctx = picoquic_demo_client_find_stream(ctx, stream_id);
         }
         if (stream_ctx != NULL && stream_ctx->is_open) {
-#if 0
             if (!stream_ctx->is_file_open && ctx->no_disk == 0) {
-                int last_err = 0;
-                stream_ctx->F = picoquic_file_open_ex(stream_ctx->f_name, "wb", &last_err);
-                if (stream_ctx->F == NULL) {
-                    picoquic_log_app_message(cnx->quic, &cnx->initial_cnxid,
-                        "Could not open file <%s> for stream %" PRIu64 ", error %d (0x%x)\n", stream_ctx->f_name, stream_id, last_err, last_err);
-                    DBG_PRINTF("Could not open file <%s> for stream %" PRIu64 ", error %d (0x%x)", stream_ctx->f_name, stream_id, last_err, last_err);
-                    ret = -1;
-                }
-                else {
-                    stream_ctx->is_file_open = 1;
-                }
+                ret = picoquic_demo_client_open_stream_file(cnx, ctx, stream_ctx);
             }
-#endif
             if (ret == 0 && length > 0) {
                 switch (ctx->alpn) {
                 case picoquic_alpn_http_3: {
@@ -623,15 +611,10 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
                                 }
                             }
                             if (ret == 0 && ctx->no_disk == 0) {
-                                if (!stream_ctx->is_file_open) {
-                                    ret = picoquic_demo_client_open_stream_file(cnx, ctx, stream_ctx);
-                                }
-                                if (ret == 0) {
-                                    ret = (fwrite(bytes, 1, available_data, stream_ctx->F) > 0) ? 0 : -1;
-                                    if (ret != 0) {
-                                        picoquic_log_app_message(cnx->quic, &cnx->initial_cnxid,
-                                            "Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
-                                    }
+                                ret = (fwrite(bytes, 1, available_data, stream_ctx->F) > 0) ? 0 : -1;
+                                if (ret != 0) {
+                                    picoquic_log_app_message(cnx->quic, &cnx->initial_cnxid,
+                                        "Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
                                 }
                             }
                             stream_ctx->received_length += available_data;
@@ -642,15 +625,10 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
                 }
                 case picoquic_alpn_http_0_9:
                     if (ctx->no_disk == 0) {
-                        if (!stream_ctx->is_file_open) {
-                            ret = picoquic_demo_client_open_stream_file(cnx, ctx, stream_ctx);
-                        }
-                        if (ret == 0) {
-                            ret = (fwrite(bytes, 1, length, stream_ctx->F) > 0) ? 0 : -1;
-                            if (ret != 0) {
-                                picoquic_log_app_message(cnx->quic, &cnx->initial_cnxid,
-                                    "Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
-                            }
+                        ret = (fwrite(bytes, 1, length, stream_ctx->F) > 0) ? 0 : -1;
+                        if (ret != 0) {
+                            picoquic_log_app_message(cnx->quic, &cnx->initial_cnxid,
+                                "Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
                         }
                     }
                     stream_ctx->received_length += length;

--- a/picohttp/democlient.h
+++ b/picohttp/democlient.h
@@ -79,6 +79,7 @@ typedef struct st_picoquic_demo_client_callback_ctx_t {
     size_t nb_demo_streams;
 
     int nb_open_streams;
+    int nb_open_files;
     uint32_t nb_client_streams;
 
     picoquic_alpn_enum alpn;

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -64,6 +64,7 @@ static const picoquic_test_def_t test_table[] = {
     { "h09_satellite", h09_satellite_test },
     { "h09_lone_fin", h09_lone_fin_test },
     { "h3_long_file_name", h3_long_file_name_test },
+    { "h3_multi_file", h3_multi_file_test },
     { "http_stress", http_stress_test }
 };
 

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 
 extern size_t picohttp_nb_stress_clients;
+size_t picohttp_test_multifile_number;
 
 typedef struct st_picoquic_test_def_t {
     char const* test_name;
@@ -114,6 +115,7 @@ int usage(char const * argv0)
     fprintf(stderr, "  -x test           Do not run the specified test.\n");
     fprintf(stderr, "  -s nnn            Run stress for nnn clients.\n");
     fprintf(stderr, "  -f nnn            Run fuzz for nnn clients.\n");
+    fprintf(stderr, "  -m nnn            Run multi file test with nnn files.\n");
     fprintf(stderr, "  -n                Disable debug prints.\n");
     fprintf(stderr, "  -r                Retry failed tests with debug print enabled.\n");
     fprintf(stderr, "  -h                Print this help message\n");
@@ -146,6 +148,8 @@ int main(int argc, char** argv)
     int opt;
     int do_fuzz = 0;
     int do_stress = 0;
+    int do_multi_file = 0;
+    int nb_multi_file = 0;
     int disable_debug = 0;
     int retry_failed_test = 0;
 
@@ -156,7 +160,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        while (ret == 0 && (opt = getopt(argc, argv, "f:s:S:x:nrh")) != -1) {
+        while (ret == 0 && (opt = getopt(argc, argv, "f:s:m:S:x:nrh")) != -1) {
             switch (opt) {
             case 'x': {
                 int test_number = get_test_number(optarg);
@@ -187,6 +191,14 @@ int main(int argc, char** argv)
                     ret = usage(argv[0]);
                 }
                 break;
+            case 'm':
+                do_multi_file = 1;
+                nb_multi_file = atoi(optarg);
+                if (nb_multi_file <= 0) {
+                    fprintf(stderr, "Incorrect number of files for multi-file test: %s\n", optarg);
+                    ret = usage(argv[0]);
+                }
+                break;
             case 'S':
                 picoquic_set_solution_dir(optarg);
                 break;
@@ -213,7 +225,7 @@ int main(int argc, char** argv)
             debug_printf_push_stream(stderr);
         }
 
-        if (ret == 0 && stress_clients > 0) {
+        if (ret == 0 && (stress_clients > 0 || nb_multi_file > 0)) {
             if (optind >= argc && found_exclusion == 0) {
                 for (size_t i = 0; i < nb_tests; i++) {
                     if (strcmp(test_table[i].test_name, "http_stress") == 0)
@@ -227,12 +239,18 @@ int main(int argc, char** argv)
                             test_status[i] = test_excluded;
                         }
                     }
+                    else if (strcmp(test_table[i].test_name, "h3_multi_file") == 0) {
+                        if (do_multi_file == 0) {
+                            test_status[i] = test_excluded;
+                        }
+                    }
                     else {
                         test_status[i] = test_excluded;
                     }
                 }
                 
                 picohttp_nb_stress_clients = (size_t) stress_clients;
+                picohttp_test_multifile_number = (size_t)nb_multi_file;
             }
         }
 

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -537,6 +537,7 @@ FILE* picoquic_file_open(char const* file_name, char const* flags)
 FILE * picoquic_file_close(FILE * F)
 {
     if (F != NULL) {
+        (void)fflush(F);
         (void)fclose(F);
     }
     return NULL;

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -537,7 +537,6 @@ FILE* picoquic_file_open(char const* file_name, char const* flags)
 FILE * picoquic_file_close(FILE * F)
 {
     if (F != NULL) {
-        (void)fflush(F);
         (void)fclose(F);
     }
     return NULL;

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1868,7 +1868,7 @@ int h3_long_file_name_test()
     }
 #else
     ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, long_file_name_scenario, nb_long_file_name_scenario, 
-        long_file_name_stream_length, 0, 400000, 0, NULL);
+        long_file_name_stream_length, 0, 400000, 0, NULL, NULL, NULL);
 #endif
     return ret;
 }

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1170,7 +1170,7 @@ static size_t const demo_test_stream_length[] = {
 
 static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server_callback_fn, void * server_param,
     int do_esni, const picoquic_demo_stream_desc_t * demo_scenario, size_t nb_scenario, size_t const * demo_length,
-    int do_sat, uint64_t completion_target, int delay_fin, const char * out_dir)
+    int do_sat, uint64_t completion_target, int delay_fin, const char * out_dir, const char * client_bin, const char * server_bin)
 {
     uint64_t simulated_time = 0;
     uint64_t loss_mask = 0;
@@ -1204,6 +1204,15 @@ static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server
         ret = tls_api_init_ctx(&test_ctx,
             PICOQUIC_INTERNAL_TEST_VERSION_1,
             PICOQUIC_TEST_SNI, alpn, &simulated_time, NULL, NULL, 0, 1, 0);
+
+        if (ret == 0 && server_bin != NULL) {
+            picoquic_set_binlog(test_ctx->qserver, server_bin);
+            test_ctx->qserver->use_long_log = 1;
+        }
+
+        if (ret == 0 && client_bin != NULL) {
+            picoquic_set_binlog(test_ctx->qclient, client_bin);
+        }
 
         if (ret == 0 && do_sat) {
             /* For the satellite test, set long delays, 10 Mbps one way, 1 Mbps the other way */
@@ -1375,31 +1384,31 @@ static int demo_server_test(char const * alpn, picoquic_stream_data_cb_fn server
 
 int h3zero_server_test()
 {
-    return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+    return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 }
 
 int h09_server_test()
 {
-    return demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+    return demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 }
 
 int generic_server_test()
 {
     char const* alpn_09 = PICOHTTP_ALPN_HQ_LATEST;
     char const* alpn_3 = PICOHTTP_ALPN_H3_LATEST;
-    int ret = demo_server_test(alpn_09, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+    int ret = demo_server_test(alpn_09, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 
     if (ret != 0) {
         DBG_PRINTF("Generic server test fails for %s\n", alpn_09);
     }
     else {
-        ret = demo_server_test(alpn_3, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+        ret = demo_server_test(alpn_3, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 
         if (ret != 0) {
             DBG_PRINTF("Generic server test fails for %s\n", alpn_3);
         }
         else {
-            ret = demo_server_test(NULL, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+            ret = demo_server_test(NULL, picoquic_demo_server_callback, NULL, 0, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 
             if (ret != 0) {
                 DBG_PRINTF("Generic server test fails for %s\n", alpn_3);
@@ -1412,7 +1421,7 @@ int generic_server_test()
 
 int http_esni_test()
 {
-    return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 1, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL);
+    return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 1, demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 }
 
 /* Test the server side post API */
@@ -1549,13 +1558,13 @@ static size_t const post_test_stream_length[] = { 2345 };
 int h3zero_post_test()
 {
     return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, (void*)&ping_test_param, 0, post_test_scenario, nb_post_test_scenario,
-        post_test_stream_length, 0, 0, 0, NULL);
+        post_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 }
 
 int h09_post_test()
 {
     return demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, (void*)&ping_test_param, 0, post_test_scenario, nb_post_test_scenario, 
-        post_test_stream_length, 0, 0, 0, NULL);
+        post_test_stream_length, 0, 0, 0, NULL, NULL, NULL);
 }
 
 int demo_file_sanitize_test()
@@ -1724,7 +1733,7 @@ int demo_server_file_test()
     ret = serve_file_test_set_param(&file_param, file_name_buffer, sizeof(file_name_buffer));
 
     if (ret == 0 && (ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, (void*)&file_param, 0, 
-        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL)) != 0) {
+        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL, NULL, NULL)) != 0) {
         DBG_PRINTF("H3 server (%s) file test fails, ret = %d\n", PICOHTTP_ALPN_H3_LATEST, ret);
     }
     else if (ret == 0) {
@@ -1732,7 +1741,7 @@ int demo_server_file_test()
     }
 
     if (ret == 0 && (ret = demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, (void*)&file_param, 0, 
-        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL)) != 0) {
+        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL, NULL, NULL)) != 0) {
         DBG_PRINTF("H09 server (%s) file test fails, ret = %d\n", PICOHTTP_ALPN_HQ_LATEST, ret);
     }
     else if (ret == 0) {
@@ -1740,7 +1749,7 @@ int demo_server_file_test()
     }
 
     if (ret == 0 && (ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, picoquic_demo_server_callback, (void*)&file_param, 0, 
-        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL)) != 0) {
+        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 0, NULL, NULL, NULL)) != 0) {
         DBG_PRINTF("Demo server (%s) file test fails, ret = %d\n", PICOHTTP_ALPN_H3_LATEST, ret);
     }
     else if (ret == 0) {
@@ -1748,7 +1757,7 @@ int demo_server_file_test()
     }
 
     if (ret == 0 && (ret = demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_demo_server_callback, (void*)&file_param, 0,
-        file_test_scenario, nb_file_test_scenario, demo_test_stream_length, 0, 0, 0, NULL)) != 0) {
+        file_test_scenario, nb_file_test_scenario, demo_test_stream_length, 0, 0, 0, NULL, NULL, NULL)) != 0) {
         DBG_PRINTF("Demo server (%s) file test fails, ret = %d\n", PICOHTTP_ALPN_HQ_LATEST, ret);
     }
     else if (ret == 0) {
@@ -1767,13 +1776,13 @@ static const size_t nb_satellite_test_scenario = sizeof(satellite_test_scenario)
 int h3zero_satellite_test()
 {
     return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, satellite_test_scenario, nb_satellite_test_scenario,
-        demo_test_stream_length, 1, 10750000, 0, NULL);
+        demo_test_stream_length, 1, 10750000, 0, NULL, NULL, NULL);
 }
 
 int h09_satellite_test()
 {
     return demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, NULL, 0, satellite_test_scenario, nb_satellite_test_scenario, 
-        demo_test_stream_length, 1, 10750000, 0, NULL);
+        demo_test_stream_length, 1, 10750000, 0, NULL, NULL, NULL);
 }
 
 int h09_lone_fin_test()
@@ -1785,7 +1794,7 @@ int h09_lone_fin_test()
     ret = serve_file_test_set_param(&file_param, file_name_buffer, sizeof(file_name_buffer));
 
     if (ret == 0 && (ret = demo_server_test(PICOHTTP_ALPN_HQ_LATEST, picoquic_h09_server_callback, (void*)&file_param, 0, 
-        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 1, NULL)) != 0) {
+        file_test_scenario, nb_file_test_scenario, demo_file_test_stream_length, 0, 0, 1, NULL, NULL, NULL)) != 0) {
         DBG_PRINTF("H09 server (%s) file test fails, ret = %d\n", PICOHTTP_ALPN_HQ_LATEST, ret);
     }
     else if (ret == 0) {
@@ -1855,7 +1864,7 @@ int h3_long_file_name_test()
         scenario_line.post_size = 0;
 
         ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, &scenario_line, 1,
-            long_file_name_stream_length, 0, 400000, 0, NULL);
+            long_file_name_stream_length, 0, 400000, 0, NULL, NULL, NULL);
     }
 #else
     ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, long_file_name_scenario, nb_long_file_name_scenario, 
@@ -2043,6 +2052,8 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
 }
 
 size_t picohttp_test_multifile_number = 128;
+#define MULTI_FILE_CLIENT_BIN "multi_file_client_trace.bin"
+#define MULTI_FILE_SERVER_BIN "multi_file_server_trace.bin"
 
 int h3_multi_file_test()
 {
@@ -2062,7 +2073,8 @@ int h3_multi_file_test()
     int ret = demo_test_multi_scenario_create(&scenario, &stream_length, random_seed, nb_files, name_length, file_length, dir_www, dir_download);
 
     if (ret == 0) {
-        ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, (void*)&file_param, 0, scenario, nb_files, stream_length, 0, 5000000, 0, NULL);
+        ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, (void*)&file_param, 0, scenario, nb_files, 
+            stream_length, 0, 5000000, 0, NULL, MULTI_FILE_CLIENT_BIN, MULTI_FILE_SERVER_BIN);
     }
 
     if (ret == 0) {

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1867,7 +1867,8 @@ int h3_long_file_name_test()
             long_file_name_stream_length, 0, 400000, 0, NULL, NULL, NULL);
     }
 #else
-    ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, long_file_name_scenario, nb_long_file_name_scenario, 
+    ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, 
+        long_file_name_scenario, nb_long_file_name_scenario, 
         long_file_name_stream_length, 0, 400000, 0, NULL, NULL, NULL);
 #endif
     return ret;

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -2059,7 +2059,7 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
     }
 }
 
-size_t picohttp_test_multifile_number = 1999;
+size_t picohttp_test_multifile_number = 64;
 #define MULTI_FILE_CLIENT_BIN "multi_file_client_trace.bin"
 #define MULTI_FILE_SERVER_BIN "multi_file_server_trace.bin"
 

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1950,6 +1950,7 @@ static char * demo_test_create_random_file_name(size_t name_length, uint64_t * r
 
 static int demo_test_check_file(char const* www_path, char const* download_path, char const* file_name)
 {
+    int ret;
     char name1[1024];
     char name2[1024];
     size_t nb_written;
@@ -1957,7 +1958,10 @@ static int demo_test_check_file(char const* www_path, char const* download_path,
     (void)picoquic_sprintf(name1, sizeof(name1), &nb_written, "%s%s%s", www_path, PICOQUIC_FILE_SEPARATOR, file_name);
     (void)picoquic_sprintf(name2, sizeof(name2), &nb_written, "%s%s%s", download_path, PICOQUIC_FILE_SEPARATOR, file_name);
 
-    return picoquic_test_compare_binary_files(name1, name2);
+    if ((ret = picoquic_test_compare_binary_files(name1, name2)) != 0) {
+        DBG_PRINTF("Files %s != %s", name1, name2);
+    }
+    return ret;
 }
 
 static int demo_test_multi_scenario_create(picoquic_demo_stream_desc_t** scenario, size_t** stream_length, uint64_t seed, size_t nb_files, size_t name_length, size_t length,
@@ -2023,6 +2027,9 @@ static int demo_test_multi_scenario_check(picoquic_demo_stream_desc_t* scenario,
 
     for (size_t i = 0; ret == 0 && i < nb_files; i++) {
         ret = demo_test_check_file(dir_www, dir_download, scenario[i].doc_name);
+        if (ret != 0) {
+            DBG_PRINTF("File #%d differs", i);
+        }
     }
 
     return ret;
@@ -2051,7 +2058,7 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
     }
 }
 
-size_t picohttp_test_multifile_number = 128;
+size_t picohttp_test_multifile_number = 1999;
 #define MULTI_FILE_CLIENT_BIN "multi_file_client_trace.bin"
 #define MULTI_FILE_SERVER_BIN "multi_file_server_trace.bin"
 

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1859,7 +1859,7 @@ int h3_long_file_name_test()
     }
 #else
     ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_server_callback, NULL, 0, long_file_name_scenario, nb_long_file_name_scenario, 
-        long_file_name_stream_length, 0, 400000, 0);
+        long_file_name_stream_length, 0, 400000, 0, NULL);
 #endif
     return ret;
 }
@@ -1915,7 +1915,6 @@ static int demo_test_create_file(char const* dir_path, char const* file_name, si
 
 static void demo_test_delete_file(char const* dir_path, char const* file_name)
 {
-    int ret = 0;
     char name[1024];
     size_t nb_sprintf;
 
@@ -2030,7 +2029,7 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
             }
             if ((*scenario)[i].f_name != NULL) {
                 free((char*)((*scenario)[i].f_name));
-                (char*)(*scenario)[i].f_name = NULL;
+                (*scenario)[i].f_name = NULL;
             }
         }
         free(*scenario);
@@ -2050,7 +2049,7 @@ int h3_multi_file_test()
     char const* dir_www = "h3-m-www";
     char const* dir_download = "h3-m-download";
 #ifdef _WINDOWS
-    size_t const nb_files = 255;
+    size_t const nb_files = 256;
 #else
     size_t const nb_files = 1999;
 #endif

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -2042,17 +2042,15 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
     }
 }
 
+size_t picohttp_test_multifile_number = 128;
+
 int h3_multi_file_test()
 {
     picoquic_demo_stream_desc_t* scenario = NULL;
     size_t* stream_length = NULL;
     char const* dir_www = "h3-m-www";
     char const* dir_download = "h3-m-download";
-#ifdef _WINDOWS
-    size_t const nb_files = 256;
-#else
-    size_t const nb_files = 1999;
-#endif
+    size_t nb_files = picohttp_test_multifile_number;
     size_t const name_length = 10;
     size_t const file_length = 32;
     uint64_t const random_seed = 0xab8acadab8aull;

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -236,6 +236,7 @@ int h09_lone_fin_test();
 int http_stress_test();
 int http_esni_test();
 int h3_long_file_name_test();
+int h3_multi_file_test();
 
 #ifdef __cplusplus
 }

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -562,9 +562,11 @@ static int picoquic_compare_binary_files(char const* fname1, char const* fname2,
         size_t len2 = fread(buffer2, 1, sizeof(buffer2), f2);
 
         if (ret == 0 && len1 != len2) {
+            DBG_PRINTF("Length %s=%z, %s=%z", fname1, len1, fname2, len2);
             ret = -1;
         }
         if (ret == 0 && memcmp(buffer1, buffer2, len1) != 0) {
+            DBG_PRINTF("Content does not match for  %s, %s", fname1, fname2);
             ret = -1;
         }
 


### PR DESCRIPTION
First version of a test that replicates the M test in the interop runner -- see issue #922. The test execution in VS debugger is very slow, due to need to create many files. More importantly, the test appears to fail on the Windows client with diagnostic "too many files open" when processing the 277th file. This is bizarre, because the tracking of open and close files shows that the client has only one file opened at that point.