### PR TITLE
Many stream lot of memory

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -484,49 +484,6 @@ static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
     return ret;
 }
 
-static void picoquic_demo_client_delete_stream_context(picoquic_demo_callback_ctx_t* ctx,
-    picoquic_demo_client_stream_ctx_t* stream_ctx)
-{
-    int removed_from_context = 0;
-
-    h3zero_delete_data_stream_state(&stream_ctx->stream_state);
-
-    if (stream_ctx->f_name != NULL) {
-        free(stream_ctx->f_name);
-        stream_ctx->f_name = NULL;
-    }
-
-    if (stream_ctx->F != NULL) {
-        DBG_PRINTF("Stream %" PRIu64 ", file close after %zu bytes\n", stream_ctx->stream_id, stream_ctx->received_length);
-        stream_ctx->F = picoquic_file_close(stream_ctx->F);
-    }
-
-    if (stream_ctx == ctx->first_stream) {
-        ctx->first_stream = stream_ctx->next_stream;
-        removed_from_context = 1;
-    }
-    else {
-        picoquic_demo_client_stream_ctx_t* previous = ctx->first_stream;
-
-        while (previous != NULL) {
-            if (previous->next_stream == stream_ctx) {
-                previous->next_stream = stream_ctx->next_stream;
-                removed_from_context = 1;
-                break;
-            }
-            else {
-                previous = previous->next_stream;
-            }
-        }
-    }
-
-    if (removed_from_context) {
-        ctx->nb_client_streams--;
-    }
-
-    free(stream_ctx);
-}
-
 static int picoquic_demo_client_close_stream(
     picoquic_demo_callback_ctx_t* ctx, picoquic_demo_client_stream_ctx_t* stream_ctx)
 {
@@ -707,7 +664,7 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
                         picoquic_log_app_message(cnx, "Stream %d ended after %d bytes, ret=0x%x",
                             (int)stream_id, (int)stream_ctx->received_length, ret);
                     }
-                    picoquic_demo_client_delete_stream_context(ctx, stream_ctx);
+
                 }
             }
         }
@@ -721,10 +678,9 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
         if (picoquic_demo_client_close_stream(ctx, stream_ctx)) {
             fin_stream_id = stream_id;
             if (!ctx->no_print) {
-                fprintf(stdout, "Stream %d reset after %d bytes\n",
-                    (int)stream_id, (int)stream_ctx->received_length);
+                fprintf(stdout, "Stream %" PRIu64 " reset after %zu bytes\n",
+                    stream_id, stream_ctx->received_length);
             }
-            picoquic_demo_client_delete_stream_context(ctx, stream_ctx);
         }
         picoquic_reset_stream(cnx, stream_id, 0);
         /* TODO: higher level notify? */
@@ -766,7 +722,6 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
             fin_stream_id = stream_id;
             fprintf(stdout, "Stream %d reset after %d bytes\n",
                 (int)stream_id, (int)stream_ctx->received_length);
-            picoquic_demo_client_delete_stream_context(ctx, stream_ctx);
         }
         /* TODO: Define what error. Stop sending? */
         picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
@@ -821,6 +776,50 @@ int picoquic_demo_client_initialize_context(
     ctx->delay_fin = delay_fin;
 
     return 0;
+}
+
+
+static void picoquic_demo_client_delete_stream_context(picoquic_demo_callback_ctx_t* ctx,
+    picoquic_demo_client_stream_ctx_t * stream_ctx)
+{
+    int removed_from_context = 0;
+
+    h3zero_delete_data_stream_state(&stream_ctx->stream_state);
+
+    if (stream_ctx->f_name != NULL) {
+        free(stream_ctx->f_name);
+        stream_ctx->f_name = NULL;
+    }
+
+    if (stream_ctx->F != NULL) {
+        DBG_PRINTF("Stream %" PRIu64 ", file close after %zu bytes\n", stream_ctx->stream_id, stream_ctx->received_length);
+        stream_ctx->F = picoquic_file_close(stream_ctx->F);
+    }
+
+    if (stream_ctx == ctx->first_stream) {
+        ctx->first_stream = stream_ctx->next_stream;
+        removed_from_context = 1;
+    }
+    else {
+        picoquic_demo_client_stream_ctx_t * previous = ctx->first_stream;
+
+        while (previous != NULL) {
+            if (previous->next_stream == stream_ctx) {
+                previous->next_stream = stream_ctx->next_stream;
+                removed_from_context = 1;
+                break;
+            }
+            else {
+                previous = previous->next_stream;
+            }
+        }
+    }
+
+    if (removed_from_context) {
+        ctx->nb_client_streams--;
+    }
+
+    free(stream_ctx);
 }
 
 void picoquic_demo_client_delete_context(picoquic_demo_callback_ctx_t* ctx)

--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -116,11 +116,6 @@ typedef struct st_picohttp_server_stream_ctx_t {
 
 typedef struct st_h3zero_server_callback_ctx_t {
     picosplay_tree_t h3_stream_tree;
-    picohttp_server_stream_ctx_t* first_stream;
-#if 0
-    size_t buffer_max;
-    uint8_t* buffer;
-#endif
     picohttp_server_path_item_t * path_table;
     size_t path_table_nb;
     char const* web_folder;
@@ -136,7 +131,6 @@ int h3zero_server_callback(picoquic_cnx_t* cnx,
 
 typedef struct st_picoquic_h09_server_callback_ctx_t {
     picosplay_tree_t h09_stream_tree;
-    picohttp_server_stream_ctx_t* first_stream;
     picohttp_server_path_item_t * path_table;
     size_t path_table_nb;
     char const* web_folder;

--- a/picohttp/quicperf.c
+++ b/picohttp/quicperf.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stddef.h>
 #include "picoquic.h"
 #include "picoquic_utils.h"
 #include "picosplay.h"

--- a/picohttp/quicperf.c
+++ b/picohttp/quicperf.c
@@ -451,7 +451,7 @@ int quicperf_process_stream_data(picoquic_cnx_t * cnx, quicperf_ctx_t * ctx, qui
                 ret = quicperf_init_streams_from_scenario(cnx, ctx, stream_ctx->stream_id);
                 if (ctx->nb_open_streams == 0) {
                     ret = picoquic_close(cnx, QUICPERF_NO_ERROR);
-                } else if (ctx->is_client) {
+                } else if (ret == 0 && ctx->is_client) {
                     quicperf_delete_stream_ctx(ctx, stream_ctx);
                 }
             }

--- a/picohttp/quicperf.h
+++ b/picohttp/quicperf.h
@@ -43,7 +43,7 @@ typedef struct st_quicperf_stream_desc_t {
 } quicperf_stream_desc_t;
 
 typedef struct st_quicperf_stream_ctx {
-    struct st_quicperf_stream_ctx* next_stream;
+    picosplay_node_t quicperf_stream_node;
     uint64_t stream_id;
     uint8_t length_header[8];
     uint64_t post_size; /* Unknown on server, from scenario on client */
@@ -66,7 +66,7 @@ typedef struct st_quicperf_ctx_t {
     size_t nb_open_streams;
     uint64_t last_interaction_time;
     quicperf_stream_desc_t* scenarios;
-    quicperf_stream_ctx_t* first_stream;
+    picosplay_tree_t quicperf_stream_tree;
 } quicperf_ctx_t;
 
 quicperf_ctx_t* quicperf_create_ctx(const char* scenario_text);

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2601,7 +2601,7 @@ static int picoquic_process_ack_of_stream_frame(picoquic_cnx_t* cnx, uint8_t* by
         stream = picoquic_find_stream(cnx, stream_id);
         if (stream != NULL) {
             (void)picoquic_update_sack_list(&stream->first_sack_item,
-                offset, offset + data_length - 1);
+                offset, offset + data_length - ((fin) ? 0 : 1));
 
             picoquic_delete_stream_if_closed(cnx, stream);
         }


### PR DESCRIPTION
Free stream context at Picoquic and application level when stream is closed. This radically diminishes the memory footprint of the picoquic servers.