### PR TITLE
macro fix and picotls api update

### DIFF
--- a/ci/build_picotls.ps1
+++ b/ci/build_picotls.ps1
@@ -1,5 +1,5 @@
 # Build at a known-good commit
-$COMMIT_ID="d5e32519516e13520ddeffa85da97d2398197df2"
+$COMMIT_ID="c91baf9c9971332d9280a7062943c54a4f13a7ec"
 
 # Match expectations of picotlsvs project.
 mkdir $dir\include\

--- a/ci/build_picotls.sh
+++ b/ci/build_picotls.sh
@@ -2,7 +2,7 @@
 #build last picotls master (for Travis)
 
 # Build at a known-good commit
-COMMIT_ID=d5e32519516e13520ddeffa85da97d2398197df2
+COMMIT_ID=c91baf9c9971332d9280a7062943c54a4f13a7ec
 
 cd ..
 # git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags https://github.com/h2o/picotls

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -421,7 +421,7 @@ void picoquic_get_close_reasons(picoquic_cnx_t* cnx, uint16_t* local_reason,
  * Expect `0` as return value, when the data matches the signature.
  */
 
-typedef int (*picoquic_verify_sign_cb_fn)(void* verify_ctx, ptls_iovec_t data, ptls_iovec_t sign);
+typedef int (*picoquic_verify_sign_cb_fn)(void* verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t sign);
 /* Will be called to verify a certificate of a connection.
  * The arguments `verify_sign` and `verify_sign_ctx` are expected to be set, when the function returns `0`.
  * See `verify_sign_cb_fn` for more information about these arguments.

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2721,7 +2721,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
 
             cnx->cnx_state = picoquic_state_client_init;
 
-            if (!quic->is_cert_store_not_empty && sni == NULL) {
+            if (!quic->is_cert_store_not_empty || sni == NULL) {
                 /* This is a hack. The open SSL certifier crashes if no name is specified,
                  * and always fails if no certificate is stored, so we just use a NULL verifier */
                 picoquic_log_app_message(cnx, "%s -- certificate will not be verified.\n",

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2721,7 +2721,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
 
             cnx->cnx_state = picoquic_state_client_init;
 
-            if (!quic->is_cert_store_not_empty || sni == NULL) {
+            if (!quic->is_cert_store_not_empty && sni == NULL) {
                 /* This is a hack. The open SSL certifier crashes if no name is specified,
                  * and always fails if no certificate is stored, so we just use a NULL verifier */
                 picoquic_log_app_message(cnx, "%s -- certificate will not be verified.\n",

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1282,15 +1282,10 @@ int picoquic_enable_custom_verify_certificate_callback(picoquic_quic_t* quic) {
     if (verifier == NULL) {
         return PICOQUIC_ERROR_MEMORY;
     } else {
-        
-        // this is a bit hacky... 
-        // so we can extract the default algo list from inside picotls
-        ptls_openssl_init_verify_certificate((ptls_openssl_verify_certificate_t *)verifier, NULL);
-
-        verifier->cb.cb = verify_certificate_callback;
         verifier->quic = quic;
+        verifier->cb.cb = verify_certificate_callback;
+        ptls_openssl_set_default_algos(verifier->cb);
         ctx->verify_certificate = &verifier->cb;
-
         quic->is_cert_store_not_empty = 1;
 
         return 0;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1282,9 +1282,15 @@ int picoquic_enable_custom_verify_certificate_callback(picoquic_quic_t* quic) {
     if (verifier == NULL) {
         return PICOQUIC_ERROR_MEMORY;
     } else {
-        verifier->quic = quic;
+        
+        // this is a bit hacky... 
+        // so we can extract the default algo list from inside picotls
+        ptls_openssl_init_verify_certificate((ptls_openssl_verify_certificate_t *)verifier, NULL);
+
         verifier->cb.cb = verify_certificate_callback;
+        verifier->quic = quic;
         ctx->verify_certificate = &verifier->cb;
+
         quic->is_cert_store_not_empty = 1;
 
         return 0;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1284,7 +1284,7 @@ int picoquic_enable_custom_verify_certificate_callback(picoquic_quic_t* quic) {
     } else {
         verifier->quic = quic;
         verifier->cb.cb = verify_certificate_callback;
-        ptls_openssl_set_default_algos(verifier->cb);
+        ptls_openssl_set_default_algos(&verifier->cb);
         ctx->verify_certificate = &verifier->cb;
         quic->is_cert_store_not_empty = 1;
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -262,14 +262,14 @@ ptls_hash_algorithm_t* picoquic_get_openssl_sha256()
    using definitions in openSSL */
 
 ptls_key_exchange_algorithm_t* picoquic_key_exchanges[] = { &ptls_openssl_secp256r1,
-#ifdef PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
+#ifdef PTLS_OPENSSL_HAVE_X25519
                                                            & ptls_openssl_x25519,
 #endif
                                                            NULL };
 
 ptls_key_exchange_algorithm_t* picoquic_key_secp256r1[] = { &ptls_openssl_secp256r1, NULL };
 
-#ifdef PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
+#ifdef PTLS_OPENSSL_HAVE_X25519
 ptls_key_exchange_algorithm_t* picoquic_key_x25519[] = { &ptls_openssl_x25519, NULL };
 #endif
 
@@ -287,7 +287,7 @@ static int picoquic_openssl_set_key_exchange_in_ctx(ptls_context_t* ctx, int key
             ctx->key_exchanges = picoquic_key_exchanges;
             break;
         case 20:
-#ifdef PTLS_OPENSSL_HAVE_CHACHA20_POLY1305
+#ifdef PTLS_OPENSSL_HAVE_X25519
             ctx->key_exchanges = picoquic_key_x25519;
             break;
 #else

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1230,15 +1230,15 @@ typedef struct {
 typedef struct {
     /* The pointer to the overlying `verify_ctx` */
     void *verify_ctx;
-    int (*verify_sign)(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t sign);
+    int (*verify_sign)(void *verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t sign);
 } picoquic_verify_ctx_t;
 
-static int verify_sign_callback(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t sign)
+static int verify_sign_callback(void *verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t sign)
 {
     picoquic_verify_ctx_t* ctx = (picoquic_verify_ctx_t*)verify_ctx;
     int ret = 0;
 
-    ret = ctx->verify_sign(ctx->verify_ctx, data, sign);
+    ret = ctx->verify_sign(ctx->verify_ctx, algo, data, sign);
 
     free(ctx);
 
@@ -1246,7 +1246,7 @@ static int verify_sign_callback(void *verify_ctx, ptls_iovec_t data, ptls_iovec_
 }
 
 static int verify_certificate_callback(ptls_verify_certificate_t* _self, ptls_t* tls,
-                                       int (**verify_sign)(void *verify_ctx, ptls_iovec_t data, ptls_iovec_t sign),
+                                       int (**verify_sign)(void *verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t sign),
                                        void **verify_data,
                                        ptls_iovec_t *certs,
                                        size_t num_certs)

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3979,7 +3979,7 @@ int bad_certificate_test()
 * Test setting the verify certificate callback.
 */
 
-static int verify_sign_test(void* verify_ctx, ptls_iovec_t data, ptls_iovec_t sign) {
+static int verify_sign_test(void* verify_ctx, uint16_t algo, ptls_iovec_t data, ptls_iovec_t sign) {
     int* ptr = (int*)verify_ctx;
     *ptr += 1;
 


### PR DESCRIPTION
correcting the macro usage and the picotls verify/sign interface has added a new parameter.. so corrected that interface.

let's forget messing with the SNI for now lol.