### PR TITLE
Remember RTT and CWIn from previous connections

### DIFF
--- a/PerfAndStressTest/PerfAndStressTest.cpp
+++ b/PerfAndStressTest/PerfAndStressTest.cpp
@@ -41,6 +41,13 @@ namespace PerfAndStressTest
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(satellite_seeded)
+        {
+            int ret = satellite_seeded_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(satellite_loss)
         {
             int ret = satellite_loss_test();

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -668,6 +668,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(ticket_seed)
+        {
+            int ret = ticket_seed_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(token_store)
         {
             int ret = token_store_test();

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -197,7 +197,7 @@ static uint32_t config_parse_target_version(char const* v_arg)
 static int config_set_string_param(char const** v, const option_param_t* params, int nb_param, int x)
 {
     int ret = 0;
-    char* p_dup;
+    char* p_dup = NULL;
 
     if (*v != NULL) {
         free((void*)*v);
@@ -206,7 +206,9 @@ static int config_set_string_param(char const** v, const option_param_t* params,
 
     if (params != NULL && x >= 0 && x < nb_param && params[x].param != NULL)
     {
-        p_dup = malloc(params[x].length + 1);
+        if (params[x].length >= 0) {
+            p_dup = malloc((size_t)params[x].length + 1);
+        }
         if (p_dup != NULL) {
             memcpy(p_dup, params[x].param, params[x].length);
             p_dup[params[x].length] = 0;

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -206,8 +206,11 @@ static int config_set_string_param(char const** v, const option_param_t* params,
 
     if (params != NULL && x >= 0 && x < nb_param && params[x].param != NULL)
     {
-        if (params[x].length >= 0) {
-            p_dup = malloc((size_t)params[x].length + 1);
+        size_t alloc_length = (size_t)params[x].length + 1;
+        int length_max = (int)alloc_length;
+
+        if (params[x].length > 0 && length_max > params[x].length) {
+            p_dup = malloc(alloc_length);
         }
         if (p_dup != NULL) {
             memcpy(p_dup, params[x].param, params[x].length);

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -36,7 +36,7 @@
 
 typedef struct st_option_param_t {
     char const * param;
-    int length;
+    size_t length;
 } option_param_t;
 
 typedef struct st_option_table_line_t {
@@ -206,11 +206,10 @@ static int config_set_string_param(char const** v, const option_param_t* params,
 
     if (params != NULL && x >= 0 && x < nb_param && params[x].param != NULL)
     {
-        size_t alloc_length = (size_t)params[x].length + 1;
-        int length_max = (int)alloc_length;
+        size_t alloc_length = params[x].length + 1;
 
-        if (params[x].length > 0 && length_max > params[x].length) {
-            p_dup = malloc(alloc_length);
+        if (params[x].length > 0 && alloc_length > params[x].length) {
+            p_dup = (char *)malloc(alloc_length);
         }
         if (p_dup != NULL) {
             memcpy(p_dup, params[x].param, params[x].length);
@@ -218,7 +217,7 @@ static int config_set_string_param(char const** v, const option_param_t* params,
             *v = (char const*)p_dup;
         }
         else {
-            fprintf(stderr, "Cannot allocate %d characters\n", params[x].length);
+            fprintf(stderr, "Cannot allocate %zu characters\n", params[x].length);
             ret = -1;
         }
     }
@@ -228,7 +227,7 @@ static int config_set_string_param(char const** v, const option_param_t* params,
     return ret;
 }
 
-static char* config_optval_string(char* buffer, int buffer_max, const char* p, int p_length)
+static char* config_optval_string(char* buffer, size_t buffer_max, const char* p, size_t p_length)
 {
     if (p_length + 1 > buffer_max) {
         p_length = buffer_max - 1;
@@ -238,7 +237,7 @@ static char* config_optval_string(char* buffer, int buffer_max, const char* p, i
     return buffer;
 }
 
-static char* config_optval_param_string(char* buffer, int buffer_max, const option_param_t* params, int nb_param, int x)
+static char* config_optval_param_string(char* buffer, size_t buffer_max, const option_param_t* params, int nb_param, int x)
 {
     if (params == NULL || x < 0 || x >= nb_param) {
         buffer[0] = 0;
@@ -257,7 +256,7 @@ int config_atoi(const option_param_t* params, int nb_param, int x, int* ret)
         *ret = -1;
     }
     else {
-        for (int i = 0; i < params[x].length; i++) {
+        for (size_t i = 0; i < params[x].length; i++) {
             int c = params[x].param[i] - '0';
             if (c < 0 || c > 9) {
                 v = -1;
@@ -280,7 +279,7 @@ uint64_t config_atoull(const option_param_t* params, int nb_param, int x, int * 
         *ret = -1;
     }
     else {
-        for (int i = 0; i < params[x].length; i++) {
+        for (size_t i = 0; i < params[x].length; i++) {
             int c = params[x].param[i];
             unsigned int d = 0;
             if (c >= '0' || c <= '9') {
@@ -552,7 +551,7 @@ int picoquic_config_set_option(picoquic_quic_config_t* config, picoquic_option_e
     else{
         if (opt_val != NULL) {
             params[0].param = opt_val;
-            params[0].length = (int)strlen(opt_val);
+            params[0].length = strlen(opt_val);
             nb_params = 1;
         }
         ret = config_set_option(option_desc, params, nb_params, config);
@@ -581,7 +580,7 @@ int picoquic_config_command_line(int opt, int * p_optind, int argc, char const *
     else {
         if (option_table[option_index].nb_params_required > 0) {
             params[0].param = optarg;
-            params[0].length = (int)strlen(optarg);
+            params[0].length = strlen(optarg);
             nb_params++;
             while (nb_params < option_table[option_index].nb_params_required) {
                 if (*p_optind + 1 > argc) {

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -302,6 +302,13 @@ static void picoquic_cubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
+                if (cubic_state->ssthresh == UINT64_MAX) {
+                    if (path_x->cwin < nb_bytes_acknowledged) {
+                        path_x->cwin = nb_bytes_acknowledged;
+                    }
+                }
+                break;
             default:
                 break;
             }
@@ -337,6 +344,7 @@ static void picoquic_cubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
             default:
                 /* ignore */
                 break;
@@ -387,6 +395,7 @@ static void picoquic_cubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
             default:
                 /* ignore */
                 break;
@@ -513,6 +522,13 @@ static void picoquic_dcubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
+                if (cubic_state->ssthresh == UINT64_MAX) {
+                    if (path_x->cwin < nb_bytes_acknowledged) {
+                        path_x->cwin = nb_bytes_acknowledged;
+                    }
+                }
+                break;
             default:
                 /* ignore */
                 break;
@@ -569,6 +585,7 @@ static void picoquic_dcubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
             default:
                 /* ignore */
                 break;
@@ -631,6 +648,7 @@ static void picoquic_dcubic_notify(
             case picoquic_congestion_notification_reset:
                 picoquic_cubic_reset(cubic_state, path_x, current_time);
                 break;
+            case picoquic_congestion_notification_seed_cwin:
             default:
                 /* ignore */
                 break;

--- a/picoquic/fastcc.c
+++ b/picoquic/fastcc.c
@@ -82,6 +82,15 @@ void picoquic_fastcc_reset(picoquic_fastcc_state_t* fastcc_state, picoquic_path_
     path_x->cwin = PICOQUIC_CWIN_INITIAL;
 }
 
+void picoquic_fastcc_seed_cwin(picoquic_fastcc_state_t* fastcc_state, picoquic_path_t* path_x, uint64_t bytes_in_flight)
+{
+    if (fastcc_state->alg_state == picoquic_fastcc_initial) {
+        if (path_x->cwin < bytes_in_flight) {
+            path_x->cwin = bytes_in_flight;
+        }
+    }
+}
+
 void picoquic_fastcc_init(picoquic_path_t* path_x, uint64_t current_time)
 {
     /* Initialize the state of the congestion control algorithm */
@@ -288,6 +297,9 @@ void picoquic_fastcc_notify(
             break;
         case picoquic_congestion_notification_reset:
             picoquic_fastcc_reset(fastcc_state, path_x, current_time);
+            break;
+        case picoquic_congestion_notification_seed_cwin:
+            picoquic_fastcc_seed_cwin(fastcc_state, path_x, nb_bytes_acknowledged);
             break;
         default:
             /* ignore */

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -943,6 +943,7 @@ typedef enum {
     picoquic_congestion_notification_bw_measurement,
     picoquic_congestion_notification_ecn_ec,
     picoquic_congestion_notification_cwin_blocked,
+    picoquic_congestion_notification_seed_cwin,
     picoquic_congestion_notification_reset
 } picoquic_congestion_notification_t;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3014,6 +3014,12 @@ void picoquic_cnx_set_spinbit_policy(picoquic_cnx_t * cnx, picoquic_spinbit_vers
     cnx->spin_policy = spinbit_policy;
 }
 
+void picoquic_seed_bandwidth(picoquic_cnx_t* cnx, uint64_t rtt_us, uint64_t bytes_per_second)
+{
+    cnx->seed_rtt_us = rtt_us;
+    cnx->seed_bytes_per_second = bytes_per_second;
+}
+
 void picoquic_cnx_set_pmtud_required(picoquic_cnx_t* cnx, int is_pmtud_required)
 {
     cnx->is_pmtud_required = is_pmtud_required;

--- a/picoquic/ticket_store.c
+++ b/picoquic/ticket_store.c
@@ -53,11 +53,16 @@ picoquic_stored_ticket_t* picoquic_format_ticket(uint64_t time_valid_until,
         *next_p++ = 0;
 
         stored->ip_addr = (uint8_t *)next_p;
-        if (ip_addr_length > PICOQUIC_STORED_IP_MAX) {
-            ip_addr_length = PICOQUIC_STORED_IP_MAX;
+        if (ip_addr == NULL || ip_addr_length == 0) {
+            stored->ip_addr_length = 0;
         }
-        stored->ip_addr_length = ip_addr_length;
-        memcpy(next_p, ip_addr, ip_addr_length);
+        else {
+            if (ip_addr_length > PICOQUIC_STORED_IP_MAX) {
+                ip_addr_length = PICOQUIC_STORED_IP_MAX;
+            }
+            stored->ip_addr_length = ip_addr_length;
+            memcpy(next_p, ip_addr, ip_addr_length);
+        }
         next_p += PICOQUIC_STORED_IP_MAX;
 
         if (tp != NULL) {

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1128,6 +1128,8 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             /* Run AEAD encryption */
             dst->off += ptls_aead_encrypt(aead_enc, dst->base + dst->off,
                 src.base, src.len, seq_num, NULL, 0);
+            /* Remember issued ticket ID in connection context */
+            quic->cnx_in_progress->issued_ticket_id = seq_num;
         }
     } else {
         ptls_aead_context_t* aead_dec = (ptls_aead_context_t*)quic->aead_decrypt_ticket_ctx;
@@ -1146,15 +1148,24 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             if (decrypted > src.len - 8) {
                 /* decryption error */
                 ret = -1;
-                if (quic->F_log != NULL) {
-                    picoquic_log_app_message(quic->cnx_in_progress, "%s",
-                        "Session ticket could not be decrypted");
-                }
+                picoquic_log_app_message(quic->cnx_in_progress, "%s",
+                    "Session ticket could not be decrypted");
             } else {
+                picoquic_issued_ticket_t* server_ticket;
                 dst->off += decrypted;
-                if (quic->F_log != NULL) {
-                    picoquic_log_app_message(quic->cnx_in_progress, "%s",
-                        "Session ticket properly decrypted");
+                picoquic_log_app_message(quic->cnx_in_progress, "%s",
+                    "Session ticket properly decrypted");
+                /* Remember resumed ticket ID in connection context */
+                quic->cnx_in_progress->resumed_ticket_id = seq_num;
+                /* Remember rtt and cwin from ticket */
+                server_ticket = picoquic_retrieve_issued_ticket(quic, seq_num);
+                if (server_ticket != NULL && server_ticket->cwin > 0) {
+                    picoquic_seed_bandwidth(
+                        quic->cnx_in_progress,
+                        server_ticket->rtt,
+                        server_ticket->cwin,
+                        server_ticket->ip_addr,
+                        server_ticket->ip_addr_length);
                 }
             }
         }
@@ -1185,8 +1196,13 @@ int picoquic_client_save_ticket_call_back(ptls_save_ticket_t* save_ticket_ctx,
         ret = picoquic_store_ticket(&quic->p_first_ticket, 0, sni, (uint16_t)strlen(sni),
             alpn, (uint16_t)strlen(alpn), NULL, 0,
             input.base, (uint16_t)input.len, &cnx->remote_parameters);
+        /* Set first 8 bytes of ticket as identifier */
+        if (input.len > 8) {
+            cnx->issued_ticket_id = PICOPARSE_64(input.base);
+        }
     } else {
-        DBG_PRINTF("Received incorrect session resume ticket, sni = %s, alpn = %s, length = %d\n",
+        picoquic_log_app_message(cnx, 
+            "Received incorrect session resume ticket, sni = %s, alpn = %s, length = %d\n",
             (sni == NULL) ? "NULL" : sni, (alpn == NULL) ? "NULL" : alpn, (int)input.len);
     }
 
@@ -2248,19 +2264,27 @@ int picoquic_initialize_tls_stream(picoquic_cnx_t* cnx, uint64_t current_time)
     /* No resumption if no alpn specified upfront, because it would make the negotiation and
      * the handling of 0-RTT way too messy */
     if (cnx->sni != NULL && cnx->alpn != NULL && !cnx->quic->client_zero_share) {
-        uint8_t* ticket = NULL;
-        uint16_t ticket_length = 0;
-
-        if (picoquic_get_ticket(cnx->quic->p_first_ticket, current_time,
-            cnx->sni, (uint16_t)strlen(cnx->sni), cnx->alpn, (uint16_t)strlen(cnx->alpn),
-            &ticket, &ticket_length, &cnx->remote_parameters, 1)
-            == 0) {
-            ctx->handshake_properties.client.session_ticket.base = ticket;
-            ctx->handshake_properties.client.session_ticket.len = ticket_length;
-
+        picoquic_stored_ticket_t* stored_ticket = picoquic_get_stored_ticket(cnx->quic->p_first_ticket, 
+            current_time, cnx->sni, (uint16_t)strlen(cnx->sni), cnx->alpn, (uint16_t)strlen(cnx->alpn),
+            1, 0);
+        if (stored_ticket != NULL) {
+            ctx->handshake_properties.client.session_ticket.base = stored_ticket->ticket;
+            ctx->handshake_properties.client.session_ticket.len = stored_ticket->ticket_length;
             ctx->handshake_properties.client.max_early_data_size = &cnx->max_early_data_size;
-
-            cnx->psk_cipher_suite_id = PICOPARSE_16(ticket + 8);
+            /* Remember first 8 bytes of ticket as ticket ID, and set psk suite from ticket */
+            cnx->resumed_ticket_id = PICOPARSE_64(stored_ticket->ticket);
+            cnx->psk_cipher_suite_id = PICOPARSE_16(stored_ticket->ticket + 8);
+            /* Set initial transport parameters from stored values */
+            cnx->remote_parameters.initial_max_data = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_data];
+            cnx->remote_parameters.initial_max_stream_data_bidi_local = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_stream_data_bidi_local];
+            cnx->remote_parameters.initial_max_stream_data_bidi_remote = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_stream_data_bidi_remote];
+            cnx->remote_parameters.initial_max_stream_data_uni = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_stream_data_uni];
+            cnx->remote_parameters.initial_max_stream_id_bidir = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_streams_id_bidir];
+            cnx->remote_parameters.initial_max_stream_id_unidir = stored_ticket->tp_0rtt[picoquic_tp_0rtt_max_streams_id_unidir];
+            /* Seed connection with remembered data */
+            picoquic_seed_bandwidth(cnx, stored_ticket->tp_0rtt[picoquic_tp_0rtt_rtt],
+                stored_ticket->tp_0rtt[picoquic_tp_0rtt_cwin],
+                stored_ticket->ip_addr, stored_ticket->ip_addr_length);
         }
     }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1183,7 +1183,8 @@ int picoquic_client_save_ticket_call_back(ptls_save_ticket_t* save_ticket_ctx,
 
     if (sni != NULL && alpn != NULL) {
         ret = picoquic_store_ticket(&quic->p_first_ticket, 0, sni, (uint16_t)strlen(sni),
-            alpn, (uint16_t)strlen(alpn), input.base, (uint16_t)input.len, &cnx->remote_parameters);
+            alpn, (uint16_t)strlen(alpn), NULL, 0,
+            input.base, (uint16_t)input.len, &cnx->remote_parameters);
     } else {
         DBG_PRINTF("Received incorrect session resume ticket, sni = %s, alpn = %s, length = %d\n",
             (sni == NULL) ? "NULL" : sni, (alpn == NULL) ? "NULL" : alpn, (int)input.len);

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -133,6 +133,7 @@ static const picoquic_test_def_t test_table[] = {
     { "sockets", socket_test },
     { "socket_ecn", socket_ecn_test },
     { "ticket_store", ticket_store_test },
+    { "ticket_seed", ticket_seed_test },
     { "token_store", token_store_test },
     { "token_reuse_api", token_reuse_api_test },
     { "session_resume", session_resume_test },

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -226,6 +226,7 @@ static const picoquic_test_def_t test_table[] = {
     { "bbr_gbps", gbps_performance_test },
     { "long_rtt", long_rtt_test },
     { "satellite_basic", satellite_basic_test },
+    { "satellite_seeded", satellite_seeded_test },
     { "satellite_loss", satellite_loss_test },
     { "satellite_jitter", satellite_jitter_test },
     { "satellite_medium", satellite_medium_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -184,6 +184,7 @@ int ready_to_send_test();
 int cubic_test();
 int cubic_jitter_test();
 int satellite_basic_test();
+int satellite_seeded_test();
 int satellite_loss_test();
 int satellite_jitter_test();
 int satellite_medium_test();

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -90,6 +90,7 @@ int app_message_overflow_test();
 int socket_test();
 int test_stateless_blowback();
 int ticket_store_test();
+int ticket_seed_test();
 int token_store_test();
 int session_resume_test();
 int zero_rtt_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -186,6 +186,7 @@ int tls_api_init_ctx_ex2(picoquic_test_tls_api_ctx_t** pctx, uint32_t proposed_v
     picoquic_connection_id_t* icid, uint32_t nb_connections, int cid_zero, size_t send_buffer_size);
 
 void tls_api_delete_ctx(picoquic_test_tls_api_ctx_t* test_ctx);
+void test_api_delete_test_streams(picoquic_test_tls_api_ctx_t* test_ctx);
 
 int tls_api_one_sim_round(picoquic_test_tls_api_ctx_t* test_ctx,
     uint64_t* simulated_time, uint64_t time_out, int* was_active);

--- a/picoquictest/ticket_store_test.c
+++ b/picoquictest/ticket_store_test.c
@@ -20,6 +20,7 @@
 */
 
 #include "picoquic_internal.h"
+#include "picoquictest_internal.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -486,6 +487,186 @@ int token_reuse_api_test()
         }
 
         picoquic_free(quic);
+    }
+
+    return ret;
+}
+
+/* Ticket seed. Do a connection, and verify that server and client have properly
+ * documented the congestion parameters in the outgoing or incoming tickets
+ */
+static char const* ticket_seed_store = "ticket_seed_store.bin";
+static test_api_stream_desc_t test_scenario_ticket_seed[] = {
+    { 4, 0, 257, 1000000 }
+};
+
+int ticket_seed_test()
+{
+    int ret = 0;
+    uint64_t simulated_time = 0;
+    uint64_t loss_mask = 0;
+    uint64_t max_completion_microsec = 1000000;
+    uint64_t server_ticket_id = 0;
+    uint64_t client_ticket_id = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+
+    /* Initialize an empty ticket store */
+    ret = picoquic_save_tickets(NULL, simulated_time, ticket_seed_store);
+
+    /* Prepare a first connection */
+    ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1,
+        PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, ticket_seed_store, NULL, 0, 0, 0);
+
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+    }
+
+    /* Prepare to send data */
+    if (ret == 0) {
+        ret = test_api_init_send_recv_scenario(test_ctx, test_scenario_ticket_seed, sizeof(test_scenario_ticket_seed));
+    }
+
+    /* Perform a data sending loop */
+    if (ret == 0) {
+        ret = tls_api_data_sending_loop(test_ctx, &loss_mask, &simulated_time, 0);
+    }
+
+    if (ret == 0) {
+        ret = tls_api_one_scenario_body_verify(test_ctx, &simulated_time, max_completion_microsec);
+    }
+
+    if (ret == 0) {
+        /* Check the ticket store at the client. */
+        picoquic_stored_ticket_t* client_ticket;
+
+        client_ticket = picoquic_get_stored_ticket(test_ctx->qclient->p_first_ticket, simulated_time,
+            PICOQUIC_TEST_SNI, (uint16_t)strlen(PICOQUIC_TEST_SNI),
+            PICOQUIC_TEST_ALPN, (uint16_t)strlen(PICOQUIC_TEST_ALPN),
+            0, test_ctx->cnx_client->issued_ticket_id);
+
+        if (client_ticket == NULL) {
+            DBG_PRINTF("%s", "No ticket found for client.");
+            ret = -1;
+        }
+        else {
+            client_ticket_id = test_ctx->cnx_client->issued_ticket_id;
+
+            if (client_ticket->tp_0rtt[picoquic_tp_0rtt_rtt] == 0) {
+                DBG_PRINTF("%s", "RTT not set for client ticket.");
+                ret = -1;
+            }
+            if (client_ticket->tp_0rtt[picoquic_tp_0rtt_cwin] == 0) {
+                DBG_PRINTF("%s", "CWIN not set for client ticket.");
+                ret = -1;
+            }
+        }
+    }
+
+    if (ret == 0) {
+        /* Check the issued tickets list at the server. */
+        picoquic_issued_ticket_t* server_ticket;
+
+        if (test_ctx->cnx_server == NULL) {
+            server_ticket = test_ctx->qserver->table_issued_tickets_first;
+        }
+        else {
+            server_ticket = picoquic_retrieve_issued_ticket(test_ctx->qserver,
+                test_ctx->cnx_server->issued_ticket_id);
+        }
+        if (server_ticket == NULL) {
+            DBG_PRINTF("%s", "No ticket found for server.");
+            ret = -1;
+        }
+        else {
+            server_ticket_id = server_ticket->ticket_id;
+
+            if (server_ticket->rtt == 0) {
+                DBG_PRINTF("%s", "RTT not set for server ticket.");
+                ret = -1;
+            }
+            if (server_ticket->cwin == 0) {
+                DBG_PRINTF("%s", "CWIN not set for server ticket.");
+                ret = -1;
+            }
+        }
+    }
+
+    /* Now we remove the client connection and create a new one. */
+    if (ret == 0) {
+        picoquic_delete_cnx(test_ctx->cnx_client);
+        if (test_ctx->cnx_server != NULL) {
+            picoquic_delete_cnx(test_ctx->cnx_server);
+            test_ctx->cnx_server = NULL;
+        }
+
+        test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient,
+            picoquic_null_connection_id, picoquic_null_connection_id,
+            (struct sockaddr*) & test_ctx->server_addr, simulated_time,
+            0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, 1);
+
+        if (test_ctx->cnx_client == NULL) {
+            ret = -1;
+        }
+        else {
+            ret = picoquic_start_client_cnx(test_ctx->cnx_client);
+        }
+    }
+
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+    }
+
+    /* Prepare to send second batch of data */
+    if (ret == 0) {
+        ret = test_api_init_send_recv_scenario(test_ctx, test_scenario_ticket_seed, sizeof(test_scenario_ticket_seed));
+    }
+
+    /* Perform a data sending loop */
+    if (ret == 0) {
+        ret = tls_api_data_sending_loop(test_ctx, &loss_mask, &simulated_time, 0);
+    }
+
+    if (ret == 0) {
+        ret = tls_api_one_scenario_body_verify(test_ctx, &simulated_time, max_completion_microsec);
+    }
+
+    if (ret == 0) {
+        /* verify that the client resume ticket id is the same as the previous one */
+        if (test_ctx->cnx_client->resumed_ticket_id != client_ticket_id) {
+            DBG_PRINTF("Client ticket id = 0x%" PRIx64 ", expected 0x%" PRIx64, 
+                test_ctx->cnx_client->resumed_ticket_id, client_ticket_id);
+            ret = -1;
+        }
+        if (test_ctx->cnx_client->seed_rtt_min == 0) {
+            DBG_PRINTF("%s", "RTT not set for client ticket.");
+            ret = -1;
+        }
+        if (test_ctx->cnx_client->seed_cwin == 0) {
+            DBG_PRINTF("%s", "CWIN not set for client ticket.");
+            ret = -1;
+        }
+    }
+
+    if (ret == 0) {
+        /* verify that the server resume ticket id is the same as the previous one */
+        if (test_ctx->cnx_server != NULL && test_ctx->cnx_server->resumed_ticket_id != server_ticket_id) {
+            DBG_PRINTF("Server ticket id = 0x%" PRIx64 ", expected 0x%" PRIx64,
+                test_ctx->cnx_server->resumed_ticket_id, server_ticket_id);
+            ret = -1;
+        }
+        if (test_ctx->cnx_client->seed_rtt_min == 0) {
+            DBG_PRINTF("%s", "RTT not set for server ticket.");
+            ret = -1;
+        }
+        if (test_ctx->cnx_client->seed_cwin == 0) {
+            DBG_PRINTF("%s", "CWIN not set for server ticket.");
+            ret = -1;
+        }
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
     }
 
     return ret;

--- a/picoquictest/ticket_store_test.c
+++ b/picoquictest/ticket_store_test.c
@@ -599,6 +599,9 @@ int ticket_seed_test()
             test_ctx->cnx_server = NULL;
         }
 
+        /* Clean the data allocated to test the streams */
+        test_api_delete_test_streams(test_ctx);
+
         test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient,
             picoquic_null_connection_id, picoquic_null_connection_id,
             (struct sockaddr*) & test_ctx->server_addr, simulated_time,

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2713,7 +2713,7 @@ int tls_retry_token_test_one(int token_mode, int dup_token)
 
             test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient,
                 picoquic_null_connection_id, picoquic_null_connection_id,
-                (struct sockaddr*) & test_ctx->server_addr, 0,
+                (struct sockaddr*) & test_ctx->server_addr, simulated_time,
                 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, 1);
 
             if (test_ctx->cnx_client == NULL) {
@@ -8099,7 +8099,12 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, size_t da
         test_ctx->immediate_exit = 1;
 
         if (seed_bw) {
-            picoquic_seed_bandwidth(test_ctx->cnx_client, 2 * latency, mbps_up * 125000);
+            uint8_t * ip_addr;
+            uint8_t ip_addr_length;
+            picoquic_get_ip_addr((struct sockaddr*) & test_ctx->server_addr, &ip_addr, &ip_addr_length);
+
+            picoquic_seed_bandwidth(test_ctx->cnx_client, 2 * latency, mbps_up * 125000,
+                ip_addr, ip_addr_length);
         }
 
         picoquic_cnx_set_pmtud_required(test_ctx->cnx_client, 1);
@@ -8143,7 +8148,7 @@ int satellite_basic_test()
 int satellite_seeded_test()
 {
     /* Simulate remembering RTT and BW from previous connection */
-    return satellite_test_one(picoquic_bbr_algorithm, 100000000, 5200000, 250, 3, 0, 0, 0, 1);
+    return satellite_test_one(picoquic_bbr_algorithm, 100000000, 4800000, 250, 3, 0, 0, 0, 1);
 }
 
 int satellite_loss_test()

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -248,6 +248,14 @@ static void test_api_delete_test_stream(test_api_stream_t* test_stream)
     memset(test_stream, 0, sizeof(test_api_stream_t));
 }
 
+void test_api_delete_test_streams(picoquic_test_tls_api_ctx_t* test_ctx)
+{
+    for (size_t i = 0; i < test_ctx->nb_test_streams; i++) {
+        test_api_delete_test_stream(&test_ctx->test_stream[i]);
+    }
+    test_ctx->nb_test_streams = 0;
+}
+
 static void test_api_receive_stream_data(
     const uint8_t* bytes, size_t length, picoquic_call_back_event_t fin_or_event,
     uint8_t* buffer, size_t max_len, const uint8_t* reference, size_t* nb_received,


### PR DESCRIPTION
This PR implements most of the recommendations from the [0RTT BDP draft](https://github.com/NicoKos/QUIC_HIGH_BDP/blob/master/ietf-document/draft-0rtt-bdp/draft-kuhn-quic-0rtt-bdp-09.txt). However, this PR does not make use of the BDP extension frames defined in the draft, and as such does not require a specific extension from QUIC V1. Instead, the PR lets both client and server remember their BDP parameters independently:

* During a 1RTT session, the client stores the client side RTT and CWIN together with the session resume ticket obtained from the server. The client also store the IP address of the server.
* The server maintains a table of previously issued tickets, indexed by the same random ticket identifier that is used to guarantee uniqueness of the AEAD encryption. Old tokens are removed from the table using LRU logic. For each ticket identifier, the table holds the RTT and CWIN, and also the IP address of the client.

During the 0-RTT session, the nodes wait for the first RTT measurement from the peer's IP address to verify that the parameters have not changed. If the RTT matches expectation, the CWIN is set to the remembered value.

Testing with 250 Mpbs satellite connection, the simulation shows that a 100MB upload time drops from just under 6 seconds with the optimized picoquic code to just under 4.8 seconds when remembering the CWIN and RTT.