### PR TITLE
Add support for 0RTT-BDP extension

### DIFF
--- a/loglib/qlog.c
+++ b/loglib/qlog.c
@@ -304,6 +304,27 @@ int qlog_transport_extensions(FILE* f, bytestream* s, size_t tp_length)
                 case picoquic_tp_grease_quic_bit:
                     qlog_boolean_transport_extension(f, "grease_quic_bit", s, extension_length);
                     break;
+                case picoquic_tp_recon_bytes_in_flight:
+                    qlog_vint_transport_extension(f, "recon_bytes_in_flight", s, extension_length);
+                    break;
+                case picoquic_tp_recon_min_rtt:
+                    qlog_vint_transport_extension(f, "recon_bytes_min_rtt", s, extension_length);
+                    break;
+                case picoquic_tp_recon_max_pkt_number:
+                    qlog_vint_transport_extension(f, "recon_max_pkt_number", s, extension_length);
+                    break;
+                case picoquic_tp_recon_cwin:
+                    qlog_vint_transport_extension(f, "recon_cwin", s, extension_length);
+                    break;
+                case picoquic_tp_recon_rtt_variant:
+                    qlog_vint_transport_extension(f, "recon_rtt_variant", s, extension_length);
+                    break;
+                case picoquic_tp_recon_smoothed_rtt:
+                    qlog_vint_transport_extension(f, "recon_smoothed_rtt", s, extension_length);
+                    break;
+                case picoquic_tp_recon_max_ack_delay:
+                    qlog_vint_transport_extension(f, "recon_max_ack_delay", s, extension_length);
+                    break;
                 default:
                     /* dump unknown extensions */
                     fprintf(f, "\"%" PRIx64 "\": ", extension_type);

--- a/picoquic/logger.c
+++ b/picoquic/logger.c
@@ -445,6 +445,27 @@ char const* picoquic_log_tp_name(uint64_t tp_number)
     case picoquic_tp_grease_quic_bit:
         tp_name = "grease_quic_bit";
         break;
+    case picoquic_tp_recon_bytes_in_flight:
+        tp_name = "recon_bytes_in_flight";
+        break;
+    case picoquic_tp_recon_min_rtt:
+        tp_name = "recon_min_rtt";
+        break;
+    case picoquic_tp_recon_max_pkt_number:
+        tp_name = "recon_max_pkt_number";
+        break;
+    case picoquic_tp_recon_cwin:
+        tp_name = "recon_cwin";
+        break;
+    case picoquic_tp_recon_rtt_variant:
+        tp_name = "recon_rtt_variant";
+        break;
+    case picoquic_tp_recon_smoothed_rtt:
+        tp_name = "recon_smoothed_rtt";
+        break;
+    case picoquic_tp_recon_max_ack_delay:
+        tp_name = "recon_max_ack_delay";
+        break;
     default:
         break;
     }

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -235,6 +235,13 @@ typedef struct st_picoquic_tp_t {
     int enable_time_stamp; /* (x&1) want, (x&2) can */
     uint64_t min_ack_delay;
     int do_grease_quic_bit;
+    uint64_t recon_bytes_in_flight;
+    uint64_t recon_min_rtt;
+    uint64_t recon_max_pkt_number;
+    uint64_t recon_cwin;
+    uint64_t recon_rtt_variant;
+    uint64_t recon_smoothed_rtt;
+    uint64_t recon_max_ack_delay;
 } picoquic_tp_t;
 
 /*


### PR DESCRIPTION
**SUMMARY**
This implements 0RTT-BDP extension: a generic method to exchange path parameters related to transport. This aims at improving traffic delivery by means of allowing the connection to short-cut slow RTT-based processes that grow connection parameters. If necessary, please see [here ](https://tools.ietf.org/html/draft-kuhn-quic-0rtt-bdp-07)for futher details about this ietf draft.

**CHANGES**
Following components have been modified:
- Core library (picoquic)
- Test program (picoquicfirts)

**DEPENDENCIES**
You will need a specific version of Picotls for testing this feature. This PicoTLS version allows to dynamically add bdp parameters as TLS extension in New Session Ticket message which now can be sent multiple times during a session. This version is currently under review and available [here ](https://github.com/h2o/picotls/pull/328).

