### PR TITLE
Fix references to p_local_cnxid

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -989,7 +989,7 @@ void picoquic_queue_stateless_retry(picoquic_cnx_t* cnx,
         cnx->path[0]->p_remote_cnxid->cnx_id = ph->srce_cnx_id;
 
         byte_index = header_length = picoquic_create_packet_header(cnx, picoquic_packet_retry,
-            0, &cnx->path[0]->p_remote_cnxid->cnx_id, &cnx->path[0]->p_local_cnxid->cnx_id, 0,
+            0, cnx->path[0], 0,
             bytes, &pn_offset, &pn_length);
 
         /* In the old drafts, there is no header protection and the sender copies the ODCID

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1327,8 +1327,7 @@ size_t picoquic_create_packet_header(
     picoquic_cnx_t* cnx,
     picoquic_packet_type_enum packet_type,
     uint64_t sequence_number,
-    picoquic_connection_id_t * dest_cnxid,
-    picoquic_connection_id_t * srce_cnxid,
+    picoquic_path_t* path_x,
     size_t header_length,
     uint8_t* bytes,
     size_t* pn_offset,
@@ -1351,8 +1350,6 @@ void picoquic_log_pn_dec_trial(picoquic_cnx_t* cnx); /* For debugging potential 
 void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret,
     size_t length, size_t header_length, size_t checksum_overhead,
     size_t * send_length, uint8_t * send_buffer, size_t send_buffer_max,
-    picoquic_connection_id_t * remote_cnxid,
-    picoquic_connection_id_t * local_cnxid,
     picoquic_path_t * path_x, uint64_t current_time);
 
 void picoquic_implicit_handshake_ack(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc, uint64_t current_time);

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -419,7 +419,7 @@ int parseheadertest()
             cnx_10->path[0]->p_remote_cnxid->cnx_id = test_cnxid_r10;
         }
         header_length = picoquic_create_packet_header(cnx_10, test_entries[i].ph->ptype,
-            test_entries[i].ph->pn, &cnx_10->path[0]->p_remote_cnxid->cnx_id, &cnx_10->path[0]->p_local_cnxid->cnx_id, 0, packet, &pn_offset, &pn_length);
+            test_entries[i].ph->pn, cnx_10->path[0], 0, packet, &pn_offset, &pn_length);
         picoquic_update_payload_length(packet, pn_offset, pn_offset, pn_offset +
             test_entries[i].ph->payload_length);
         
@@ -548,8 +548,7 @@ int test_packet_encrypt_one(
         /* Create a packet with specified parameters */
         picoquic_finalize_and_protect_packet(cnx_client, packet,
             ret, length, header_length, checksum_overhead,
-            &send_length, send_buffer, PICOQUIC_MAX_PACKET_SIZE, 
-            &path_x->p_remote_cnxid->cnx_id, &path_x->p_local_cnxid->cnx_id,
+            &send_length, send_buffer, PICOQUIC_MAX_PACKET_SIZE,
             path_x, current_time);
 
         expected_header.ptype = packet->ptype;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -377,7 +377,7 @@ static int tls_api_inject_packet(picoquic_test_tls_api_ctx_t* test_ctx, int from
 
         picoquic_finalize_and_protect_packet(cnx, packet, 0, length, header_length, checksum_overhead,
             &sim_packet->length, sim_packet->bytes, sizeof(sim_packet->bytes),
-            &path_x->p_remote_cnxid->cnx_id, &path_x->p_local_cnxid->cnx_id, path_x, current_time);
+            path_x, current_time);
         /* Forward on selected link */
         picoquictest_sim_link_submit((from_client) ? test_ctx->c_to_s_link : test_ctx->s_to_c_link, sim_packet, current_time);
     }
@@ -6756,7 +6756,7 @@ int false_migration_inject(picoquic_test_tls_api_ctx_t* test_ctx, int target_cli
         picoquic_finalize_and_protect_packet(cnx, packet,
             ret, length, header_length, checksum_overhead,
             &sim_packet->length, sim_packet->bytes, PICOQUIC_MAX_PACKET_SIZE,
-            &path_x->p_remote_cnxid->cnx_id, &path_x->p_local_cnxid->cnx_id, path_x, simulated_time);
+            path_x, simulated_time);
 
         picoquic_store_addr(&sim_packet->addr_from, (struct sockaddr *)&false_address);
 


### PR DESCRIPTION
@IvanNardi this is a fix for issue #1155. The code verifier complains about dereferencing a NULL reference to p_local_cnxid. That reference is not actually needed in the specific code path in which the error is detected. The PR rewrites the calls to the packet protection and header formatting functions, so that p_local_cnxid is only deferenced when formatting long header packets (initial, handshake, 0-RTT) and not when formatting 1-RTT packets. The code guarantees that path[0]->p_local_cnxid will always be a valid reference during the handshake.