### PR TITLE
Stricter tests on incoming VN

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -486,6 +486,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(version_negotiation_spoof)
+        {
+            int ret = test_version_negotiation_spoof();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(test_transport_param_stream_id)
         {
             int ret = transport_param_stream_id_test();

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -868,7 +868,12 @@ int picoquic_incoming_version_negotiation(
         DBG_PRINTF("Unexpected VN packet (%d), state %d, type: %d, epoch: %d, pc: %d, pn: %d\n",
             cnx->client_mode, cnx->cnx_state, ph->ptype, ph->epoch, ph->pc, (int)ph->pn);
     } else if (picoquic_compare_connection_id(&ph->dest_cnx_id, &cnx->path[0]->p_local_cnxid->cnx_id) != 0 || ph->vn != 0) {
-        /* Packet that do not match the "echo" checks should be logged and ignored */
+        /* Packet destination ID does not match local CID, should be logged and ignored */
+        DBG_PRINTF("VN packet (%d), does not pass echo test.\n", cnx->client_mode);
+        ret = PICOQUIC_ERROR_DETECTED;
+    }
+    else if (picoquic_compare_connection_id(&ph->srce_cnx_id, &cnx->initial_cnxid) != 0 || ph->vn != 0) {
+        /* Packet destination ID does not match initial DCID, should be logged and ignored */
         DBG_PRINTF("VN packet (%d), does not pass echo test.\n", cnx->client_mode);
         ret = PICOQUIC_ERROR_DETECTED;
     } else {

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -828,6 +828,8 @@ int picoquic_parse_header_and_decrypt(
             }
         }
         else {
+            /* Clear text packet. Copy content to decrypted data */
+            memmove(decrypted_data->data, bytes, length);
             *consumed = length;
         }
     }

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -881,16 +881,19 @@ int picoquic_incoming_version_negotiation(
                     cnx->client_mode, length, nb_vn);
                 ret = PICOQUIC_ERROR_DETECTED;
                 break;
-            } else if (vn == cnx->proposed_version) {
+            } else if (vn == cnx->proposed_version || vn == 0) {
                 DBG_PRINTF("VN packet (%d), proposed_version[%d] = 0x%08x.\n", cnx->client_mode, nb_vn, vn);
                 ret = PICOQUIC_ERROR_DETECTED;
                 break;
             }
-            nb_vn++;
+            else if (picoquic_get_version_index(vn) >= 0){
+                /* The VN packet proposes a valid version that is locally supported */
+                nb_vn++;
+            }
         }
         if (ret == 0) {
             if (nb_vn == 0) {
-                DBG_PRINTF("VN packet (%d), does not propose any version.\n", cnx->client_mode);
+                DBG_PRINTF("VN packet (%d), does not propose any interesting version.\n", cnx->client_mode);
                 ret = PICOQUIC_ERROR_DETECTED;
             }
             else {

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -92,6 +92,7 @@ static const picoquic_test_def_t test_table[] = {
     { "silence_test", tls_api_silence_test },
     { "version_negotiation", tls_api_version_negotiation_test },
     { "version_invariant", tls_api_version_invariant_test },
+    { "version_negotiation_spoof", test_version_negotiation_spoof },
     { "first_loss", tls_api_client_first_loss_test },
     { "second_loss", tls_api_client_second_loss_test },
     { "SH_loss", tls_api_server_first_loss_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -59,6 +59,7 @@ int tls_api_server_first_loss_test();
 int tls_api_many_losses();
 int tls_api_version_negotiation_test();
 int tls_api_version_invariant_test();
+int test_version_negotiation_spoof();
 int transport_param_test();
 int tls_api_sni_test();
 int tls_api_alpn_test();

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2236,7 +2236,7 @@ size_t test_version_negotiation_get_spoofed(picoquic_cnx_t* cnx, int spoof_mode,
                 plausible_vn = this_vn;
             }
             else if (spoof_mode != 6 && picoquic_nb_supported_versions > 1) {
-                int plausible_index = picoquic_nb_supported_versions - 1;
+                size_t plausible_index = picoquic_nb_supported_versions - 1;
                 if (cnx->version_index == plausible_index) {
                     plausible_index = 0;
                 }


### PR DESCRIPTION
Minimal fix for the silly VN injection in the interop runner test -- see issue #1297