### PR TITLE
Add missing dependencies for the core libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,12 +102,22 @@ add_library(picoquic-core
     ${PICOQUIC_LIBRARY_FILES}
 )
 
+target_link_libraries(picoquic-core
+    ${PTLS_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
+)
+
 add_library(picoquic-log
     ${LOGLIB_LIBRARY_FILES}
 )
 
 add_library(picohttp-core
     ${PICOHTTP_LIBRARY_FILES}
+)
+
+target_link_libraries(picohttp-core
+    ${PTLS_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
 )
 
 add_executable(picoquicdemo


### PR DESCRIPTION
When using an OpenSSL library installed in a path that is not included as library path by make/CMake,
`picoquic-core` and `picohttp-core` would encounter a "missing symbols" error. Thus, they need to know explicitly where `${OPENSSL_LIBRARIES}` are.  

Currently, Linux, with `openssl` installed by a package manager, would compile and execute `picohttp_ct` well without any errors. However, when a custom-built `openssl`  were to be used, whose location is unknown to the CMake, we've got a problem.

In such a case, it should be `picoquic`'s responsibility to supply any dependencies existing between its executables and libraries, not the one's who use/tweak/port `picoquic` for her/his own purpose.