### PR TITLE
fix max_stream and retire_cid repeat checks

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -915,7 +915,9 @@ typedef struct st_picoquic_remote_cnxid_t {
     picoquic_connection_id_t cnx_id;
     uint8_t reset_secret[PICOQUIC_RESET_SECRET_SIZE];
     int nb_path_references;
-    int needs_removal;
+    unsigned int needs_removal : 1;
+    unsigned int retire_sent : 1;
+    unsigned int retire_acked : 1;
     picoquic_packet_context_t pkt_ctx;
 } picoquic_remote_cnxid_t;
 
@@ -1284,6 +1286,11 @@ typedef struct st_picoquic_cnx_t {
     uint64_t nb_packets_logged;
     uint64_t nb_retransmission_total;
     uint64_t nb_preemptive_repeat;
+#if 1
+    uint64_t nb_preemptive_data_blocked;
+    uint64_t nb_preemptive_steam_blocked;
+    uint64_t nb_preemptive_others;
+#endif
     uint64_t nb_spurious;
     uint64_t nb_crypto_key_rotations;
     uint64_t nb_packet_holes_inserted;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1286,11 +1286,6 @@ typedef struct st_picoquic_cnx_t {
     uint64_t nb_packets_logged;
     uint64_t nb_retransmission_total;
     uint64_t nb_preemptive_repeat;
-#if 1
-    uint64_t nb_preemptive_data_blocked;
-    uint64_t nb_preemptive_steam_blocked;
-    uint64_t nb_preemptive_others;
-#endif
     uint64_t nb_spurious;
     uint64_t nb_crypto_key_rotations;
     uint64_t nb_packet_holes_inserted;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1710,7 +1710,7 @@ void picoquic_set_ack_needed(picoquic_cnx_t* cnx, uint64_t current_time, picoqui
 /* If the packet contained an ACK frame, perform the ACK of ACK pruning logic.
  * Record stream data as acknowledged, signal datagram frames as acknowledged.
  */
-void picoquic_process_possible_ack_of_ack_frame(picoquic_cnx_t* cnx, picoquic_packet_t* p,
+void picoquic_process_ack_of_frames(picoquic_cnx_t* cnx, picoquic_packet_t* p,
     int is_spurious, uint64_t current_time);
 
 /* Coding and decoding of frames */

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1907,24 +1907,6 @@ static int picoquic_preemptive_retransmit_packet(picoquic_packet_t* old_p,
             if (ret == 0 && frame_is_pure_ack == 0) {
                 ret = picoquic_check_frame_needs_repeat(cnx, &old_p->bytes[byte_index],
                     frame_length, old_p->ptype, &frame_is_pure_ack, &do_not_detect_spurious, 1);
-                if (!frame_is_pure_ack && PICOQUIC_IN_RANGE(old_p->bytes[byte_index], picoquic_frame_type_stream_range_min, picoquic_frame_type_stream_range_max)) {
-                    /* Only perform preemptive repeat if the FIN stream has been sent */
-                    uint64_t stream_id = 0;
-                    uint64_t offset = 0;
-                    size_t data_length = 0;
-                    int fin = 0;
-                    size_t consumed = 0;
-
-                    ret = picoquic_parse_stream_header(&old_p->bytes[byte_index], frame_length,
-                        &stream_id, &offset, &data_length, &fin, &consumed);
-                    if (ret == 0) {
-                        picoquic_stream_head_t* p_stream = picoquic_find_stream(cnx, stream_id);
-
-                        if (p_stream == NULL || !p_stream->fin_sent) {
-                            frame_is_pure_ack = 1;
-                        }
-                    }
-                }
             }
 
             /* Prepare retransmission if needed */

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1921,9 +1921,6 @@ static int picoquic_preemptive_retransmit_packet(picoquic_packet_t* old_p,
                         picoquic_stream_head_t* p_stream = picoquic_find_stream(cnx, stream_id);
 
                         if (p_stream == NULL || !p_stream->fin_sent) {
-                            if (p_stream->sent_offset >= p_stream->maxdata_remote) {
-                                cnx->nb_preemptive_steam_blocked++;
-                            }
                             frame_is_pure_ack = 1;
                         }
                     }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1921,6 +1921,9 @@ static int picoquic_preemptive_retransmit_packet(picoquic_packet_t* old_p,
                         picoquic_stream_head_t* p_stream = picoquic_find_stream(cnx, stream_id);
 
                         if (p_stream == NULL || !p_stream->fin_sent) {
+                            if (p_stream->sent_offset >= p_stream->maxdata_remote) {
+                                cnx->nb_preemptive_steam_blocked++;
+                            }
                             frame_is_pure_ack = 1;
                         }
                     }

--- a/picoquictest/satellite_test.c
+++ b/picoquictest/satellite_test.c
@@ -156,8 +156,9 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, size_t da
             else {
                 uint64_t bdp = mbps_up * latency * 2;
                 uint64_t bdp_p = bdp / (8 * test_ctx->cnx_client->path[0]->send_mtu);
+                uint64_t bdp_p_plus = bdp_p + (bdp_p / 8);
 
-                if (test_ctx->cnx_client->nb_preemptive_repeat > bdp_p) {
+                if (test_ctx->cnx_client->nb_preemptive_repeat > bdp_p_plus) {
                     DBG_PRINTF("Preemptive repeats > BDP(packets): %" PRIu64 " vs %" PRIu64, 
                         test_ctx->cnx_client->nb_preemptive_repeat, bdp_p);
                     ret = -1;


### PR DESCRIPTION
There was an off by 1 error in the check of max stream data frames. Also, there was no correct repeat check for Retire_CID frames, leading to potential outbursts. Plus, needed to relax a bit the number of repeats allowed in the preemptive test.