### PR TITLE
Delay file opening on server and close quickly

### DIFF
--- a/picohttp/demoserver.h
+++ b/picohttp/demoserver.h
@@ -109,6 +109,7 @@ typedef struct st_picohttp_server_stream_ctx_t {
     int method;
     picohttp_post_data_cb_fn path_callback;
     void* path_callback_ctx;
+    char* file_path;
     FILE* F;
 } picohttp_server_stream_ctx_t;
 
@@ -154,6 +155,7 @@ size_t picoquic_demo_server_callback_select_alpn(picoquic_quic_t* quic, ptls_iov
 
 int demo_server_is_path_sane(const uint8_t* path, size_t path_length);
 
-int demo_server_try_file_path(const uint8_t* path, size_t path_length, size_t* echo_size, FILE** pF, char const* web_folder);
+int demo_server_try_file_path(const uint8_t* path, size_t path_length, size_t* echo_size, 
+    char ** file_path,char const* web_folder);
 
 #endif /* DEMO_SERVER_H */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -35,7 +35,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "0.34c"
+#define PICOQUIC_VERSION "0.34d"
 
 #ifndef PICOQUIC_MAX_PACKET_SIZE
 #define PICOQUIC_MAX_PACKET_SIZE 1536


### PR DESCRIPTION
The cause of the crash was "too many open files". Files were opened as soon as the request was received, but were served in order. By piling a large number of file opening, the client could cause the server to exceed the available number of file descriptors, which triggered a buggy code path. That path has been fixed too.

Close #1170 