### PR TITLE
Verify datagram max size

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -409,6 +409,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(datagram_size)
+        {
+            int ret = datagram_size_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(ddos_amplification)
         {
             int ret = ddos_amplification_test();

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -98,6 +98,7 @@ static const picoquic_test_def_t test_table[] = {
     { "datagram", datagram_test },
     { "datagram_rt", datagram_rt_test },
     { "datagram_loss", datagram_loss_test },
+    { "datagram_size", datagram_size_test },
     { "ddos_amplification", ddos_amplification_test},
     { "ddos_amplification_0rtt", ddos_amplification_0rtt_test},
     { "blackhole", blackhole_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -263,6 +263,7 @@ int fast_nat_rebinding_test();
 int datagram_test();
 int datagram_rt_test();
 int datagram_loss_test();
+int datagram_size_test();
 int ddos_amplification_test();
 int ddos_amplification_0rtt_test();
 int blackhole_test();

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -653,6 +653,9 @@ int parse_test_packet(picoquic_quic_t* qclient, struct sockaddr* saddr, uint64_t
         /* enable time stamp so it can be used in test */
         cnx->is_time_stamp_enabled = 1;
 
+        /* Set datagram max size to pass verification */
+        cnx->local_parameters.max_datagram_frame_size = PICOQUIC_MAX_PACKET_SIZE;
+
         /* Set min ack delay so there is no issue with ack frequency frame */
         cnx->is_ack_frequency_negotiated = 1;
         cnx->remote_parameters.min_ack_delay = 1000;


### PR DESCRIPTION
Check that incoming datagrams are not larger than specified max size, and add test to verify functionality.