### PR TITLE
Fix performance on local 10mbps/100kbps link

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2041,11 +2041,6 @@ void picoquic_compute_ack_gap_and_delay(picoquic_cnx_t* cnx, uint64_t rtt, uint6
             if (nb_packets < 2) {
                 nb_packets = 2;
             }
-#if 1
-            if (cnx->client_mode) {
-                DBG_PRINTF("Watch");
-            }
-#endif
         }
         if (return_data_rate > 0) {
             /* Estimate of ACK size = L2 + IPv6 + UDP + padded ACK */
@@ -2079,11 +2074,6 @@ void picoquic_compute_ack_gap_and_delay(picoquic_cnx_t* cnx, uint64_t rtt, uint6
                     }
                 }
             }
-#if 1
-            if (cnx->client_mode) {
-                DBG_PRINTF("Watch");
-            }
-#endif
         }
     }
 }
@@ -3288,7 +3278,7 @@ uint8_t * picoquic_format_connection_close_frame(picoquic_cnx_t* cnx,
     if ((bytes = picoquic_frames_uint8_encode(bytes, bytes_max, picoquic_frame_type_connection_close)) != NULL &&
         (bytes = picoquic_frames_varint_encode(bytes, bytes_max, cnx->local_error)) != NULL &&
         (bytes = picoquic_frames_varint_encode(bytes, bytes_max, cnx->offending_frame_type)) != NULL &&
-        (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, 0)) != NULL) {
+        (bytes = picoquic_frames_charz_encode(bytes, bytes_max, cnx->local_error_reason)) != NULL) {
         *is_pure_ack = 0;
     }
     else {

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2041,6 +2041,12 @@ void picoquic_compute_ack_gap_and_delay(picoquic_cnx_t* cnx, uint64_t rtt, uint6
             if (nb_packets < 2) {
                 nb_packets = 2;
             }
+            return_data_rate = cnx->path[0]->bandwidth_estimate;
+#if 1
+            if (cnx->client_mode) {
+                DBG_PRINTF("Watch");
+            }
+#endif
         }
         if (return_data_rate > 0) {
             /* Estimate of ACK size = L2 + IPv6 + UDP + padded ACK */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1569,14 +1569,9 @@ int picoquic_process_ack_of_ack_frame(
     picoquic_sack_list_t* first_sack, uint8_t* bytes, size_t bytes_max, size_t* consumed, int is_ecn);
 
 /* Computation of ack delay max and ack gap, based on RTT and Data Rate.
- * If ACK Frequency extension is used, these functions will compute the values
+ * If ACK Frequency extension is used, this function will compute the values
  * that will be sent to the peer. Otherwise, they computes the values used locally.
  */
-
-uint64_t picoquic_compute_ack_gap(picoquic_cnx_t* cnx, uint64_t data_rate);
-
-uint64_t picoquic_compute_ack_delay_max(picoquic_cnx_t * cnx, uint64_t rtt, uint64_t remote_min_ack_delay);
-
 void picoquic_compute_ack_gap_and_delay(picoquic_cnx_t* cnx, uint64_t rtt, uint64_t remote_min_ack_delay, uint64_t data_rate, uint64_t* ack_gap, uint64_t* ack_delay_max);
 
 /* seed the rtt and bandwidth discovery */

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -8116,14 +8116,12 @@ int bbr_asym100_test()
     return ret;
 }
 
-/* Asymmetric test, nodelay
+/* Asymmetric test, no delay.
  * Variant in which the negotiation of delayed ACK is disabled.
- * 
- * TODO: fix bugs and get the target time under 9 seconds.
  */
 int bbr_asym100_nodelay_test()
 {
-    uint64_t max_completion_time = 29000000;
+    uint64_t max_completion_time = 8500000;
     uint64_t latency = 1000;
     uint64_t jitter = 750;
     uint64_t buffer = 50000;


### PR DESCRIPTION
Fix the computation of the ack gap and minimum ack delay, which was causing bad performance on some asymmetric links.