### PR TITLE
Manage unack packet queue per path

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1277,6 +1277,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(path_packet_queue)
+        {
+            int ret = path_packet_queue_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(perflog)
         {
             int ret = perflog_test();

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3103,20 +3103,13 @@ uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* byte
                     else {
                         picoquic_sack_item_record_sent(next_sack);
                         lowest_acknowledged = picoquic_sack_item_first(next_sack);
-                        next_sack = picoquic_sack_item_next(next_sack);
                         num_block++;
                     }
                 }
                 else {
                     range_skipped = 1;
-#if 1
-#else
-                    if (picoquic_sack_item_nb_times_sent(next_sack) < lowest_skipped_range) {
-                        lowest_skipped_range = picoquic_sack_item_nb_times_sent(next_sack);
-                    }
-#endif
-                    next_sack = picoquic_sack_item_next(next_sack);
                 }
+                next_sack = picoquic_sack_item_next(next_sack);
             }
             while (next_sack != NULL) {
                 range_skipped = 1;
@@ -3125,7 +3118,7 @@ uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* byte
                 }
                 next_sack = picoquic_sack_item_next(next_sack);
             }
-#if 1
+
             if (range_skipped &&
                 ack_ctx->max_repeat_per_range > PICOQUIC_MIN_ACK_RANGE_REPEAT &&
                 lowest_skipped_range + 1 < ack_ctx->max_repeat_per_range) {
@@ -3134,17 +3127,7 @@ uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* byte
             else if (ack_ctx->max_repeat_per_range < PICOQUIC_MAX_ACK_RANGE_REPEAT) {
                 ack_ctx->max_repeat_per_range++;
             }
-#else
-            if (range_skipped) {
-                if (ack_ctx->max_repeat_per_range > PICOQUIC_MIN_ACK_RANGE_REPEAT &&
-                    lowest_skipped_range + 1 < ack_ctx->max_repeat_per_range) {
-                    ack_ctx->max_repeat_per_range--;
-                }
-                else if (ack_ctx->max_repeat_per_range < PICOQUIC_MAX_ACK_RANGE_REPEAT) {
-                    ack_ctx->max_repeat_per_range++;
-                }
-            }
-#endif
+
             /* When numbers are lower than 64, varint encoding fits on one byte */
             *num_block_byte = (uint8_t)num_block;
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3082,11 +3082,14 @@ uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* byte
             *more_data = 1;
         }
         else {
+            /* Implement adaptive tuning of lowest repeat range */
+            int range_skipped = 0;
+            int lowest_skipped_range = PICOQUIC_MAX_ACK_RANGE_REPEAT;
             /* Set the lowest acknowledged */
             lowest_acknowledged = picoquic_sack_list_first(&ack_ctx->first_sack_item);
             /* Encode the ack blocks that fit in the allocated space */
             while (num_block < 32 && next_sack != NULL) {
-                if (num_block < 4 || picoquic_sack_item_nb_times_sent(next_sack) < 4) {
+                if (num_block < 4 || picoquic_sack_item_nb_times_sent(next_sack) < ack_ctx->max_repeat_per_range) {
                     uint8_t* bytes_start_range = bytes;
                     ack_gap = lowest_acknowledged - picoquic_sack_item_last(next_sack) - 2; /* per spec */
                     ack_range = picoquic_sack_item_last(next_sack) - picoquic_sack_item_first(next_sack);
@@ -3105,9 +3108,43 @@ uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* byte
                     }
                 }
                 else {
+                    range_skipped = 1;
+#if 1
+#else
+                    if (picoquic_sack_item_nb_times_sent(next_sack) < lowest_skipped_range) {
+                        lowest_skipped_range = picoquic_sack_item_nb_times_sent(next_sack);
+                    }
+#endif
                     next_sack = picoquic_sack_item_next(next_sack);
                 }
             }
+            while (next_sack != NULL) {
+                range_skipped = 1;
+                if (picoquic_sack_item_nb_times_sent(next_sack) < lowest_skipped_range) {
+                    lowest_skipped_range = picoquic_sack_item_nb_times_sent(next_sack);
+                }
+                next_sack = picoquic_sack_item_next(next_sack);
+            }
+#if 1
+            if (range_skipped &&
+                ack_ctx->max_repeat_per_range > PICOQUIC_MIN_ACK_RANGE_REPEAT &&
+                lowest_skipped_range + 1 < ack_ctx->max_repeat_per_range) {
+                ack_ctx->max_repeat_per_range--;
+            }
+            else if (ack_ctx->max_repeat_per_range < PICOQUIC_MAX_ACK_RANGE_REPEAT) {
+                ack_ctx->max_repeat_per_range++;
+            }
+#else
+            if (range_skipped) {
+                if (ack_ctx->max_repeat_per_range > PICOQUIC_MIN_ACK_RANGE_REPEAT &&
+                    lowest_skipped_range + 1 < ack_ctx->max_repeat_per_range) {
+                    ack_ctx->max_repeat_per_range--;
+                }
+                else if (ack_ctx->max_repeat_per_range < PICOQUIC_MAX_ACK_RANGE_REPEAT) {
+                    ack_ctx->max_repeat_per_range++;
+                }
+            }
+#endif
             /* When numbers are lower than 64, varint encoding fits on one byte */
             *num_block_byte = (uint8_t)num_block;
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -369,6 +369,8 @@ typedef struct st_picoquic_packet_t {
     struct st_picoquic_packet_t* previous_packet;
     struct st_picoquic_packet_t* next_packet;
     struct st_picoquic_path_t* send_path;
+    struct st_picoquic_packet_t* path_packet_next;
+    struct st_picoquic_packet_t* path_packet_previous;
     uint64_t sequence_number;
     uint64_t path_packet_number;
     uint64_t send_time;
@@ -928,6 +930,9 @@ typedef struct st_picoquic_path_t {
     uint64_t last_sent_time;
     /* Number of packets sent on this path*/
     uint64_t path_packet_number;
+    /* The packet list holds unkacknowledged packets sent on this path.*/
+    picoquic_packet_t* path_packet_first;
+    picoquic_packet_t* path_packet_last;
     /* flags */
     unsigned int mtu_probe_sent : 1;
     unsigned int path_is_published : 1;
@@ -1368,6 +1373,9 @@ int picoquic_register_net_secret(picoquic_cnx_t* cnx);
 int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time,
     const struct sockaddr* local_addr, const struct sockaddr* peer_addr);
 void picoquic_register_path(picoquic_cnx_t* cnx, picoquic_path_t * path_x);
+void picoquic_enqueue_packet_with_path(picoquic_packet_t* p);
+void picoquic_dequeue_packet_from_path(picoquic_packet_t* p);
+void picoquic_empty_path_packet_queue(picoquic_path_t* path_x);
 void picoquic_delete_path(picoquic_cnx_t* cnx, int path_index);
 void picoquic_demote_path(picoquic_cnx_t* cnx, int path_index, uint64_t current_time);
 void picoquic_promote_path_to_default(picoquic_cnx_t* cnx, int path_index, uint64_t current_time);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -833,6 +833,8 @@ typedef struct st_picoquic_packet_context_t {
 * 2: Initial
 * The context holds all the data required to manage acknowledgments
 */
+#define PICOQUIC_MAX_ACK_RANGE_REPEAT 4
+#define PICOQUIC_MIN_ACK_RANGE_REPEAT 2
 
 typedef struct st_picoquic_ack_context_t {
     picoquic_sack_list_t first_sack_item; /* picoquic_format_ack_frame */
@@ -843,6 +845,8 @@ typedef struct st_picoquic_ack_context_t {
     uint64_t time_oldest_unack_packet_received; /* picoquic_is_ack_needed: first packet that has not been acked yet */
 
     uint64_t crypto_rotation_sequence; /* Lowest sequence seen with current key */
+
+    int max_repeat_per_range; /* Max repeat counter used to fill ack ranges */
 
     /* ECN Counters */
     uint64_t ecn_ect0_total_local; /* picoquic_format_ack_frame */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1461,7 +1461,6 @@ void picoquic_enqueue_packet_with_path(picoquic_packet_t* p)
 
 void picoquic_dequeue_packet_from_path(picoquic_packet_t* p)
 {
-
     if (p->send_path != NULL) {
         if (p->path_packet_previous == NULL && p->path_packet_next == NULL) {
             /* verify that the packet was not already dequeued before making any correction. */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1882,6 +1882,7 @@ void picoquic_init_ack_ctx(picoquic_cnx_t* cnx, picoquic_ack_context_t* ack_ctx)
     ack_ctx->highest_ack_sent_time = cnx->start_time;
     ack_ctx->time_stamp_largest_received = UINT64_MAX;
     ack_ctx->ack_needed = 0;
+    ack_ctx->max_repeat_per_range = PICOQUIC_MAX_ACK_RANGE_REPEAT;
 }
 
 void picoquic_init_packet_ctx(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx)

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1219,7 +1219,7 @@ static int picoquic_retransmit_needed_by_packet(picoquic_cnx_t* cnx,
                  * monopath versions. Without that distinction, some tests would not pass -- but this
                  * is not exactly a good reason. It may be hiding something else, e.g. the need to
                  * adjust the out-of-order packet threshold as a function of paths. */
-                if (cnx->is_multipath_enabled || cnx->is_simple_multipath_enabled) {
+                if (cnx->is_multipath_enabled) {
                     /* When enough ulterior packets are acknowledged, we know that the packet need to be retransmitted */
                     retransmit_time = current_time;
                 }
@@ -1683,15 +1683,11 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
             r_cid = r_cid->next;
         }
     }
-#if 1
     else if (cnx->is_simple_multipath_enabled && cnx->cnx_state == picoquic_state_ready) {
-        /* walk through a per path loop */
+        /* Find the path with the lowest repeat wait? */
         for (int i_path = 0; i_path < cnx->nb_paths; i_path++) {
-#if 0
-            length = picoquic_retransmit_needed_path_loop(cnx, &cnx->pkt_ctx[pc], pc, path_x, current_time, next_wake_time,
-                packet, send_buffer_max, header_length);
-#endif
             picoquic_packet_t* old_p = cnx->path[i_path]->path_packet_first;
+
             if (length == 0) {
                 int continue_next = 1;
 
@@ -1725,7 +1721,6 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
             }
         }
     }
-#endif
     else {
         length = picoquic_retransmit_needed_loop(cnx, &cnx->pkt_ctx[pc], pc, path_x, current_time, next_wake_time,
             packet, send_buffer_max, header_length);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1386,186 +1386,194 @@ int picoquic_copy_before_retransmit(picoquic_packet_t * old_p,
     return ret;
 }
 
-static int picoquic_retransmit_needed_body(picoquic_cnx_t* cnx, picoquic_packet_context_t * pkt_ctx,
+static int picoquic_retransmit_needed_packet(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx,
+    picoquic_packet_t* old_p,
     picoquic_packet_context_enum pc,
-    picoquic_path_t * path_x, uint64_t current_time, uint64_t * next_wake_time,
-    picoquic_packet_t* packet, size_t send_buffer_max, size_t* header_length)
+    picoquic_path_t* path_x, uint64_t current_time, uint64_t* next_wake_time,
+    picoquic_packet_t* packet, size_t send_buffer_max, size_t* header_length,
+    int* continue_next)
 {
-    picoquic_packet_t* old_p = pkt_ctx->retransmit_oldest;
     size_t length = 0;
+    *continue_next = 0;
 
     /* TODO: while packets are pure ACK, drop them from retransmit queue */
-    while (old_p != NULL) {
-        picoquic_path_t * old_path = old_p->send_path; /* should be the path on which the packet was transmitted */
-        int should_retransmit = 0;
-        int timer_based_retransmit = 0;
-        uint64_t next_retransmit_time = *next_wake_time;
-        uint64_t lost_packet_number = old_p->path_packet_number;
-        picoquic_packet_t* p_next = old_p->previous_packet;
-        uint8_t * new_bytes = packet->bytes;
-        int ret = 0;
+    picoquic_path_t* old_path = old_p->send_path; /* should be the path on which the packet was transmitted */
+    int should_retransmit = 0;
+    int timer_based_retransmit = 0;
+    uint64_t next_retransmit_time = *next_wake_time;
+    uint64_t lost_packet_number = old_p->path_packet_number;
+    uint8_t* new_bytes = packet->bytes;
+    int ret = 0;
 
-        length = 0;
+    length = 0;
 
-        /* Get the packet type */
+    /* Get the packet type */
+    should_retransmit = cnx->initial_repeat_needed ||
+        picoquic_retransmit_needed_by_packet(cnx, old_p, current_time, &next_retransmit_time, &timer_based_retransmit);
 
-        should_retransmit = cnx->initial_repeat_needed || 
-            picoquic_retransmit_needed_by_packet(cnx, old_p, current_time, &next_retransmit_time, &timer_based_retransmit);
+    if (should_retransmit == 0) {
+        /*
+         * Always retransmit in order. If not this one, then nothing.
+         * But make an exception for 0-RTT packets.
+         */
+        if (old_p->ptype == picoquic_packet_0rtt_protected) {
+            *continue_next = 1;
+        }
+        else {
+            if (next_retransmit_time < *next_wake_time) {
+                *next_wake_time = next_retransmit_time;
+                SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+            }
+            /* Will not continue */
+            *continue_next = 0;
+        }
+    }
+    else if (old_p->is_ack_trap) {
+        picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, old_p, 1);
+        *continue_next = 1;
+    }
+    else {
+        /* check if this is an ACK only packet */
+        int packet_is_pure_ack = 1;
+        int do_not_detect_spurious = 1;
+        size_t checksum_length = 0;
 
-        if (should_retransmit == 0) {
-            /*
-             * Always retransmit in order. If not this one, then nothing.
-             * But make an exception for 0-RTT packets.
-             */
-            if (old_p->ptype == picoquic_packet_0rtt_protected) {
-                old_p = p_next;
-                continue;
+        /* we'll report it where it got lost */
+        if (old_path) {
+            old_path->retrans_count++;
+        }
+
+        *header_length = 0;
+
+        if (old_p->ptype == picoquic_packet_0rtt_protected) {
+            if (cnx->cnx_state < picoquic_state_client_ready_start) {
+                should_retransmit = 0;
             }
             else {
-                if (next_retransmit_time < *next_wake_time) {
-                    *next_wake_time = next_retransmit_time;
-                    SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
-                }
-                break;
-            }
-        } else if (old_p->is_ack_trap){
-            picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, old_p, 1);
-            old_p = p_next;
-            continue;
-        } else {
-            /* check if this is an ACK only packet */
-            int packet_is_pure_ack = 1;
-            int do_not_detect_spurious = 1;
-            size_t checksum_length = 0;
-
-	        /* we'll report it where it got lost */
-            if (old_path) {
-                old_path->retrans_count++;
-            }
-
-            *header_length = 0;
-
-            if (old_p->ptype == picoquic_packet_0rtt_protected) {
-                if (cnx->cnx_state < picoquic_state_client_ready_start) {
-                    should_retransmit = 0;
-                } else {
-                    length = picoquic_predict_packet_header_length(cnx, picoquic_packet_1rtt_protected, pkt_ctx);
-                    packet->ptype = picoquic_packet_1rtt_protected;
-                    packet->offset = length;
-                }
-            } else {
-                length = picoquic_predict_packet_header_length(cnx, old_p->ptype, pkt_ctx);
-                packet->ptype = old_p->ptype;
+                length = picoquic_predict_packet_header_length(cnx, picoquic_packet_1rtt_protected, pkt_ctx);
+                packet->ptype = picoquic_packet_1rtt_protected;
                 packet->offset = length;
             }
+        }
+        else {
+            length = picoquic_predict_packet_header_length(cnx, old_p->ptype, pkt_ctx);
+            packet->ptype = old_p->ptype;
+            packet->offset = length;
+        }
 
-            if (should_retransmit != 0) {
-                packet->sequence_number = pkt_ctx->send_sequence;
-                packet->send_path = path_x;
-                packet->pc = pc;
-                *header_length = length;
+        if (should_retransmit != 0) {
+            packet->sequence_number = pkt_ctx->send_sequence;
+            packet->send_path = path_x;
+            packet->pc = pc;
+            *header_length = length;
 
-                switch (packet->ptype) {
-                case picoquic_packet_1rtt_protected:
-                    checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_1rtt);
-                    break;
-                case picoquic_packet_initial:
-                    checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_initial);
-                    break;
-                case picoquic_packet_handshake:
-                    checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_handshake);
-                    break;
-                case picoquic_packet_0rtt_protected:
-                    checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_0rtt);
-                    break;
-                default:
-                    DBG_PRINTF("Trying to retransmit packet type %d", old_p->ptype);
-                    checksum_length = 0;
-                    break;
+            switch (packet->ptype) {
+            case picoquic_packet_1rtt_protected:
+                checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_1rtt);
+                break;
+            case picoquic_packet_initial:
+                checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_initial);
+                break;
+            case picoquic_packet_handshake:
+                checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_handshake);
+                break;
+            case picoquic_packet_0rtt_protected:
+                checksum_length = picoquic_get_checksum_length(cnx, picoquic_epoch_0rtt);
+                break;
+            default:
+                DBG_PRINTF("Trying to retransmit packet type %d", old_p->ptype);
+                checksum_length = 0;
+                break;
+            }
+
+            ret = picoquic_copy_before_retransmit(old_p, cnx,
+                new_bytes,
+                send_buffer_max - checksum_length,
+                &packet_is_pure_ack,
+                &do_not_detect_spurious, 0,
+                &length);
+
+            if (ret != 0) {
+                DBG_PRINTF("Copy before retransmit returns %d\n", ret);
+            }
+
+            /* Update the number of bytes in transit and remove old packet from queue */
+            /* If not pure ack, the packet will be placed in the "retransmitted" queue,
+             * in order to enable detection of spurious restransmissions */
+
+            picoquic_log_packet_lost(cnx, old_p->send_path, old_p->ptype, old_p->sequence_number,
+                (timer_based_retransmit == 0) ? "repeat" : "timer",
+                (old_p->send_path == NULL) ? NULL : &old_p->send_path->p_remote_cnxid->cnx_id,
+                old_p->length, current_time);
+
+            old_p = picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, old_p, packet_is_pure_ack & do_not_detect_spurious);
+
+            /* If we have a good packet, return it */
+            if (old_p == NULL || packet_is_pure_ack) {
+                length = 0;
+                *continue_next = 1;
+            }
+            else {
+                int exit_early = 0;
+                if (old_p->send_path != NULL) {
+                    old_p->send_path->lost++;
                 }
-
-                ret = picoquic_copy_before_retransmit(old_p, cnx,
-                    new_bytes,
-                    send_buffer_max - checksum_length,
-                    &packet_is_pure_ack,
-                    &do_not_detect_spurious, 0,
-                    &length);
-
-                if (ret != 0) {
-                    DBG_PRINTF("Copy before retransmit returns %d\n", ret);
-                }
-
-                /* Update the number of bytes in transit and remove old packet from queue */
-                /* If not pure ack, the packet will be placed in the "retransmitted" queue,
-                 * in order to enable detection of spurious restransmissions */
-
-                picoquic_log_packet_lost(cnx, old_p->send_path, old_p->ptype, old_p->sequence_number,
-                        (timer_based_retransmit == 0) ? "repeat" : "timer",
-                        (old_p->send_path == NULL) ? NULL : &old_p->send_path->p_remote_cnxid->cnx_id,
-                        old_p->length, current_time);
-
-                old_p = picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, old_p, packet_is_pure_ack & do_not_detect_spurious);
-
-                /* If we have a good packet, return it */
-                if (old_p == NULL || packet_is_pure_ack) {
-                    length = 0;
-                } else {
-                    if (old_p->send_path != NULL) {
-                        old_p->send_path->lost++;
+                if (old_p->send_path != NULL &&
+                    (old_p->length + old_p->checksum_overhead) == old_p->send_path->send_mtu) {
+                    old_p->send_path->nb_mtu_losses++;
+                    if (old_p->send_path->nb_mtu_losses > PICOQUIC_MTU_LOSS_THRESHOLD) {
+                        picoquic_reset_path_mtu(old_p->send_path);
+                        picoquic_log_app_message(cnx,
+                            "Reset path MTU after %d retransmissions, %d MTU losses",
+                            old_p->send_path->nb_retransmit,
+                            old_p->send_path->nb_mtu_losses);
                     }
+                }
+
+                if (timer_based_retransmit != 0) {
+                    /* First, keep track of retransmissions per path, in order to
+                     * manage scheduling in multipath setup */
                     if (old_p->send_path != NULL &&
-                        (old_p->length + old_p->checksum_overhead) == old_p->send_path->send_mtu) {
-                        old_p->send_path->nb_mtu_losses++;
-                        if (old_p->send_path->nb_mtu_losses > PICOQUIC_MTU_LOSS_THRESHOLD) {
-                            picoquic_reset_path_mtu(old_p->send_path);
-                            picoquic_log_app_message(cnx,
-                                "Reset path MTU after %d retransmissions, %d MTU losses",
-                                old_p->send_path->nb_retransmit,
-                                old_p->send_path->nb_mtu_losses);
+                        old_p->path_packet_number > old_p->send_path->path_packet_acked_number &&
+                        old_p->send_time > old_p->send_path->last_loss_event_detected) {
+                        old_p->send_path->nb_retransmit++;
+                        old_p->send_path->last_loss_event_detected = current_time;
+                        if (old_p->send_path->nb_retransmit > 7) {
+                            /* Max retransmission reached for this path */
+                            DBG_PRINTF("%s\n", "Too many data retransmits, abandon path");
+                            picoquic_log_app_message(cnx, "%s", "Too many data retransmits, abandon path");
+                            old_p->send_path->challenge_failed = 1;
+                            cnx->path_demotion_needed = 1;
                         }
                     }
 
-                    if (timer_based_retransmit != 0) {
-                        /* First, keep track of retransmissions per path, in order to
-                         * manage scheduling in multipath setup */
-                        if (old_p->send_path != NULL  &&
-                            old_p->path_packet_number > old_p->send_path->path_packet_acked_number &&
-                            old_p->send_time > old_p->send_path->last_loss_event_detected){
-                            old_p->send_path->nb_retransmit++;
-                            old_p->send_path->last_loss_event_detected = current_time;
-                            if (old_p->send_path->nb_retransmit > 7) {
-                                /* Max retransmission reached for this path */
-                                DBG_PRINTF("%s\n", "Too many data retransmits, abandon path");
-                                picoquic_log_app_message(cnx, "%s", "Too many data retransmits, abandon path");
-                                old_p->send_path->challenge_failed = 1;
-                                cnx->path_demotion_needed = 1;
-                            }
-                        }
-
-                        /* Then, manage the total number of retransmissions across all paths. */
-                        if (old_p->send_path->nb_retransmit > 7 && cnx->cnx_state >= picoquic_state_ready) {
-                            /* TODO: only disconnect if there is no other available path */
-                            int all_paths_bad = 1;
-                            if (cnx->is_multipath_enabled || cnx->is_simple_multipath_enabled) {
-                                for (int path_id = 0; path_id < cnx->nb_paths; path_id++) {
-                                    if (cnx->path[path_id]->nb_retransmit < 8) {
-                                        all_paths_bad = 0;
-                                        break;
-                                    }
+                    /* Then, manage the total number of retransmissions across all paths. */
+                    if (old_p->send_path->nb_retransmit > 7 && cnx->cnx_state >= picoquic_state_ready) {
+                        /* TODO: only disconnect if there is no other available path */
+                        int all_paths_bad = 1;
+                        if (cnx->is_multipath_enabled || cnx->is_simple_multipath_enabled) {
+                            for (int path_id = 0; path_id < cnx->nb_paths; path_id++) {
+                                if (cnx->path[path_id]->nb_retransmit < 8) {
+                                    all_paths_bad = 0;
+                                    break;
                                 }
                             }
-                            if (all_paths_bad) {
-                                /*
-                                 * Max retransmission count was exceeded. Disconnect.
-                                 */
-                                DBG_PRINTF("Too many retransmits of packet number %d, disconnect", (int)old_p->sequence_number);
-                                cnx->local_error = PICOQUIC_ERROR_REPEAT_TIMEOUT;
-                                picoquic_connection_disconnect(cnx);
-                                length = 0;
-                                break;
-                            }
+                        }
+                        if (all_paths_bad) {
+                            /*
+                             * Max retransmission count was exceeded. Disconnect.
+                             */
+                            DBG_PRINTF("Too many retransmits of packet number %d, disconnect", (int)old_p->sequence_number);
+                            cnx->local_error = PICOQUIC_ERROR_REPEAT_TIMEOUT;
+                            picoquic_connection_disconnect(cnx);
+                            length = 0;
+                            *continue_next = 0;
+                            exit_early = 1;
                         }
                     }
+                }
+
+                if (!exit_early) {
 
                     if (old_p->ptype < picoquic_packet_1rtt_protected) {
                         DBG_PRINTF("Retransmit packet type %d, pc=%d, seq = %llx, is_client = %d\n",
@@ -1590,7 +1598,7 @@ static int picoquic_retransmit_needed_body(picoquic_cnx_t* cnx, picoquic_packet_
                                 0, 0, 0, lost_packet_number, current_time);
                         }
                     }
-                    
+
                     if (length <= packet->offset) {
                         length = 0;
                         packet->length = 0;
@@ -1599,21 +1607,43 @@ static int picoquic_retransmit_needed_body(picoquic_cnx_t* cnx, picoquic_packet_
                             /* Pace down the next retransmission so as to not pile up error upon error */
                             path_x->pacing_bucket_nanosec -= path_x->pacing_packet_time_nanosec;
                         }
+                        /*
+                         * If the loop is continuing, this means that we need to look
+                         * at the next candidate packet.
+                         */
+                        *continue_next = 1;
+
                     }
                     else {
-                        break;
+                        *continue_next = 0;
                     }
                 }
             }
         }
-        /*
-         * If the loop is continuing, this means that we need to look
-         * at the next candidate packet.
-         */
+    }
+
+
+    return (int)length;
+}
+
+static int picoquic_retransmit_needed_loop(picoquic_cnx_t* cnx, picoquic_packet_context_t* pkt_ctx,
+    picoquic_packet_context_enum pc,
+    picoquic_path_t* path_x, uint64_t current_time, uint64_t* next_wake_time,
+    picoquic_packet_t* packet, size_t send_buffer_max, size_t* header_length)
+{
+    int continue_next = 1;
+    int ret = 0;
+    picoquic_packet_t* old_p = pkt_ctx->retransmit_oldest;
+
+    /* Call the per packet routine in a loop */
+    while (old_p != 0 && continue_next) {
+        picoquic_packet_t* p_next = old_p->previous_packet;
+        ret = picoquic_retransmit_needed_packet(cnx, pkt_ctx, old_p, pc, path_x, current_time,
+            next_wake_time, packet, send_buffer_max, header_length, &continue_next);
         old_p = p_next;
     }
 
-    return (int)length;
+    return ret;
 }
 
 int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
@@ -1629,7 +1659,7 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
 
         while (r_cid != NULL) {
             if (length == 0) {
-                length = picoquic_retransmit_needed_body(cnx, &r_cid->pkt_ctx, pc, path_x, current_time,
+                length = picoquic_retransmit_needed_loop(cnx, &r_cid->pkt_ctx, pc, path_x, current_time,
                     next_wake_time, packet, send_buffer_max, header_length);
             }
             else {
@@ -1654,8 +1684,13 @@ int picoquic_retransmit_needed(picoquic_cnx_t* cnx,
         }
     }
     else {
+#if 1
+        length = picoquic_retransmit_needed_loop(cnx, &cnx->pkt_ctx[pc], pc, path_x, current_time, next_wake_time,
+            packet, send_buffer_max, header_length);
+#else
         length = picoquic_retransmit_needed_body(cnx, &cnx->pkt_ctx[pc], pc, path_x, current_time, next_wake_time,
             packet, send_buffer_max, header_length);
+#endif
     }
 
     return length;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -220,6 +220,7 @@ static const picoquic_test_def_t test_table[] = {
     { "qlog_trace_auto", qlog_trace_auto_test },
     { "qlog_trace_only", qlog_trace_only_test },
     { "qlog_trace_ecn", qlog_trace_ecn_test },
+    { "path_packet_queue", path_packet_queue_test },
     { "perflog", perflog_test },
     { "nat_rebinding_stress", rebinding_stress_test },
     { "random_padding", random_padding_test },

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -1178,7 +1178,7 @@ int simple_multipath_basic_test()
 int simple_multipath_drop_first_test()
 {
     /* This is about same as the full multipath test */
-    uint64_t max_completion_microsec = 1500000;
+    uint64_t max_completion_microsec = 1420000;
 
     return multipath_test_one(max_completion_microsec, multipath_test_drop_first, 1);
 }
@@ -1186,7 +1186,7 @@ int simple_multipath_drop_first_test()
 int simple_multipath_drop_second_test()
 {
     /* This is about same as the full multipath test */
-    uint64_t max_completion_microsec = 1350000;
+    uint64_t max_completion_microsec = 1510000;
 
     return multipath_test_one(max_completion_microsec, multipath_test_drop_second, 1);
 }
@@ -1194,7 +1194,7 @@ int simple_multipath_drop_second_test()
 int simple_multipath_sat_plus_test()
 {
     /* Not to far from theoretical 10-12 sec! */
-    uint64_t max_completion_microsec = 10900000;
+    uint64_t max_completion_microsec = 11000000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_sat_plus, 1);
 }
@@ -1237,7 +1237,7 @@ int simple_multipath_back1_test()
 
 int simple_multipath_perf_test()
 {
-    uint64_t max_completion_microsec = 1800000;
+    uint64_t max_completion_microsec = 1450000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_perf, 1);
 }

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -1169,8 +1169,8 @@ int multipath_qlog_test()
  */
 int simple_multipath_basic_test()
 {
-    /* Same duration as the full multipath test */
-    uint64_t max_completion_microsec = 1080000;
+    /* Slightly faster than the full multipath test */
+    uint64_t max_completion_microsec = 1030000;
 
     return multipath_test_one(max_completion_microsec, multipath_test_basic, 1);
 }
@@ -1178,7 +1178,7 @@ int simple_multipath_basic_test()
 int simple_multipath_drop_first_test()
 {
     /* This is about same as the full multipath test */
-    uint64_t max_completion_microsec = 1450000;
+    uint64_t max_completion_microsec = 1500000;
 
     return multipath_test_one(max_completion_microsec, multipath_test_drop_first, 1);
 }
@@ -1186,7 +1186,7 @@ int simple_multipath_drop_first_test()
 int simple_multipath_drop_second_test()
 {
     /* This is about same as the full multipath test */
-    uint64_t max_completion_microsec = 1400000;
+    uint64_t max_completion_microsec = 1350000;
 
     return multipath_test_one(max_completion_microsec, multipath_test_drop_second, 1);
 }
@@ -1194,50 +1194,50 @@ int simple_multipath_drop_second_test()
 int simple_multipath_sat_plus_test()
 {
     /* Not to far from theoretical 10-12 sec! */
-    uint64_t max_completion_microsec = 12300000;
+    uint64_t max_completion_microsec = 10900000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_sat_plus, 1);
 }
 
 int simple_multipath_renew_test()
 {
-    uint64_t max_completion_microsec = 3000000;
+    uint64_t max_completion_microsec = 1100000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_renew, 1);
 }
 
 int simple_multipath_rotation_test()
 {
-    uint64_t max_completion_microsec = 3000000;
+    uint64_t max_completion_microsec = 1100000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_rotation, 1);
 }
 
 int simple_multipath_nat_test()
 {
-    uint64_t max_completion_microsec = 3000000;
+    uint64_t max_completion_microsec = 1200000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_nat, 1);
 }
 
 int simple_multipath_break1_test()
 {
-    uint64_t max_completion_microsec = 13000000;
+    uint64_t max_completion_microsec = 12000000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_break1, 1);
 }
 
 int simple_multipath_back1_test()
 {
-    /* TODO: understand why 5.5 sec instead of 3.7 sec in full multipath test */
-    uint64_t max_completion_microsec = 5500000;
+    /* Slightly better than 3.7 sec in full multipath test */
+    uint64_t max_completion_microsec = 3100000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_back1, 1);
 }
 
 int simple_multipath_perf_test()
 {
-    uint64_t max_completion_microsec = 1480000;
+    uint64_t max_completion_microsec = 1800000;
 
     return  multipath_test_one(max_completion_microsec, multipath_test_perf, 1);
 }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -182,6 +182,7 @@ int qlog_trace_test();
 int qlog_trace_auto_test();
 int qlog_trace_only_test();
 int qlog_trace_ecn_test();
+int path_packet_queue_test();
 int perflog_test();
 int rebinding_stress_test();
 int many_short_loss_test();


### PR DESCRIPTION
Manage a chained list of packets awaiting acknowledgements for each path, so we can perform a clean version of RACK for each path. The goal is to equalize performance of the "simple" and "multiple" packet number spaces options.