### PR TITLE
Fix parsing of coalesced packets

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2015,7 +2015,10 @@ int picoquic_incoming_segment(
     else {
         if (ret == 0 && picoquic_compare_connection_id(previous_dest_id, &ph.dest_cnx_id) != 0) {
             ret = PICOQUIC_ERROR_CNXID_SEGMENT;
-        }
+        } else if (ret == PICOQUIC_ERROR_VERSION_NOT_SUPPORTED) {
+            /* A coalesced packet with unknown version is likely some kind of padding */
+            ret = PICOQUIC_ERROR_CNXID_SEGMENT;
+	}
     }
 
     /* Store packet if received in advance of encryption keys */


### PR DESCRIPTION
Is very unlikely that a coalesced packet with an unexpected version
is a valid QUIC packet. It is probably some kind of unencrypted random
padding data added after a previously valid QUIC packet.

Note that we don't perform any checks on CIDs presence/values for any
packets with an unsupported version; if the coalesced packet is very
short , we might read invalid data when preparing the VN reply.