### PR TITLE
Only issue closed callback if disconnected

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2812,9 +2812,7 @@ uint8_t * picoquic_format_connection_close_frame(picoquic_cnx_t* cnx,
 
 const uint8_t* picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max)
 {
-    uint64_t error_code = 0;
-    bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &error_code);
-    cnx->remote_error = (uint16_t)error_code;
+    bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &cnx->remote_error);
 
     if (bytes == NULL ||
         (bytes = picoquic_frames_varint_skip(bytes, bytes_max)) == NULL ||
@@ -2858,9 +2856,7 @@ uint8_t * picoquic_format_application_close_frame(picoquic_cnx_t* cnx,
 
 const uint8_t* picoquic_decode_application_close_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max)
 {
-    uint64_t error_code = 0;
-    bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &error_code);
-    cnx->remote_application_error = (uint16_t)error_code;
+    bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &cnx->remote_application_error);
 
     if (bytes == NULL ||
         /* TODO, maybe: skip frame type for compatibility with draft-13 */

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2824,9 +2824,10 @@ const uint8_t* picoquic_decode_connection_close_frame(picoquic_cnx_t* cnx, const
             picoquic_frame_type_connection_close);
     }
     else {
+        picoquic_state_enum old_state = cnx->cnx_state;
         cnx->cnx_state = (cnx->cnx_state < picoquic_state_client_ready_start || cnx->crypto_context[picoquic_epoch_1rtt].aead_decrypt == NULL) ? picoquic_state_disconnected : picoquic_state_closing_received;
 
-        if (cnx->callback_fn) {
+        if (cnx->callback_fn != NULL && cnx->cnx_state != old_state && cnx->cnx_state == picoquic_state_disconnected) {
             (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
         }
     }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -764,6 +764,7 @@ int picoquic_incoming_version_negotiation(
                 }
                 /* TODO: consider rewriting the version negotiation code */
                 DBG_PRINTF("%s", "Disconnect upon receiving version negotiation.\n");
+                cnx->remote_error = PICOQUIC_ERROR_VERSION_NEGOTIATION;
                 cnx->cnx_state = picoquic_state_disconnected;
                 ret = 0;
             }
@@ -1460,6 +1461,9 @@ int picoquic_incoming_stateless_reset(
     picoquic_cnx_t* cnx)
 {
     /* Stateless reset. The connection should be abandonned */
+    if (cnx->cnx_state <= picoquic_state_ready) {
+        cnx->remote_error = PICOQUIC_ERROR_STATELESS_RESET;
+    }
     cnx->cnx_state = picoquic_state_disconnected;
 
     if (cnx->callback_fn) {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -90,6 +90,11 @@ extern "C" {
 #define PICOQUIC_NO_ERROR_SIMULATE_NAT (PICOQUIC_ERROR_CLASS + 48)
 #define PICOQUIC_NO_ERROR_SIMULATE_MIGRATION (PICOQUIC_ERROR_CLASS + 49)
 #define PICOQUIC_ERROR_VERSION_NOT_SUPPORTED (PICOQUIC_ERROR_CLASS + 50)
+#define PICOQUIC_ERROR_IDLE_TIMEOUT (PICOQUIC_ERROR_CLASS + 51)
+#define PICOQUIC_ERROR_REPEAT_TIMEOUT (PICOQUIC_ERROR_CLASS + 52)
+#define PICOQUIC_ERROR_HANDSHAKE_TIMEOUT (PICOQUIC_ERROR_CLASS + 53)
+#define PICOQUIC_ERROR_SOCKET_ERROR (PICOQUIC_ERROR_CLASS + 54)
+#define PICOQUIC_ERROR_VERSION_NEGOTIATION (PICOQUIC_ERROR_CLASS + 54)
 
 /*
  * Protocol errors defined in the QUIC spec
@@ -180,7 +185,7 @@ typedef struct st_ptls_iovec_t ptls_iovec_t;
 
 /* Detect whether error occured in TLS
  */
-int picoquic_is_handshake_error(uint16_t error_code);
+int picoquic_is_handshake_error(uint64_t error_code);
 
 
 typedef struct st_picoquic_quic_t picoquic_quic_t;
@@ -392,6 +397,11 @@ int picoquic_esni_load_key(picoquic_quic_t * quic, char const * esni_key_file_na
 /* Set the ESNI RR. Must be called after setting the ESNI key at least once. */
 int picoquic_esni_server_setup(picoquic_quic_t * quic, char const * esni_rr_file_name);
 
+/* Obtain the reasons why a connection was closed */
+void picoquic_get_close_reasons(picoquic_cnx_t* cnx, uint16_t* local_reason,
+    uint16_t* remote_reason, uint16_t* local_application_reason,
+    uint16_t* remote_application_reason);
+
 /* Will be called to verify that the given data corresponds to the given signature.
  * This callback and the `verify_ctx` will be set by the `verify_certificate_cb_fn`.
  * If `data` and `sign` are empty buffers, an error occurred and `verify_ctx` should be freed.
@@ -546,7 +556,7 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx);
 
 int picoquic_esni_client_from_file(picoquic_cnx_t * cnx, char const * esni_rr_file_name);
 
-int picoquic_close(picoquic_cnx_t* cnx, uint16_t reason_code);
+int picoquic_close(picoquic_cnx_t* cnx, uint16_t application_reason_code);
 
 int picoquic_probe_new_path(picoquic_cnx_t* cnx, const struct sockaddr* addr_from,
     const struct sockaddr* addr_to, uint64_t current_time);
@@ -818,10 +828,13 @@ void picoquic_disable_keep_alive(picoquic_cnx_t* cnx);
 int picoquic_is_client(picoquic_cnx_t* cnx);
 
 /* Returns the local error of the given connection context. */
-int picoquic_get_local_error(picoquic_cnx_t* cnx);
+uint64_t picoquic_get_local_error(picoquic_cnx_t* cnx);
 
 /* Returns the remote error of the given connection context. */
-int picoquic_get_remote_error(picoquic_cnx_t* cnx);
+uint64_t picoquic_get_remote_error(picoquic_cnx_t* cnx);
+
+/* Returns the application error after application close */
+uint64_t picoquic_get_application_error(picoquic_cnx_t* cnx);
 
 /* Returns the remote error for the given stream. */
 uint64_t picoquic_get_remote_stream_error(picoquic_cnx_t* cnx, uint64_t stream_id);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -981,10 +981,10 @@ typedef struct st_picoquic_cnx_t {
     struct st_picoquic_net_icid_key_t* net_icid_key;
     struct st_picoquic_net_secret_key_t* reset_secret_key;
     uint64_t start_time;
-    uint16_t application_error;
-    uint16_t local_error;
-    uint16_t remote_application_error;
-    uint16_t remote_error;
+    uint64_t application_error;
+    uint64_t local_error;
+    uint64_t remote_application_error;
+    uint64_t remote_error;
     uint64_t offending_frame_type;
     uint16_t retry_token_length;
     uint8_t * retry_token;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1431,6 +1431,7 @@ void picoquic_notify_destination_unreachable(picoquic_cnx_t* cnx, uint64_t curre
             if (no_path_left) {
                 picoquic_log_app_message(cnx, "Deleting connection after error on path %d,  socket error %d, if %d", path_id, socket_err, if_index);
                 cnx->cnx_state = picoquic_state_disconnected;
+                cnx->local_error = PICOQUIC_ERROR_SOCKET_ERROR;
                 if (cnx->callback_fn) {
                     (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
                 }
@@ -3243,7 +3244,7 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
     }
 }
 
-int picoquic_is_handshake_error(uint16_t error_code)
+int picoquic_is_handshake_error(uint64_t error_code)
 {
     return ((error_code & 0xFF00) == PICOQUIC_TRANSPORT_CRYPTO_ERROR(0) ||
         error_code == PICOQUIC_TLS_HANDSHAKE_FAILED);
@@ -3469,14 +3470,21 @@ int picoquic_is_client(picoquic_cnx_t* cnx)
     return cnx->client_mode;
 }
 
-int picoquic_get_local_error(picoquic_cnx_t* cnx)
+/* Retrieve the error codes after failure of a connection or of a stream */
+
+uint64_t picoquic_get_local_error(picoquic_cnx_t* cnx)
 {
     return cnx->local_error;
 }
 
-int picoquic_get_remote_error(picoquic_cnx_t* cnx)
+uint64_t picoquic_get_remote_error(picoquic_cnx_t* cnx)
 {
     return cnx->remote_error;
+}
+
+uint64_t picoquic_get_application_error(picoquic_cnx_t* cnx)
+{
+    return cnx->remote_application_error;
 }
 
 uint64_t picoquic_get_remote_stream_error(picoquic_cnx_t* cnx, uint64_t stream_id)

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2585,6 +2585,8 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
     } else if (ret == 0 && (cnx->cnx_state == picoquic_state_disconnecting || 
         cnx->cnx_state == picoquic_state_handshake_failure || 
         cnx->cnx_state == picoquic_state_handshake_failure_resend)) {
+        picoquic_state_enum old_state = cnx->cnx_state;
+
         length = picoquic_predict_packet_header_length(
             cnx, packet_type);
         bytes_next = bytes + length;
@@ -2634,7 +2636,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
         SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
         cnx->pkt_ctx[pc].ack_needed = 0;
 
-        if (cnx->callback_fn) {
+        if (cnx->callback_fn != NULL && cnx->cnx_state != old_state && cnx->cnx_state == picoquic_state_disconnected) {
             (void)(cnx->callback_fn)(cnx, 0, NULL, 0, picoquic_callback_close, cnx->callback_ctx, NULL);
         }
     }

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -669,6 +669,21 @@ int quic_client(const char* ip_address_text, int server_port,
     }
 
     if (ret == 0) {
+        uint64_t last_err;
+        
+        if ((last_err = picoquic_get_local_error(cnx_client)) != 0) {
+            fprintf(stdout, "Connection end with local error 0x%" PRIx64 ".\n", last_err);
+            ret = -1;
+        }
+        if ((last_err = picoquic_get_remote_error(cnx_client)) != 0) {
+            fprintf(stdout, "Connection end with remote error 0x%" PRIx64 ".\n", last_err);
+            ret = -1;
+        }
+        if ((last_err = picoquic_get_application_error(cnx_client)) != 0) {
+            fprintf(stdout, "Connection end with application error 0x%" PRIx64 ".\n", last_err);
+            ret = -1;
+        }
+
         /* Report on successes and failures */
         if (cnx_client->nb_zero_rtt_sent != 0) {
             fprintf(stdout, "Out of %d zero RTT packets, %d were acked by the server.\n",

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -651,7 +651,7 @@ static int stress_handle_packet_prepare(picoquic_stress_ctx_t * ctx, picoquic_qu
                     ret = 0;
                     if (c_ctx != NULL) {
                         if (simulate_disconnect == 0 && (
-                            c_ctx->next_bidir <= c_ctx->max_bidir ||
+                            c_ctx->next_bidir < c_ctx->max_bidir ||
                             c_ctx->nb_open_streams != 0)) {
                             ret = stress_debug_break(0);
                         }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2104,7 +2104,7 @@ int tls_api_wrong_alpn_test()
                     ret = 0;
                 }
                 else {
-                    DBG_PRINTF("Connection loop returns 0x%x\n", test_ctx->cnx_client->remote_error);
+                    DBG_PRINTF("Connection loop returns 0x%" PRIx64, test_ctx->cnx_client->remote_error);
                     ret = -1;
                 }
             }
@@ -5763,16 +5763,16 @@ int server_busy_test()
 
         if (test_ctx->cnx_server != NULL &&
             test_ctx->cnx_server->cnx_state != picoquic_state_disconnected) {
-            DBG_PRINTF("Server state: %d, local error: %x\n", test_ctx->cnx_server->cnx_state, test_ctx->cnx_server->local_error);
+            DBG_PRINTF("Server state: %d, local error: %" PRIx64, test_ctx->cnx_server->cnx_state, test_ctx->cnx_server->local_error);
             ret = -1;
         }
         else if (test_ctx->cnx_client->cnx_state != picoquic_state_disconnected ||
             test_ctx->cnx_client->remote_error != PICOQUIC_TRANSPORT_SERVER_BUSY) {
-            DBG_PRINTF("Client state: %d, remote error: %x", test_ctx->cnx_client->cnx_state, test_ctx->cnx_client->remote_error);
+            DBG_PRINTF("Client state: %d, remote error: %" PRIx64, test_ctx->cnx_client->cnx_state, test_ctx->cnx_client->remote_error);
             ret = -1;
         }
         else if (simulated_time > 50000ull) {
-            DBG_PRINTF("Simulated time: %llu", (unsigned long long)simulated_time);
+            DBG_PRINTF("Simulated time: %" PRIu64, (unsigned long long)simulated_time);
             ret = -1;
         }
     }

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -656,7 +656,7 @@ int transport_param_decode_test(int mode, uint32_t version, uint32_t proposed_ve
     return ret;
 }
 
-int transport_param_error_test(int mode, uint8_t* target, size_t target_length, uint16_t local_error)
+int transport_param_error_test(int mode, uint8_t* target, size_t target_length, uint64_t local_error)
 {
     int ret = 0;
     picoquic_quic_t * quic_ctx = NULL;


### PR DESCRIPTION
This appears to be the least intrusive way to close issue #1074. The current code is confusing, because the "connection closed" callback can happen before the last packets for the connection can be sent or received. With this change, the callback is only issued once per connection, when the connection is disconnected.