### PR TITLE
Add min timeout option.

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1186,6 +1186,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(min_timeout)
+        {
+            int ret = min_timeout_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(packet_trace)
         {
             int ret = packet_trace_test();

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -93,6 +93,7 @@ static option_table_line_t option_table[] = {
     { picoquic_option_Version_Upgrade, 'U', "version_upgrade", 1, "", "Version upgrade if server agrees, e.g. -U 00000002" },
     { picoquic_option_No_GSO, '0', "no_gso", 0, "", "Do not use UDP GSO or equivalent" },
     { picoquic_option_BDP_frame, 'j', "bdp", 1, "number", "use bdp extension frame(1) or don\'t (0). Default=0" },
+    { picoquic_option_MIN_TIMEOUT, 'y', "min_timeout", 1, "number", "Set min retransmission timeout for tests in microsec. Default=0" },
     { picoquic_option_HELP, 'h', "help", 0, "This help message" }
 };
 
@@ -492,6 +493,17 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
         }
         break;
     }
+    case picoquic_option_MIN_TIMEOUT: {
+        int v = config_atoi(params, nb_params, 0, &ret);
+        if (ret != 0 || v < 0 ) {
+            fprintf(stderr, "Invalid timeout option: %s\n", config_optval_param_string(opval_buffer, 256, params, nb_params, 0));
+            ret = (ret == 0) ? -1 : ret;
+        }
+        else {
+            config->min_timeout_option = v;
+        }
+        break;
+    }
     case picoquic_option_HELP:
         ret = -1;
         break;
@@ -836,6 +848,7 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
         }
 
         picoquic_set_default_bdp_frame_option(quic, config->bdp_frame_option);
+        picoquic_set_default_min_timeout_option(quic, (uint64_t)config->min_timeout_option);
 
         if (ret != 0) {
             /* Something went wrong */

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -544,6 +544,12 @@ int picoquic_save_retry_tokens(picoquic_quic_t* quic, char const* token_store_fi
 /* Manage bdps */
 void picoquic_set_default_bdp_frame_option(picoquic_quic_t* quic, int enable_bdp_frame);
 
+/* Set a min value of the retransmission timer
+ * This should only be used in special configurations, such as during tests if the
+ * test infrastructure introduces unexpected delays.
+ */
+void picoquic_set_default_min_timeout_option(picoquic_quic_t* quic, uint64_t min_timeout);
+
 /* Set default connection ID length for the context.
  * All valid values are supported on the client.
  * Using a null value on the server is not tested, may not work.

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -71,6 +71,7 @@ typedef enum {
     picoquic_option_Version_Upgrade,
     picoquic_option_No_GSO,
     picoquic_option_BDP_frame,
+    picoquic_option_MIN_TIMEOUT,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -97,6 +98,7 @@ typedef struct st_picoquic_quic_config_t {
     picoquic_lossbit_version_enum lossbit_policy; /* control loss bit */
     int multipath_option;
     int bdp_frame_option;
+    int min_timeout_option;
     /* TODO: control other extensions, e.g. time stamp, ack delay */
     /* Common flags */
     unsigned int initial_random : 1;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -604,6 +604,7 @@ typedef struct st_picoquic_quic_t {
     uint32_t max_number_connections;
     uint64_t stateless_reset_next_time; /* Next time Stateless Reset or VN packet can be sent */
     uint64_t stateless_reset_min_interval; /* Enforced interval between two stateless reset packets */
+    uint64_t min_timeout; /* Min timeout, for tests or special configurations */
     /* Flags */
     unsigned int check_token : 1;
     unsigned int force_check_token : 1;
@@ -624,6 +625,7 @@ typedef struct st_picoquic_quic_t {
     unsigned int use_low_memory : 1; /* if possible, use low memory alternatives, e.g. for AES */
     unsigned int is_preemptive_repeat_enabled : 1; /* enable premptive repeat on new connections */
     unsigned int default_send_receive_bdp_frame : 1; /* enable sending and receiving BDP frame */
+
     picoquic_stateless_packet_t* pending_stateless_packet;
 
     picoquic_congestion_algorithm_t const* default_congestion_alg;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -723,6 +723,12 @@ void picoquic_set_default_bdp_frame_option(picoquic_quic_t* quic, int bdp_option
     quic->default_send_receive_bdp_frame = bdp_option;
 }
 
+
+void picoquic_set_default_min_timeout_option(picoquic_quic_t* quic, uint64_t min_timeout)
+{
+    quic->min_timeout = min_timeout;
+}
+
 void picoquic_free(picoquic_quic_t* quic)
 {
     if (quic != NULL) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -266,7 +266,8 @@ int picoquic_reset_stream(picoquic_cnx_t* cnx,
 
 uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir)
 {
-    int stream_type_id = (cnx->client_mode ^ 1) | ((is_unidir) ? 2 : 0);
+    int stream_type_id = (cnx->client_mode ^ 1);
+    stream_type_id |= ((is_unidir) ? 2 : 0);
 
     return cnx->next_stream_id[stream_type_id];     
 }
@@ -1144,6 +1145,10 @@ static uint64_t picoquic_current_retransmit_timer(picoquic_cnx_t* cnx,
         if (alt_rto < rto) {
             rto = alt_rto;
         }
+    }
+
+    if (rto < cnx->quic->min_timeout > 0) {
+        rto = cnx->quic->min_timeout;
     }
 
     return rto;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -267,7 +267,7 @@ int picoquic_reset_stream(picoquic_cnx_t* cnx,
 uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir)
 {
     /* This code could be written as:
-     * int stream_type_id = ((cnx->client_mode ^ 1) | ((is_unidir) ? 2 : 0));
+     * int stream_type_id = ((cnx->client_mode ^ 1) | ((is_unidir) ? 2 : 0)); 
      * but Visual Studio produces an obnoxious error message about
      * mixing bitwise or and logical or. */
     int stream_type_id = cnx->client_mode ^ 1;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -266,8 +266,14 @@ int picoquic_reset_stream(picoquic_cnx_t* cnx,
 
 uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir)
 {
-    int stream_type_id = (cnx->client_mode ^ 1);
-    stream_type_id |= ((is_unidir) ? 2 : 0);
+    /* This code could be written as:
+     * int stream_type_id = ((cnx->client_mode ^ 1) | ((is_unidir) ? 2 : 0));
+     * but Visual Studio produces an obnoxious error message about
+     * mixing bitwise or and logical or. */
+    int stream_type_id = cnx->client_mode ^ 1;
+    if (is_unidir) {
+        stream_type_id |= 2;
+    }
 
     return cnx->next_stream_id[stream_type_id];     
 }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -207,6 +207,7 @@ static const picoquic_test_def_t test_table[] = {
     { "short_initial_cid", short_initial_cid_test },
     { "stream_id_max", stream_id_max_test },
     { "padding_test", padding_test },
+    { "min_timeout", min_timeout_test },
     { "packet_trace", packet_trace_test },
     { "qlog_trace", qlog_trace_test },
     { "qlog_trace_auto", qlog_trace_auto_test },

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:VU:0j:h";
+static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:VU:0j:y:h";
 
 int config_option_letters_test()
 {
@@ -66,6 +66,7 @@ static picoquic_quic_config_t param1 = {
     2,
     3,
     1,
+    123456,
     /* Common flags */
     1, /* unsigned int initial_random : 1; */
     1, /* unsigned int use_long_log : 1; */
@@ -120,6 +121,7 @@ static char const* config_argv1[] = {
     "-F", "/data/performance_log.csv",
     "-V",
     "-j", "1",
+    "-y", "123456",
     "-0",
     "-i", "0N8C-000123",
     NULL
@@ -143,6 +145,7 @@ static picoquic_quic_config_t param2 = {
     0, /* socket_buffer_size */
     NULL, /* const picoquic_congestion_algorithm_t* cc_algorithm; */
     NULL, /* char const* cnx_id_cbdata; */
+    0,
     0,
     0,
     0,
@@ -280,6 +283,7 @@ int config_test_compare(const picoquic_quic_config_t* expected, const picoquic_q
     ret |= config_test_compare_int("large_client_hello", expected->large_client_hello, actual->large_client_hello);
     ret |= config_test_compare_int("cnx_id_length", expected->cnx_id_length, actual->cnx_id_length);
     ret |= config_test_compare_int("bdp", expected->bdp_frame_option, actual->bdp_frame_option);
+    ret |= config_test_compare_int("min_timeout", expected->min_timeout_option, actual->min_timeout_option);
 
     return ret;
 }
@@ -321,7 +325,7 @@ int config_test_parse_command_line(const picoquic_quic_config_t* expected, const
         }
         ret = picoquic_config_command_line(opt, &opt_ind, argc, argv, optval, &actual);
         if (ret != 0) {
-            DBG_PRINTF("Could not part opt -%c", opt);
+            DBG_PRINTF("Could not parse opt -%c", opt);
         }
     }
 

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -199,6 +199,7 @@ int bdp_cubic_test();
 int bdp_rtt_test();
 int bdp_ip_test();
 int bdp_delay_test();
+int min_timeout_test();
 int long_rtt_test();
 int cid_length_test();
 int initial_server_close_test();

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -11256,6 +11256,12 @@ int min_timeout_test()
             test_scenario_very_long, sizeof(test_scenario_very_long), 0, loss_mask, 0, 20000, 2300000);
     }
 
+    /* Free the resource, which will close the log file. */
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
     return ret;
 }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -7956,6 +7956,8 @@ int performance_test_one(uint64_t max_completion_time, uint64_t mbps, uint64_t r
 
         picoquic_set_binlog(test_ctx->qserver, ".");
         picoquic_set_binlog(test_ctx->qclient, ".");
+        /* Since the client connection was created before the binlog was set, force log of connection header */
+        binlog_new_connection(test_ctx->cnx_client);
 
         test_ctx->c_to_s_link->jitter = jitter;
         test_ctx->c_to_s_link->microsec_latency = latency;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -11446,3 +11446,32 @@ int bdp_cubic_test()
 {
     return bdp_option_test_one(bdp_test_option_cubic);
 }
+
+/* Test of the min timeout option.
+ * Set the min timeout to 100ms, and verify that the connection is still functional despite losses.
+ */
+int min_timeout_test()
+{
+
+    uint64_t simulated_time = 0;
+    uint64_t loss_mask = 0xF00;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_connection_id_t initial_cid = { {0x71, 0x9e, 0x09, 1, 2, 3, 4, 5}, 8 };
+    int ret = tls_api_init_ctx_ex(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 1, 0, &initial_cid);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = -1;
+    }
+
+    /* Set the logging policy on the server side, to store data in the
+     * current working directory, and run a basic test scenario */
+    if (ret == 0) {
+        picoquic_set_binlog(test_ctx->qserver, ".");
+        picoquic_set_default_min_timeout_option(test_ctx->qserver, 100000);
+        test_ctx->qserver->use_long_log = 1;
+        ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
+            test_scenario_very_long, sizeof(test_scenario_very_long), 0, loss_mask, 0, 20000, 2300000);
+    }
+
+    return ret;
+}


### PR DESCRIPTION
@victorstewart Adding a "-y min_timeout" parameter to picoquicdemo, and a corresponding API: 
```
void picoquic_set_default_min_timeout_option(picoquic_quic_t* quic, uint64_t min_timeout);
```
This should unblock your local-loop tests.