### PR TITLE
Expose Connection Limits

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1192,7 +1192,7 @@ int picoquic_incoming_client_initial(
 
         if ((*pcnx)->cnx_state == picoquic_state_server_init && 
             ((*pcnx)->quic->server_busy || 
-            (*pcnx)->quic->current_number_connections > (*pcnx)->quic->max_number_connections)) {
+            (*pcnx)->quic->current_number_connections > (*pcnx)->quic->tentative_max_number_connections)) {
             (*pcnx)->local_error = PICOQUIC_TRANSPORT_SERVER_BUSY;
             (*pcnx)->cnx_state = picoquic_state_handshake_failure;
         }

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -410,6 +410,12 @@ int picoquic_esni_load_key(picoquic_quic_t * quic, char const * esni_key_file_na
 /* Set the ESNI RR. Must be called after setting the ESNI key at least once. */
 int picoquic_esni_server_setup(picoquic_quic_t * quic, char const * esni_rr_file_name);
 
+/* Adjust maximum connections allowed */
+void picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections);
+
+/* Get number of open connections */
+uint32_t picoquic_current_number_connections(picoquic_quic_t * quic);
+
 /* Obtain the reasons why a connection was closed */
 void picoquic_get_close_reasons(picoquic_cnx_t* cnx, uint64_t* local_reason,
     uint64_t* remote_reason, uint64_t* local_application_reason,

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -410,8 +410,11 @@ int picoquic_esni_load_key(picoquic_quic_t * quic, char const * esni_key_file_na
 /* Set the ESNI RR. Must be called after setting the ESNI key at least once. */
 int picoquic_esni_server_setup(picoquic_quic_t * quic, char const * esni_rr_file_name);
 
-/* Adjust maximum connections allowed */
-void picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections);
+/* Adjust maximum connections allowed to the specified value.
+ * The maximum number cannot be set to a value higher than the limit set when the context was
+ * created. Trying higher values has no effect.
+ */
+int picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections);
 
 /* Get number of open connections */
 uint32_t picoquic_current_number_connections(picoquic_quic_t * quic);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -551,6 +551,7 @@ typedef struct st_picoquic_quic_t {
     uint32_t max_half_open_before_retry;
     uint32_t current_number_half_open;
     uint32_t current_number_connections;
+    uint32_t tentative_max_number_connections;
     uint32_t max_number_connections;
     uint64_t stateless_reset_next_time; /* Next time Stateless Reset or VN packet can be sent */
     uint64_t stateless_reset_min_interval; /* Enforced interval between two stateless reset packets */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -330,12 +330,14 @@ void picoquic_registered_token_clear(picoquic_quic_t* quic, uint64_t expiry_time
     } while (!end_reached);
 }
 
-void picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections)
+int picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections)
 {
-    if (max_nb_connections <= quic->max_number_connections)
-    {
+    if (max_nb_connections <= quic->max_number_connections) {
         quic->tentative_max_number_connections = max_nb_connections;
+        return 1;
     }
+
+    return 0;
 }
 
 uint32_t picoquic_current_number_connections(picoquic_quic_t * quic)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -334,10 +334,10 @@ int picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_conn
 {
     if (max_nb_connections <= quic->max_number_connections) {
         quic->tentative_max_number_connections = max_nb_connections;
-        return 1;
+        return 0;
     }
 
-    return 0;
+    return -1;
 }
 
 uint32_t picoquic_current_number_connections(picoquic_quic_t * quic)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -330,6 +330,16 @@ void picoquic_registered_token_clear(picoquic_quic_t* quic, uint64_t expiry_time
     } while (!end_reached);
 }
 
+void picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections)
+{
+    quic->max_number_connections = max_nb_connections;
+}
+
+uint32_t picoquic_current_number_connections(picoquic_quic_t * quic)
+{
+    return quic->current_number_connections;
+}
+
 /* Forward reference */
 static void picoquic_wake_list_init(picoquic_quic_t* quic);
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -332,7 +332,10 @@ void picoquic_registered_token_clear(picoquic_quic_t* quic, uint64_t expiry_time
 
 void picoquic_adjust_max_connections(picoquic_quic_t * quic, uint32_t max_nb_connections)
 {
-    quic->max_number_connections = max_nb_connections;
+    if (max_nb_connections <= quic->max_number_connections)
+    {
+        quic->tentative_max_number_connections = max_nb_connections;
+    }
 }
 
 uint32_t picoquic_current_number_connections(picoquic_quic_t * quic)
@@ -410,6 +413,7 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
                 max_nb_connections = 1;
             }
 
+            quic->tentative_max_number_connections = max_nb_connections;
             quic->max_number_connections = max_nb_connections;
 
             quic->table_cnx_by_id = picohash_create((size_t)max_nb_connections * 4,


### PR DESCRIPTION
Given that ~5% of QUIC connections on the Internet still get blocked by middleware, it is still necessary to have a TCP fallback. Thus in order to enforce a unified application wide connection limit over TCP **and** QUIC connections, these connection limits need to be fluid. 

An alternative design might be to "listen" for new QUIC connections on one port, and then transition to a different port via Server Preferred Address. But unfortunately that is not an option here since using any port besides 443 sometimes also results in traffic being dropped or throttled by middleware.

So the new behavior would be... setting `max_nb_connections` during `picoquic_create` would initialize data structures to the maximum possible number of quic connections, and then `picoquic_adjust_max_connections` allows this maximal limit to be titrated up or down as the server open and closes backup TCP connections with clients unable to connect over UDP. 