### PR TITLE
Fix local computation of ack gap

### DIFF
--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -85,6 +85,7 @@ static option_table_line_t option_table[] = {
     "send a large client hello in order to test post quantum readiness" },
     { picoquic_option_Ticket_File_Name, 'T', "ticket_file", 1, "file", "File storing the session tickets" },
     { picoquic_option_Token_File_Name, 'N', "token_file", 1, "file", "File storing the new tokens" },
+    { picoquic_option_Small_SO_buffers, 'B', "small_so_buf", 0, "", "Do not use large SO_SNDBUF SO_RCVBUF" },
     { picoquic_option_HELP, 'h', "help", 0, "This help message" }
 };
 
@@ -443,6 +444,9 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
         break;
     case picoquic_option_Token_File_Name:
         ret = config_set_string_param(&config->token_file_name, params, nb_params, 0);
+        break;
+    case picoquic_option_Small_SO_buffers:
+        config->use_small_so_buffers = 1;
         break;
     case picoquic_option_HELP:
         ret = -1;

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1889,7 +1889,7 @@ int picoquic_incoming_1rtt(
                 }
                 else {
                     uint64_t delta = current_time - cnx->path[path_id]->receive_rate_epoch;
-                    if (delta > path_x->smoothed_rtt&& delta > PICOQUIC_BANDWIDTH_TIME_INTERVAL_MIN) {
+                    if (delta > path_x->smoothed_rtt && delta > PICOQUIC_BANDWIDTH_TIME_INTERVAL_MIN) {
                         path_x->receive_rate_estimate = ((cnx->path[path_id]->received - cnx->path[path_id]->received_prior) * 1000000) / delta;
                         path_x->received_prior = cnx->path[path_id]->received;
                         path_x->receive_rate_epoch = current_time;

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -64,6 +64,7 @@ typedef enum {
     picoquic_option_LARGE_CLIENT_HELLO,
     picoquic_option_Ticket_File_Name,
     picoquic_option_Token_File_Name,
+    picoquic_option_Small_SO_buffers,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -91,6 +92,7 @@ typedef struct st_picoquic_quic_config_t {
     /* Common flags */
     unsigned int initial_random : 1;
     unsigned int use_long_log : 1;
+    unsigned int use_small_so_buffers : 1;
     /* Server only */
     char const* www_dir;
     uint64_t reset_seed[2];

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -71,8 +71,7 @@ extern "C" {
 
 #define PICOQUIC_BANDWIDTH_ESTIMATE_MAX 10000000000ull /* 10 GB per second */
 #define PICOQUIC_BANDWIDTH_TIME_INTERVAL_MIN 1000
-#define PICOQUIC_BANDWIDTH_MEDIUM 2000000 /* 16 Mbps, threshold for coalescing 10 packets per ACK */
-#define PICOQUIC_BANDWIDTH_MEDIUM 2000000 /* 16 Mbps, threshold for coalescing 10 packets per ACK */
+#define PICOQUIC_BANDWIDTH_MEDIUM 2000000 /* 16 Mbps, threshold for coalescing 10 packets per ACK with long delays */
 #define PICOQUIC_MAX_BANDWIDTH_TIME_INTERVAL_MIN 1000
 #define PICOQUIC_MAX_BANDWIDTH_TIME_INTERVAL_MAX 15000
 

--- a/picoquic/picoquic_packet_loop.h
+++ b/picoquic/picoquic_packet_loop.h
@@ -44,6 +44,7 @@ int picoquic_packet_loop(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
+    int use_small_so_buffers,
     picoquic_packet_loop_cb_fn loop_callback,
     void * loop_callback_ctx);
 
@@ -52,6 +53,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
+    int use_small_so_buffers,
     picoquic_packet_loop_cb_fn loop_callback,
     void* loop_callback_ctx);
 #endif

--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -135,10 +135,11 @@ typedef struct st_picoquic_recvmsg_async_ctx_t {
     size_t udp_coalesced_size;
     int nb_immediate_receive;
     int bytes_recv;
+    int so_sndbuf;
+    int so_rcvbuf;
     unsigned int is_started : 1;
     unsigned int supports_udp_send_coalesced : 1;
     unsigned int supports_udp_recv_coalesced : 1;
-
 } picoquic_recvmsg_async_ctx_t;
 
 //

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2691,7 +2691,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
         cnx->ack_frequency_delay_local = PICOQUIC_ACK_DELAY_MAX_DEFAULT;
         cnx->ack_frequency_sequence_remote = UINT64_MAX;
         cnx->ack_gap_remote = 2;
-        cnx->ack_delay_remote = PICOQUIC_ACK_DELAY_MAX_DEFAULT;
+        cnx->ack_delay_remote = PICOQUIC_ACK_DELAY_MIN;
 
         picosplay_init_tree(&cnx->stream_tree, picoquic_stream_node_compare, picoquic_stream_node_create, picoquic_stream_node_delete, picoquic_stream_node_value);
 

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -150,7 +150,7 @@ int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE 
         }
         else {
             if (!use_small_so_buffers) {
-                int opt_len;
+                socklen_t opt_len;
                 int opt_ret;
                 int so_sndbuf;
                 int so_rcvbuf;
@@ -169,7 +169,8 @@ int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE 
                 }
                 opt_len = sizeof(int);
                 so_rcvbuf = 655360;
-                opt_ret = setsockopt(s_socket[i], SOL_SOCKET, SO_RCVBUF, (const char*)&so_rcvbuf, opt_len); if (opt_ret != 0) {
+                opt_ret = setsockopt(s_socket[i], SOL_SOCKET, SO_RCVBUF, (const char*)&so_rcvbuf, opt_len);
+                if (opt_ret != 0) {
 #ifdef _WINDOWS
                     int sock_error = WSAGetLastError();
 #else

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -109,7 +109,8 @@ static int udp_gso_available = 0;
 #endif
 #endif
 
-int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE * s_socket, int * sock_af, int nb_sockets_max)
+int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE * s_socket, int * sock_af, 
+    int use_small_so_buffers, int nb_sockets_max)
 {
     int nb_sockets = (local_af == AF_UNSPEC) ? 2 : 1;
 
@@ -147,6 +148,38 @@ int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE 
             nb_sockets = 0;
             break;
         }
+        else {
+            if (!use_small_so_buffers) {
+                int opt_len;
+                int opt_ret;
+                int so_sndbuf;
+                int so_rcvbuf;
+
+                opt_len = sizeof(int);
+                so_sndbuf = 655360;
+                opt_ret = setsockopt(s_socket[i], SOL_SOCKET, SO_SNDBUF, (const char*)&so_sndbuf, opt_len);
+                if (opt_ret != 0) {
+#ifdef _WINDOWS
+                    int sock_error = WSAGetLastError();
+#else
+                    int sock_error = errno;
+#endif
+                    opt_ret = getsockopt(s_socket[i], SOL_SOCKET, SO_SNDBUF, (char*)&so_sndbuf, &opt_len);
+                    DBG_PRINTF("Cannot set SO_SNDBUF, err=%d, so_sndbuf=%d (%d)", sock_error, so_sndbuf, opt_ret);
+                }
+                opt_len = sizeof(int);
+                so_rcvbuf = 655360;
+                opt_ret = setsockopt(s_socket[i], SOL_SOCKET, SO_RCVBUF, (const char*)&so_rcvbuf, opt_len); if (opt_ret != 0) {
+#ifdef _WINDOWS
+                    int sock_error = WSAGetLastError();
+#else
+                    int sock_error = errno;
+#endif
+                    opt_ret = getsockopt(s_socket[i], SOL_SOCKET, SO_RCVBUF, (char*)&so_rcvbuf, &opt_len);
+                    DBG_PRINTF("Cannot set SO_RCVBUF, err=%d, so_rcvbuf=%d (%d)", sock_error, so_rcvbuf, opt_ret);
+                }
+            }
+        }
     }
 
     return nb_sockets;
@@ -156,6 +189,7 @@ int picoquic_packet_loop(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
+    int use_small_so_buffers,
     picoquic_packet_loop_cb_fn loop_callback,
     void* loop_callback_ctx)
 {
@@ -188,7 +222,7 @@ int picoquic_packet_loop(picoquic_quic_t* quic,
 #endif
     memset(sock_af, 0, sizeof(sock_af));
 
-    if ((nb_sockets = picoquic_packet_loop_open_sockets(local_port, local_af, s_socket, sock_af, PICOQUIC_PACKET_LOOP_SOCKETS_MAX)) == 0) {
+    if ((nb_sockets = picoquic_packet_loop_open_sockets(local_port, local_af, s_socket, sock_af, use_small_so_buffers, PICOQUIC_PACKET_LOOP_SOCKETS_MAX)) == 0) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
     }
     else if (loop_callback != NULL) {
@@ -389,7 +423,7 @@ int picoquic_packet_loop(picoquic_quic_t* quic,
             int testing_nat = (ret == PICOQUIC_NO_ERROR_SIMULATE_NAT);
             
             next_port = (testing_nat) ? 0 : socket_port + 1;
-            sock_ret = picoquic_packet_loop_open_sockets(next_port, sock_af[0], &s_mig, &s_mig_af, 1);
+            sock_ret = picoquic_packet_loop_open_sockets(next_port, sock_af[0], &s_mig, &s_mig_af, use_small_so_buffers, 1);
             if (sock_ret != 1 || s_mig == INVALID_SOCKET) {
                 if (last_cnx != NULL) {
                     picoquic_log_app_message(last_cnx, "Could not create socket for migration test, port=%d, af=%d, err=%d",

--- a/picoquic/winsockloop.c
+++ b/picoquic/winsockloop.c
@@ -170,7 +170,24 @@ int picoquic_packet_loop_open_sockets_win(int local_port, int local_af,
                 break;
             }
             else {
+                int opt_len;
+                int opt_ret;
                 events[i] = sock_ctx[i]->overlap.hEvent;
+                opt_len = sizeof(int);
+                sock_ctx[i]->so_sndbuf = 655360;
+                opt_ret = setsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_SNDBUF, (const char*)&sock_ctx[i]->so_sndbuf, opt_len);
+                if (opt_ret != 0) {
+                    int sock_error = WSAGetLastError();
+                    opt_ret = getsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_SNDBUF, (char*)&sock_ctx[i]->so_sndbuf, &opt_len);
+                    DBG_PRINTF("Cannot set SO_SNDBUF, err=%d, so_sndbuf=%d (%d)", sock_error, sock_ctx[i]->so_sndbuf, ret);
+                }
+                opt_len = sizeof(int);
+                sock_ctx[i]->so_rcvbuf = 655360;
+                opt_ret = setsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_RCVBUF, (const char*)&sock_ctx[i]->so_rcvbuf, opt_len); if (opt_ret != 0) {
+                    int sock_error = WSAGetLastError();
+                    opt_ret = getsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_RCVBUF, (char*)&sock_ctx[i]->so_rcvbuf, &opt_len);
+                    DBG_PRINTF("Cannot set SO_RCVBUF, err=%d, so_rcvbuf=%d (%d)", sock_error, sock_ctx[i]->so_rcvbuf, ret);
+                }
             }
         }
     }

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -193,9 +193,11 @@ int quic_server(const char* server_name, picoquic_quic_config_t * config,
     if (ret == 0) {
         /* Wait for packets */
 #if _WINDOWS
-        ret = picoquic_packet_loop_win(qserver, config->server_port, 0, config->dest_if, server_loop_cb, &loop_cb_ctx);
+        ret = picoquic_packet_loop_win(qserver, config->server_port, 0, config->dest_if, 
+            config->use_small_so_buffers, server_loop_cb, &loop_cb_ctx);
 #else
-        ret = picoquic_packet_loop(qserver, config->server_port, 0, config->dest_if, server_loop_cb, &loop_cb_ctx);
+        ret = picoquic_packet_loop(qserver, config->server_port, 0, config->dest_if,
+            config->use_small_so_buffers, server_loop_cb, &loop_cb_ctx);
 #endif
     }
 
@@ -241,6 +243,7 @@ typedef struct st_client_loop_cb_t {
     int zero_rtt_available;
     int is_siduck;
     int is_quicperf;
+    int use_small_so_buffers;
     char const* saved_alpn;
     struct sockaddr_storage server_address;
     struct sockaddr_storage client_address;
@@ -622,6 +625,7 @@ int quic_client(const char* ip_address_text, int server_port,
         loop_cb.nb_packets_before_key_update = nb_packets_before_key_update;
         loop_cb.is_siduck = is_siduck;
         loop_cb.is_quicperf = is_quicperf;
+        loop_cb.use_small_so_buffers = config->use_small_so_buffers;
         if (is_siduck) {
             loop_cb.siduck_ctx = siduck_ctx;
         }
@@ -630,9 +634,11 @@ int quic_client(const char* ip_address_text, int server_port,
         }
 
 #ifdef _WINDOWS
-        ret = picoquic_packet_loop_win(qclient, 0, loop_cb.server_address.ss_family, 0, client_loop_cb, &loop_cb);
+        ret = picoquic_packet_loop_win(qclient, 0, loop_cb.server_address.ss_family, 0, 
+            config->use_small_so_buffers, client_loop_cb, &loop_cb);
 #else
-        ret = picoquic_packet_loop(qclient, 0, loop_cb.server_address.ss_family, 0, client_loop_cb, &loop_cb);
+        ret = picoquic_packet_loop(qclient, 0, loop_cb.server_address.ss_family, 0,
+            config->use_small_so_buffers, client_loop_cb, &loop_cb);
 #endif
     }
 

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:K:p:v:o:w:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:h";
+static char* ref_option_text = "c:k:K:p:v:o:w:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:Bh";
 
 int config_option_letters_test()
 {
@@ -66,6 +66,7 @@ static picoquic_quic_config_t param1 = {
     /* Common flags */
     1, /* unsigned int initial_random : 1; */
     1, /* unsigned int use_long_log : 1; */
+    1, /* int use_small_so_buffers */
     /* Server only */
     "/data/www/", /* char const* www_dir; */
     { 0x012345678abcdef, 0xfedcba9876543210}, /* uint64_t reset_seed[2]; */
@@ -109,6 +110,7 @@ static char const* config_argv1[] = {
     "-w", "/data/www/",
     "-r",
     "-s", "012345678abcdef", "0xfedcba9876543210",
+    "-B",
     NULL
 };
 
@@ -134,6 +136,7 @@ static picoquic_quic_config_t param2 = {
     /* Common flags */
     0, /* unsigned int initial_random : 1; */
     0, /* unsigned int use_long_log : 1; */
+    0, /* use_small_so_buffers */
     /* Server only */
     NULL, /* char const* www_dir; */
     {0, 0}, /* uint64_t reset_seed[2]; */

--- a/sample/sample_client.c
+++ b/sample/sample_client.c
@@ -547,7 +547,7 @@ int picoquic_sample_client(char const * server_name, int server_port, char const
     }
 
     /* Wait for packets */
-    ret = picoquic_packet_loop(quic, 0, server_address.ss_family, 0, sample_client_loop_cb, &client_ctx);
+    ret = picoquic_packet_loop(quic, 0, server_address.ss_family, 0, 0, sample_client_loop_cb, &client_ctx);
 
     /* Done. At this stage, we could print out statistics, etc. */
     sample_client_report(&client_ctx);

--- a/sample/sample_server.c
+++ b/sample/sample_server.c
@@ -410,7 +410,7 @@ int picoquic_sample_server(int server_port, const char* server_cert, const char*
 
     /* Wait for packets */
     if (ret == 0) {
-        ret = picoquic_packet_loop(quic, server_port, 0, 0, NULL, NULL);
+        ret = picoquic_packet_loop(quic, server_port, 0, 0, 0, NULL, NULL);
     }
 
     /* And finish. */


### PR DESCRIPTION
When doing performance testing between msquic client and picoquic server, we found that the throughput was about 500 Mbps, while we observed more than 2 Gbps between picoquic client and picoquic server on the same platform. Investigation shows that the picoquic client was sending way to many acknowledgements, which diminished the performance during high speed tests. This PR fixes that.