### PR TITLE
harden and reseed public random

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2693,6 +2693,7 @@ void picoquic_ready_state_transition(picoquic_cnx_t* cnx, uint64_t current_time)
     picoquic_implicit_handshake_ack(cnx, picoquic_packet_context_handshake, current_time);
 
     (void)picoquic_register_net_secret(cnx);
+    picoquic_public_random_seed(cnx->quic);
 
     if (!cnx->client_mode) {
         (void)picoquic_queue_handshake_done_frame(cnx);


### PR DESCRIPTION
Close #1075 

Add an obfuscation step to the public random generator.

Reseed the public random generator when connection establishment completes.