### PR TITLE
ACK every 2 in multipath slowstart

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2239,12 +2239,6 @@ int picoquic_incoming_segment(
         if (cnx != NULL) {
             picoquic_reinsert_by_wake_time(cnx->quic, cnx, current_time);
         }
-    } else if (ret == PICOQUIC_ERROR_DUPLICATE) {
-        /* Bad packets are dropped silently, but duplicates should be acknowledged */
-        if (cnx != NULL) {
-            picoquic_set_ack_needed(cnx, current_time, ph.pc, ph.l_cid);
-        }
-        ret = -1;
     } else if (ret == PICOQUIC_ERROR_AEAD_CHECK || ret == PICOQUIC_ERROR_INITIAL_TOO_SHORT ||
         ret == PICOQUIC_ERROR_INITIAL_CID_TOO_SHORT ||
         ret == PICOQUIC_ERROR_UNEXPECTED_PACKET || 
@@ -2254,6 +2248,7 @@ int picoquic_incoming_segment(
         ret == PICOQUIC_ERROR_CNXID_SEGMENT ||
         ret == PICOQUIC_ERROR_VERSION_NOT_SUPPORTED ||
         ret == PICOQUIC_ERROR_PACKET_TOO_LONG ||
+        ret == PICOQUIC_ERROR_DUPLICATE ||
         ret == PICOQUIC_ERROR_AEAD_NOT_READY) {
         /* Bad packets are dropped silently */
         if (ret == PICOQUIC_ERROR_AEAD_CHECK ||

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2711,7 +2711,7 @@ int picoquic_prepare_packet_closing(picoquic_cnx_t* cnx, picoquic_path_t * path_
     bytes_max = bytes + send_buffer_max - checksum_overhead;
 
     if (ret == 0 && cnx->cnx_state == picoquic_state_closing_received) {
-        /* Send a closing frame, move to closing state */
+        /* Send a closing frame, move to draining state */
         uint64_t exit_time = cnx->latest_progress_time + 3 * path_x->retransmit_timer;
 
         length = picoquic_predict_packet_header_length(cnx, packet_type, pkt_ctx);

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -739,7 +739,7 @@ int multipath_back1_test()
 /* Test that a typical wifi+lte scenario provides good performance */
 int multipath_perf_test()
 {
-    uint64_t max_completion_microsec = 1450000;
+    uint64_t max_completion_microsec = 1320000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_perf, 0);
 }
@@ -1237,7 +1237,7 @@ int simple_multipath_back1_test()
 
 int simple_multipath_perf_test()
 {
-    uint64_t max_completion_microsec = 1450000;
+    uint64_t max_completion_microsec = 1340000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_perf, 1);
 }


### PR DESCRIPTION
In the multipath implementation, verify that a short ACK gap is used if doing slow start on one of the links.