### PR TITLE
Allow short server initial if resuming path

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1520,7 +1520,8 @@ int picoquic_incoming_server_initial(
                             break;
                         }
                     }
-                    if (ack_needed) {
+                    if (ack_needed && cnx->retry_token_length == 0) {
+                        /* perform the test on new paths, but not if resuming an existing path */
                         picoquic_log_app_message(cnx, "Server initial too short (%zu bytes)", packet_length);
                         ret = PICOQUIC_ERROR_INITIAL_TOO_SHORT;
                     }


### PR DESCRIPTION
Loosening the verification of the size of initial server messages. They should be fully padded, otherwise there is a risk of connection failure if the path is asymmetric and cannot carry minimum size datagrams from server to client. But if the path is being resumed, the risk is minimal. Loosening the test allows for fewer interop failures.