### PR TITLE
Hunt core dump

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3792,7 +3792,15 @@ int picoquic_prepare_next_packet(picoquic_quic_t* quic,
                     fflush(cnx->f_binlog);
                 }
 
-                picoquic_delete_cnx(cnx);
+                if (cnx->client_mode) {
+                    /* Do not unilaterally delete the connection context, as it was set by the application */
+                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, UINT64_MAX);
+                    SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+
+                }
+                else {
+                    picoquic_delete_cnx(cnx);
+                }
             }
             else {
                 if (*if_index == -1) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3794,9 +3794,8 @@ int picoquic_prepare_next_packet(picoquic_quic_t* quic,
 
                 if (cnx->client_mode) {
                     /* Do not unilaterally delete the connection context, as it was set by the application */
-                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, UINT64_MAX);
+                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time + PICOQUIC_MICROSEC_WAIT_MAX);
                     SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
-
                 }
                 else {
                     picoquic_delete_cnx(cnx);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3794,7 +3794,7 @@ int picoquic_prepare_next_packet(picoquic_quic_t* quic,
 
                 if (cnx->client_mode) {
                     /* Do not unilaterally delete the connection context, as it was set by the application */
-                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time + PICOQUIC_MICROSEC_WAIT_MAX);
+                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, UINT64_MAX);
                     SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
                 }
                 else {


### PR DESCRIPTION
This solves a crash observed in the Interop Runner, when clients try to write log messages on a connection that was already deleted by the stack. The fix is to not delete client-created connection contexts from inside the stack.