### PR TITLE
Extend socket loop

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -700,6 +700,17 @@ int picoquic_incoming_packet(
     unsigned char received_ecn,
     uint64_t current_time);
 
+int picoquic_incoming_packet_ex(
+    picoquic_quic_t* quic,
+    uint8_t* bytes,
+    size_t packet_length,
+    struct sockaddr* addr_from,
+    struct sockaddr* addr_to,
+    int if_index_to,
+    unsigned char received_ecn,
+    picoquic_cnx_t** first_cnx,
+    uint64_t current_time);
+
 /* Applications must regularly poll the "next packet" API to obtain the
  * next packet that will be set over the network. The API for that is
  * picoquic_prepare_next_packet", which operates on a "quic context".

--- a/picoquic/winsockloop.c
+++ b/picoquic/winsockloop.c
@@ -161,7 +161,7 @@ int picoquic_packet_loop_open_sockets_win(int local_port, int local_af,
             if (picoquic_socket_set_ecn_options(sock_ctx[i]->fd, sock_af[i], &recv_set, &send_set) != 0 ||
                 picoquic_socket_set_pkt_info(sock_ctx[i]->fd, sock_af[i]) != 0 ||
                 picoquic_bind_to_port(sock_ctx[i]->fd, sock_af[i], local_port) != 0 ||
-                picoquic_get_local_address(sock_ctx[0]->fd, &local_address) != 0){
+                picoquic_get_local_address(sock_ctx[i]->fd, &local_address) != 0){
                 DBG_PRINTF("Cannot set socket (af=%d, port = %d)\n", sock_af[i], local_port);
                 for (int j = 0; j < i; j++) {
                     if (sock_ctx[i] != NULL) {
@@ -724,6 +724,7 @@ int picoquic_packet_loop_win(picoquic_quic_t* quic,
                             ((struct sockaddr_in*) & local_address)->sin_port = next_port;
                         }
                         sock_ctx[nb_sockets] = sock_ctx_mig;
+                        sock_ports[nb_sockets] = next_port;
                         events[nb_sockets] = mig_sock_event;
                         nb_sockets++;
                         testing_migration = 1;


### PR DESCRIPTION
Make sure that the default socket used by picoquic is numbered, so it can be used for ad hoc signalling.