### PR TITLE
Small fix during gcc compile

### DIFF
--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 extern size_t picohttp_nb_stress_clients;
-size_t picohttp_test_multifile_number;
+static size_t picohttp_test_multifile_number;
 
 typedef struct st_picoquic_test_def_t {
     char const* test_name;

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -2069,7 +2069,7 @@ static void demo_test_multi_scenario_free(picoquic_demo_stream_desc_t** scenario
     }
 }
 
-size_t picohttp_test_multifile_number = 64;
+static size_t picohttp_test_multifile_number = 64;
 #define MULTI_FILE_CLIENT_BIN "multi_file_client_trace.bin"
 #define MULTI_FILE_SERVER_BIN "multi_file_server_trace.bin"
 


### PR DESCRIPTION
Fixes during compiling with gcc:
```bash
FAILED: picohttp_ct 
: && /bin/g++-10  -g  -rdynamic CMakeFiles/picohttp_ct.dir/picohttp_t/picohttp_t.c.o CMakeFiles/picohttp_ct.dir/picoquictest/ack_of_ack_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/bytestream_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/cleartext_aead_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/cnx_creation_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/cnxstress.c.o CMakeFiles/picohttp_ct.dir/picoquictest/cplusplus.cpp.o CMakeFiles/picohttp_ct.dir/picoquictest/hashtest.c.o CMakeFiles/picohttp_ct.dir/picoquictest/intformattest.c.o CMakeFiles/picohttp_ct.dir/picoquictest/multipath_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/netperf_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/parseheadertest.c.o CMakeFiles/picohttp_ct.dir/picoquictest/pn2pn64test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/sacktest.c.o CMakeFiles/picohttp_ct.dir/picoquictest/skip_frame_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/socket_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/splay_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/stream0_frame_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/stresstest.c.o CMakeFiles/picohttp_ct.dir/picoquictest/ticket_store_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/tls_api_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/transport_param_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/util_test.c.o CMakeFiles/picohttp_ct.dir/picoquictest/h3zerotest.c.o  -o picohttp_ct  -Wl,-rpath,/home/ubuntu/projects/http-3-test-env-real/src/picoquic/3rdparty/picoquic/repo/../../../../openssl/client/3rdparty/openssllib/lib  libpicoquic-log.a  libpicoquic-core.a  libpicohttp-core.a  ../../../picotls/repo/build/openssl/libpicotls-core.a  ../../../picotls/repo/build/openssl/libpicotls-openssl.a  ../../../../../openssl/client/3rdparty/openssllib/lib/libssl.so  -lcrypto  -ldl  -lpthread && :
/usr/bin/ld: CMakeFiles/picohttp_ct.dir/picoquictest/h3zerotest.c.o:/home/ubuntu/projects/http-3-test-env-real/src/picoquic/3rdparty/picoquic/repo/build/../picoquictest/h3zerotest.c:2072: multiple definition of `picohttp_test_multifile_number'; CMakeFiles/picohttp_ct.dir/picohttp_t/picohttp_t.c.o:/home/ubuntu/projects/http-3-test-env-real/src/picoquic/3rdparty/picoquic/repo/build/../picohttp_t/picohttp_t.c:32: first defined here
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

Additional some formatting