### PR TITLE
Add preemptive repeat logic and test

### DIFF
--- a/PerfAndStressTest/PerfAndStressTest.cpp
+++ b/PerfAndStressTest/PerfAndStressTest.cpp
@@ -62,6 +62,13 @@ namespace PerfAndStressTest
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(satellite_preemptive)
+        {
+            int ret = satellite_preemptive_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(satellite_small)
         {
             int ret = satellite_small_test();

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -89,6 +89,7 @@ static option_table_line_t option_table[] = {
     { picoquic_option_Token_File_Name, 'N', "token_file", 1, "file", "File storing the new tokens" },
     { picoquic_option_Socket_buffer_size, 'B', "so_buf_size", 1, "number", "Set buffer size with SO_SNDBUF SO_RCVBUF" },
     { picoquic_option_Performance_Log, 'F', "log_file_name", 1, "file", "Append performance reports to performance log" },
+    { picoquic_option_Preemptive_Repeat, 'V', "preemptive_repeat", 0, "", "enable preemptive repeat" },
     { picoquic_option_HELP, 'h', "help", 0, "This help message" }
 };
 
@@ -469,6 +470,9 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
     case picoquic_option_Performance_Log:
         ret = config_set_string_param(&config->performance_log, params, nb_params, 0);
         break;
+    case picoquic_option_Preemptive_Repeat:
+        config->do_preemptive_repeat = 1;
+        break;
     case picoquic_option_HELP:
         ret = -1;
         break;
@@ -780,6 +784,8 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
         picoquic_set_textlog(quic, config->log_file);
 
         picoquic_set_log_level(quic, config->use_long_log);
+
+        picoquic_set_preemptive_repeat_policy(quic, config->do_preemptive_repeat);
 
         if (config->initial_random) {
             picoquic_set_random_initial(quic, 1);

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3095,8 +3095,9 @@ int picoquic_is_ack_needed_in_ctx(picoquic_cnx_t* cnx, picoquic_ack_context_t* a
     int ret = 0;
 
     if (ack_ctx->ack_needed) {
-        if (pc != picoquic_packet_context_application || ack_ctx->ack_after_fin) {
+        if (pc != picoquic_packet_context_application || ack_ctx->ack_after_fin ) {
             ret = 1;
+            ack_ctx->ack_after_fin = 0;
         }
         else if (ack_ctx->out_of_order_received && !cnx->ack_ignore_order_remote) {
             ret = 1;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -860,8 +860,12 @@ int picoquic_stop_sending(picoquic_cnx_t* cnx,
  * which in average will be separated by the pseudo period. By default,
  * the pseudo perio is 0, which means no hole insertion.
  */
-
 void picoquic_set_optimistic_ack_policy(picoquic_quic_t* quic, uint32_t sequence_hole_pseudo_period);
+
+/* Enable or disable the preemptive repeat function
+ */
+void picoquic_set_preemptive_repeat_policy(picoquic_quic_t* quic, int do_repeat);
+void picoquic_set_preemptive_repeat_per_cnx(picoquic_cnx_t* cnx, int do_repeat);
 
 /* Enables keep alive for a connection.
  * Keep alive interval is expressed in microseconds.

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -67,6 +67,7 @@ typedef enum {
     picoquic_option_Token_File_Name,
     picoquic_option_Socket_buffer_size,
     picoquic_option_Performance_Log,
+    picoquic_option_Preemptive_Repeat,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -96,6 +97,7 @@ typedef struct st_picoquic_quic_config_t {
     /* Common flags */
     unsigned int initial_random : 1;
     unsigned int use_long_log : 1;
+    unsigned int do_preemptive_repeat : 1;
     /* Server only */
     char const* www_dir;
     uint64_t reset_seed[2];
@@ -103,7 +105,6 @@ typedef struct st_picoquic_quic_config_t {
     size_t ticket_encryption_key_length;
     /* Server flags */
     unsigned int do_retry : 1;
-
     /* Client only */
     char const* ticket_file_name; /* TODO: allocate key */
     char const* token_file_name; /* TODO: allocate key */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -381,6 +381,8 @@ typedef struct st_picoquic_packet_t {
     unsigned int is_multipath_probe : 1;
     unsigned int is_ack_trap : 1;
     unsigned int delivered_app_limited : 1;
+    unsigned int is_preemptive_repeat : 1;
+    unsigned int was_preemptively_repeated : 1;
 
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquic_packet_t;
@@ -572,6 +574,7 @@ typedef struct st_picoquic_quic_t {
     unsigned int packet_train_mode : 1; /* Tune pacing for sending packet trains */
     unsigned int use_constant_challenges : 1; /* Use predictable challenges when producing constant logs. */
     unsigned int use_low_memory : 1; /* if possible, use low memory alternatives, e.g. for AES */
+    unsigned int is_preemptive_repeat_enabled : 1; /* enable premptive repeat on new connections */
     picoquic_stateless_packet_t* pending_stateless_packet;
 
     picoquic_congestion_algorithm_t const* default_congestion_alg;
@@ -758,6 +761,7 @@ typedef struct st_picoquic_packet_context_t {
     picoquic_packet_t* retransmit_oldest;
     picoquic_packet_t* retransmitted_newest;
     picoquic_packet_t* retransmitted_oldest;
+    picoquic_packet_t* preemptive_repeat_ptr;
     /* ECN Counters */
     uint64_t ecn_ect0_total_remote;
     uint64_t ecn_ect1_total_remote;
@@ -1068,6 +1072,7 @@ typedef struct st_picoquic_cnx_t {
     unsigned int is_multipath_enabled : 1; /* Usage of multipath was negotiated */
     unsigned int is_simple_multipath_enabled : 1; /* Usage of simple multipath was negotiated */
     unsigned int is_sending_large_buffer : 1; /* Buffer provided by application is sufficient for PMTUD */
+    unsigned int is_preemptive_repeat_enabled : 1; /* Preemptive repat of packets to reduce transaction latency */
 
     /* Spin bit policy */
     picoquic_spinbit_version_enum spin_policy;
@@ -1147,6 +1152,7 @@ typedef struct st_picoquic_cnx_t {
     uint64_t nb_packets_sent;
     uint64_t nb_packets_logged;
     uint64_t nb_retransmission_total;
+    uint64_t nb_preemptive_repeat;
     uint64_t nb_spurious;
     uint64_t nb_crypto_key_rotations;
     uint64_t nb_packet_holes_inserted;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2705,6 +2705,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
         cnx->callback_fn = quic->default_callback_fn;
         cnx->callback_ctx = quic->default_callback_ctx;
         cnx->congestion_alg = quic->default_congestion_alg;
+        cnx->is_preemptive_repeat_enabled = quic->is_preemptive_repeat_enabled;
 
         /* Initialize key rotation interval to default value */
         cnx->crypto_epoch_length_max = quic->crypto_epoch_length_max;
@@ -3739,6 +3740,16 @@ void picoquic_set_default_congestion_algorithm_by_name(picoquic_quic_t* quic, ch
 void picoquic_set_optimistic_ack_policy(picoquic_quic_t* quic, uint32_t sequence_hole_pseudo_period)
 {
     quic->sequence_hole_pseudo_period = sequence_hole_pseudo_period;
+}
+
+void picoquic_set_preemptive_repeat_policy(picoquic_quic_t* quic, int do_repeat)
+{
+    quic->is_preemptive_repeat_enabled = (do_repeat) ? 1 : 0;
+}
+
+void picoquic_set_preemptive_repeat_per_cnx(picoquic_cnx_t* cnx, int do_repeat)
+{
+    cnx->is_preemptive_repeat_enabled = (do_repeat) ? 1 : 0;
 }
 
 void picoquic_set_congestion_algorithm(picoquic_cnx_t* cnx, picoquic_congestion_algorithm_t const* alg)

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -227,6 +227,7 @@ static const picoquic_test_def_t test_table[] = {
     { "satellite_loss", satellite_loss_test },
     { "satellite_jitter", satellite_jitter_test },
     { "satellite_medium", satellite_medium_test },
+    { "satellite_preemptive", satellite_preemptive_test },
     { "satellite_small", satellite_small_test },
     { "satellite_small_up", satellite_small_up_test },
     { "cid_length", cid_length_test },

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:h";
+static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:Vh";
 
 int config_option_letters_test()
 {
@@ -68,6 +68,7 @@ static picoquic_quic_config_t param1 = {
     /* Common flags */
     1, /* unsigned int initial_random : 1; */
     1, /* unsigned int use_long_log : 1; */
+    1, /* unsigned int do_preemptive_repeat : 1; */
     /* Server only */
     "/data/www/", /* char const* www_dir; */
     { 0x012345678abcdef, 0xfedcba9876543210}, /* uint64_t reset_seed[2]; */
@@ -114,6 +115,7 @@ static char const* config_argv1[] = {
     "-s", "012345678abcdef", "0xfedcba9876543210",
     "-B", "655360",
     "-F", "/data/performance_log.csv",
+    "-V",
     NULL
 };
 
@@ -141,6 +143,7 @@ static picoquic_quic_config_t param2 = {
     /* Common flags */
     0, /* unsigned int initial_random : 1; */
     0, /* unsigned int use_long_log : 1; */
+    0, /* unsigned int do_preemptive_repeat : 1; */
     /* Server only */
     NULL, /* char const* www_dir; */
     {0, 0}, /* uint64_t reset_seed[2]; */
@@ -248,6 +251,7 @@ int config_test_compare(const picoquic_quic_config_t* expected, const picoquic_q
     ret |= config_test_compare_int("multipath", expected->multipath_option, actual->multipath_option);
     ret |= config_test_compare_int("initial_random", expected->initial_random, actual->initial_random);
     ret |= config_test_compare_int("use_long_log", expected->use_long_log, actual->use_long_log);
+    ret |= config_test_compare_int("preemptive_repeat", expected->do_preemptive_repeat, actual->do_preemptive_repeat);
     ret |= config_test_compare_string("www_dir", expected->www_dir, actual->www_dir);
     ret |= config_test_compare_int("do_retry", expected->do_retry, actual->do_retry);
     /* TODO: reset_seed */

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -185,6 +185,7 @@ int satellite_basic_test();
 int satellite_loss_test();
 int satellite_jitter_test();
 int satellite_medium_test();
+int satellite_preemptive_test();
 int satellite_small_test();
 int satellite_small_up_test();
 int long_rtt_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -133,6 +133,7 @@ typedef struct st_picoquic_test_tls_api_ctx_t {
     int test_finished;
     int streams_finished;
     int reset_received;
+    int immediate_exit;
 
     /* Blackhole period if needed */
     uint64_t blackhole_start;


### PR DESCRIPTION
Add a flag to perform "preemptive repeat" of not yet acknowledged packets if there is no application data to send. In the "satellite test with 1% packet loss", this reduces the transmission time from 7.36 seconds to 6.79 sec, i.e. almost 1 rtt.

Close #924 

There is still work to do before merging this PR:

- Add an option to turn on this function in the demo program
- Verify that the demo program does not wait acknowledgement of redundant data before closing
- Add redundant transmission in the "almost ready" states, subject to connection validation
- Consider redundant transmission of handshake packets
- Consider variant of "many losses" connection test with preemptive repeat turned on