### PR TITLE
Isolate crypto ops

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -462,9 +462,9 @@ int picoquic_set_cipher_suite(picoquic_quic_t* quic, int cipher_suite_id);
 
 /* Set key exchange algorithms, for tests.
  * 0: default values
- * 20: ptls_openssl_x25519
- * 128: ptls_openssl_secp256r1
- * 256: ptls_openssl_secp256r1
+ * 20: x25519
+ * 128: secp256r1
+ * 256: secp256r1
  * returns 0 if OK, -1 if the specified ciphersuite is not supported.
  */
 int picoquic_set_key_exchange(picoquic_quic_t* quic, int key_exchange_id);

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -164,7 +164,9 @@ uint8_t * picoquic_esni_nonce(picoquic_cnx_t * cnx);
 /* Define hash functions here so applications don't need to directly interface picotls */
 #define PICOQUIC_HASH_SIZE_MAX 64
 void * picoquic_hash_create(char const * algorithm_name);
+#if 0
 size_t picoquic_hash_get_length(char const* algorithm_name);
+#endif
 void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context);
 void picoquic_hash_finalize(uint8_t* output, void* hash_context);
 
@@ -174,6 +176,14 @@ void * picoquic_find_retry_protection_context(picoquic_cnx_t * cnx, int sending)
 void picoquic_delete_retry_protection_contexts(picoquic_quic_t * quic);
 size_t picoquic_encode_retry_protection(void * integrity_aead, uint8_t * bytes, size_t bytes_max, size_t byte_index, const picoquic_connection_id_t * odcid);
 int picoquic_verify_retry_protection(void * integrity_aead, uint8_t * bytes, size_t * length, size_t byte_index, const picoquic_connection_id_t * odcid);
+
+/* Exportable definition of ciphersuites */
+void* picoquic_get_cipher_suite_by_id_v(int cipher_suite_id);
+
+/* Exportable version of ciphersuite definition for AES128GCM SHA256 ciphersuite */
+void* picoquic_get_aes128gcm_sha256_v();
+
+void* picoquic_get_aes128gcm_v();
 
 /* AES ECB function used for CID encryption */
 void* picoquic_aes128_ecb_create(int is_enc, const void* ecb_key);

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -170,6 +170,10 @@ size_t picoquic_hash_get_length(char const* algorithm_name);
 void picoquic_hash_update(uint8_t* input, size_t input_length, void* hash_context);
 void picoquic_hash_finalize(uint8_t* output, void* hash_context);
 
+uint8_t* picoquic_get_private_key_from_key_file(char const* file_name, int* key_length);
+ptls_iovec_t* picoquic_get_certs_from_file(char const* file_name, size_t * count);
+
+
 /* Special AEAD context definition functions used for stateless retry integrity protection */
 void * picoquic_create_retry_protection_context(int is_enc, uint8_t * key);
 void * picoquic_find_retry_protection_context(picoquic_cnx_t * cnx, int sending);


### PR DESCRIPTION
Isolate the crypto dependencies in "tls_api.c", group them in a block at the beginning of that file. It is now the only code file that needs a reference to the openssl libraries, or to the openssl module of picotls.

The API still needs work. The functions listed now include overlaps and redundancies, the design should be unified, etc. But this is a step towards better modularity.

This is meant to facilitate the design of the crypto provider API in PR #1059 

