### PR TITLE
Remove obsolete handling of 0-RTT repeat

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -350,7 +350,6 @@ typedef struct st_picoquic_packet_t {
     picoquic_packet_context_enum pc;
     unsigned int is_evaluated : 1;
     unsigned int is_pure_ack : 1;
-    unsigned int contains_crypto : 1;
     unsigned int is_mtu_probe : 1;
     unsigned int is_multipath_probe : 1;
     unsigned int is_ack_trap : 1;


### PR DESCRIPTION
This fixes a SEGV issue when running fuzz. The code was a remnant of some long ago specification, now obsolete.