### PR TITLE
CLI parameter for socket buffer size

### DIFF
--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -85,7 +85,7 @@ static option_table_line_t option_table[] = {
     "send a large client hello in order to test post quantum readiness" },
     { picoquic_option_Ticket_File_Name, 'T', "ticket_file", 1, "file", "File storing the session tickets" },
     { picoquic_option_Token_File_Name, 'N', "token_file", 1, "file", "File storing the new tokens" },
-    { picoquic_option_Small_SO_buffers, 'B', "small_so_buf", 0, "", "Do not use large SO_SNDBUF SO_RCVBUF" },
+    { picoquic_option_Socket_buffer_size, 'B', "so_buf_size", 1, "number", "Set buffer size with SO_SNDBUF SO_RCVBUF" },
     { picoquic_option_HELP, 'h', "help", 0, "This help message" }
 };
 
@@ -445,8 +445,12 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
     case picoquic_option_Token_File_Name:
         ret = config_set_string_param(&config->token_file_name, params, nb_params, 0);
         break;
-    case picoquic_option_Small_SO_buffers:
-        config->use_small_so_buffers = 1;
+    case picoquic_option_Socket_buffer_size:
+        config->socket_buffer_size = config_atoi(params, nb_params, 0, &ret);
+        if (config->socket_buffer_size < 0 ) {
+            fprintf(stderr, "Invalid socket_buffer_size: %s\n", config_optval_param_string(opval_buffer, 256, params, nb_params, 0));
+            ret = -1;
+        }
         break;
     case picoquic_option_HELP:
         ret = -1;

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -64,7 +64,7 @@ typedef enum {
     picoquic_option_LARGE_CLIENT_HELLO,
     picoquic_option_Ticket_File_Name,
     picoquic_option_Token_File_Name,
-    picoquic_option_Small_SO_buffers,
+    picoquic_option_Socket_buffer_size,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -82,6 +82,7 @@ typedef struct st_picoquic_quic_config_t {
     int dest_if;
     int mtu_max;
     int cnx_id_length;
+    int socket_buffer_size;
     char const* cc_algo_id;
     picoquic_connection_id_callback_ctx_t* cnx_id_cbdata;
     /* TODO: control key logging */
@@ -92,7 +93,6 @@ typedef struct st_picoquic_quic_config_t {
     /* Common flags */
     unsigned int initial_random : 1;
     unsigned int use_long_log : 1;
-    unsigned int use_small_so_buffers : 1;
     /* Server only */
     char const* www_dir;
     uint64_t reset_seed[2];

--- a/picoquic/picoquic_packet_loop.h
+++ b/picoquic/picoquic_packet_loop.h
@@ -44,7 +44,7 @@ int picoquic_packet_loop(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
-    int use_small_so_buffers,
+    int socket_buffer_size,
     picoquic_packet_loop_cb_fn loop_callback,
     void * loop_callback_ctx);
 
@@ -53,7 +53,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
-    int use_small_so_buffers,
+    int socket_buffer_size,
     picoquic_packet_loop_cb_fn loop_callback,
     void* loop_callback_ctx);
 #endif

--- a/picoquic/winsockloop.c
+++ b/picoquic/winsockloop.c
@@ -40,7 +40,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
-    int use_small_so_buffers,
+    int socket_buffer_size,
     picoquic_packet_loop_cb_fn loop_callback,
     void* loop_callback_ctx)
 {
@@ -119,7 +119,7 @@ void picoquic_socks_win_coalescing_test(int * recv_coalesced, int * send_coalesc
 
 /* Open a set of sockets in asynch mode. */
 int picoquic_packet_loop_open_sockets_win(int local_port, int local_af, 
-    picoquic_recvmsg_async_ctx_t** sock_ctx, int * sock_af, int use_small_so_buffers, HANDLE * events,
+    picoquic_recvmsg_async_ctx_t** sock_ctx, int * sock_af, int socket_buffer_size, HANDLE * events,
     int nb_sockets_max)
 {
     int ret = 0;
@@ -174,21 +174,22 @@ int picoquic_packet_loop_open_sockets_win(int local_port, int local_af,
                 int opt_len;
                 int opt_ret;
                 events[i] = sock_ctx[i]->overlap.hEvent;
-                if (!use_small_so_buffers) {
+                if (socket_buffer_size > 0) {
                     opt_len = sizeof(int);
-                    sock_ctx[i]->so_sndbuf = 655360;
+                    sock_ctx[i]->so_sndbuf = socket_buffer_size;
                     opt_ret = setsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_SNDBUF, (const char*)&sock_ctx[i]->so_sndbuf, opt_len);
                     if (opt_ret != 0) {
                         int sock_error = WSAGetLastError();
                         opt_ret = getsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_SNDBUF, (char*)&sock_ctx[i]->so_sndbuf, &opt_len);
-                        DBG_PRINTF("Cannot set SO_SNDBUF, err=%d, so_sndbuf=%d (%d)", sock_error, sock_ctx[i]->so_sndbuf, opt_ret);
+                        DBG_PRINTF("Cannot set SO_SNDBUF to %d, err=%d, so_sndbuf=%d (%d)", socket_buffer_size, 
+                            sock_error, sock_ctx[i]->so_sndbuf, opt_ret);
                     }
                     opt_len = sizeof(int);
-                    sock_ctx[i]->so_rcvbuf = 655360;
+                    sock_ctx[i]->so_rcvbuf = socket_buffer_size;
                     opt_ret = setsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_RCVBUF, (const char*)&sock_ctx[i]->so_rcvbuf, opt_len); if (opt_ret != 0) {
                         int sock_error = WSAGetLastError();
                         opt_ret = getsockopt(sock_ctx[i]->fd, SOL_SOCKET, SO_RCVBUF, (char*)&sock_ctx[i]->so_rcvbuf, &opt_len);
-                        DBG_PRINTF("Cannot set SO_RCVBUF, err=%d, so_rcvbuf=%d (%d)", sock_error, sock_ctx[i]->so_rcvbuf, opt_ret);
+                        DBG_PRINTF("Cannot set SO_RCVBUF to %d, err=%d, so_rcvbuf=%d (%d)", socket_buffer_size, sock_error, sock_ctx[i]->so_rcvbuf, opt_ret);
                     }
                 }
             }
@@ -387,7 +388,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
     int local_port,
     int local_af,
     int dest_if,
-    int use_small_so_buffers,
+    int socket_buffer_size,
     picoquic_packet_loop_cb_fn loop_callback,
     void* loop_callback_ctx)
 {
@@ -412,7 +413,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
 
     /* Open the sockets */
     if ((nb_sockets = picoquic_packet_loop_open_sockets_win(
-        local_port, local_af, sock_ctx, sock_af, use_small_so_buffers, events, PICOQUIC_PACKET_LOOP_SOCKETS_MAX)) == 0) {
+        local_port, local_af, sock_ctx, sock_af, socket_buffer_size, events, PICOQUIC_PACKET_LOOP_SOCKETS_MAX)) == 0) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
     }
     else if (loop_callback != NULL) {
@@ -701,7 +702,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
             
             next_port = socket_port + 1;
             if (picoquic_packet_loop_open_sockets_win(next_port, sock_af[0], &sock_ctx_mig, &s_mig_af,
-                use_small_so_buffers, &mig_sock_event, 1) != 1){
+                socket_buffer_size, &mig_sock_event, 1) != 1){
                 if (last_cnx != NULL) {
                     picoquic_log_app_message(last_cnx, "Could not create socket for migration test, port=%d, af=%d",
                         next_port, sock_af[0]);

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -194,10 +194,10 @@ int quic_server(const char* server_name, picoquic_quic_config_t * config,
         /* Wait for packets */
 #if _WINDOWS
         ret = picoquic_packet_loop_win(qserver, config->server_port, 0, config->dest_if, 
-            config->use_small_so_buffers, server_loop_cb, &loop_cb_ctx);
+            config->socket_buffer_size, server_loop_cb, &loop_cb_ctx);
 #else
         ret = picoquic_packet_loop(qserver, config->server_port, 0, config->dest_if,
-            config->use_small_so_buffers, server_loop_cb, &loop_cb_ctx);
+            config->socket_buffer_size, server_loop_cb, &loop_cb_ctx);
 #endif
     }
 
@@ -243,7 +243,7 @@ typedef struct st_client_loop_cb_t {
     int zero_rtt_available;
     int is_siduck;
     int is_quicperf;
-    int use_small_so_buffers;
+    int socket_buffer_size;
     char const* saved_alpn;
     struct sockaddr_storage server_address;
     struct sockaddr_storage client_address;
@@ -625,7 +625,7 @@ int quic_client(const char* ip_address_text, int server_port,
         loop_cb.nb_packets_before_key_update = nb_packets_before_key_update;
         loop_cb.is_siduck = is_siduck;
         loop_cb.is_quicperf = is_quicperf;
-        loop_cb.use_small_so_buffers = config->use_small_so_buffers;
+        loop_cb.socket_buffer_size = config->socket_buffer_size;
         if (is_siduck) {
             loop_cb.siduck_ctx = siduck_ctx;
         }
@@ -635,10 +635,10 @@ int quic_client(const char* ip_address_text, int server_port,
 
 #ifdef _WINDOWS
         ret = picoquic_packet_loop_win(qclient, 0, loop_cb.server_address.ss_family, 0, 
-            config->use_small_so_buffers, client_loop_cb, &loop_cb);
+            config->socket_buffer_size, client_loop_cb, &loop_cb);
 #else
         ret = picoquic_packet_loop(qclient, 0, loop_cb.server_address.ss_family, 0,
-            config->use_small_so_buffers, client_loop_cb, &loop_cb);
+            config->socket_buffer_size, client_loop_cb, &loop_cb);
 #endif
     }
 

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:K:p:v:o:w:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:Bh";
+static char* ref_option_text = "c:k:K:p:v:o:w:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:h";
 
 int config_option_letters_test()
 {
@@ -58,6 +58,7 @@ static picoquic_quic_config_t param1 = {
     1, /* int dest_if; */
     1536, /* int mtu_max; */
     -1, /* int cnx_id_length; */
+    655360, /* Socket buffer size */
     "cubic", /* const picoquic_congestion_algorithm_t* cc_algorithm; */
     NULL, /* picoquic_connection_id_callback_ctx_t* cnx_id_cbdata; */
     3,
@@ -66,7 +67,6 @@ static picoquic_quic_config_t param1 = {
     /* Common flags */
     1, /* unsigned int initial_random : 1; */
     1, /* unsigned int use_long_log : 1; */
-    1, /* int use_small_so_buffers */
     /* Server only */
     "/data/www/", /* char const* www_dir; */
     { 0x012345678abcdef, 0xfedcba9876543210}, /* uint64_t reset_seed[2]; */
@@ -110,7 +110,7 @@ static char const* config_argv1[] = {
     "-w", "/data/www/",
     "-r",
     "-s", "012345678abcdef", "0xfedcba9876543210",
-    "-B",
+    "-B", "655360",
     NULL
 };
 
@@ -128,6 +128,7 @@ static picoquic_quic_config_t param2 = {
     0, /* int dest_if; */
     0, /* int mtu_max; */
     5, /* int cnx_id_length; */
+    0, /* socket_buffer_size */
     NULL, /* const picoquic_congestion_algorithm_t* cc_algorithm; */
     NULL, /* picoquic_connection_id_callback_ctx_t* cnx_id_cbdata; */
     0,
@@ -136,7 +137,6 @@ static picoquic_quic_config_t param2 = {
     /* Common flags */
     0, /* unsigned int initial_random : 1; */
     0, /* unsigned int use_long_log : 1; */
-    0, /* use_small_so_buffers */
     /* Server only */
     NULL, /* char const* www_dir; */
     {0, 0}, /* uint64_t reset_seed[2]; */
@@ -236,6 +236,7 @@ int config_test_compare(const picoquic_quic_config_t* expected, const picoquic_q
     ret |= config_test_compare_int("port", expected->server_port, actual->server_port);
     ret |= config_test_compare_int("dest_if", expected->dest_if, actual->dest_if);
     ret |= config_test_compare_int("mtu_max", expected->mtu_max, actual->mtu_max);
+    ret |= config_test_compare_int("socket_buffer_size", expected->socket_buffer_size, actual->socket_buffer_size);
     ret |= config_test_compare_string("cc_algo_id", expected->cc_algo_id, actual->cc_algo_id);
     ret |= config_test_compare_int("spinbit", expected->spinbit_policy, actual->spinbit_policy);
     ret |= config_test_compare_int("lossbit", expected->lossbit_policy, actual->lossbit_policy);


### PR DESCRIPTION
Allow the operator to state for example "-b 655360" to set SO_SNDBUF and SO_RCVBUF to that size. By default, use the system default.