### PR TITLE
Protection against reflection attacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,7 @@ set(PICOQUIC_LIBRARY_FILES
     picoquic/picoquic_lb.c
     picoquic/picosocks.c
     picoquic/picosplay.c
+    picoquic/port_blocking.c
     picoquic/quicctx.c
     picoquic/sacks.c
     picoquic/sender.c

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2147,6 +2147,13 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+
+        TEST_METHOD(port_blocked) {
+            int ret = port_blocked_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(cplusplus) {
             int ret = cplusplustest();
 

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -61,6 +61,7 @@ static option_table_line_t option_table[] = {
     { picoquic_option_DO_RETRY, 'r', "do_retry", 0, "", "Do Retry Request" },
     { picoquic_option_INITIAL_RANDOM, 'R', "initial_random", 0, "", "randomize initial packet number" },
     { picoquic_option_RESET_SEED, 's', "reset_seed", 2, "<64b 64b>", "Reset seed" },
+    { picoquic_option_DisablePortBlocking, 'X', "disable_block", 0, "", "Disable the check for blocked ports"},
     { picoquic_option_SOLUTION_DIR, 'S', "solution_dir", 1, "folder", "Set the path to the source files to find the default files" },
     { picoquic_option_CC_ALGO, 'G', "cc_algo", 1, "cc_algorithm",
     "Use the specified congestion control algorithm: reno, cubic, bbr or fast. Defaults to bbr." },
@@ -357,6 +358,9 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
     case picoquic_option_RESET_SEED:
         config->reset_seed[1] = config_atoull(params, nb_params, 0, &ret);
         config->reset_seed[0] = config_atoull(params, nb_params, 1, &ret);
+        break;
+    case picoquic_option_DisablePortBlocking:
+        config->disable_port_blocking = 1;
         break;
     case picoquic_option_SOLUTION_DIR:
         ret = config_set_string_param(&config->solution_dir, params, nb_params, 0);
@@ -808,6 +812,8 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
         picoquic_set_log_level(quic, config->use_long_log);
 
         picoquic_set_preemptive_repeat_policy(quic, config->do_preemptive_repeat);
+
+        picoquic_disable_port_blocking(quic, config->disable_port_blocking);
 
         if (config->initial_random) {
             picoquic_set_random_initial(quic, 1);

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -720,7 +720,8 @@ int picoquic_parse_header_and_decrypt(
                 *pcnx = NULL;
                 *new_ctx_created = 0;
             }
-        } else if (ph->ptype != picoquic_packet_version_negotiation && 
+        }
+        else if (ph->ptype != picoquic_packet_version_negotiation &&
             ph->ptype != picoquic_packet_retry && ph->ptype != picoquic_packet_error) {
             /* TODO: clarify length, payload length, packet length -- special case of initial packet */
             length = ph->offset + ph->payload_length;
@@ -736,6 +737,10 @@ int picoquic_parse_header_and_decrypt(
                     else if (ph->dest_cnx_id.id_len < PICOQUIC_ENFORCED_INITIAL_CID_LENGTH) {
                         /* Initial CID too short -- ignore the packet */
                         ret = PICOQUIC_ERROR_INITIAL_CID_TOO_SHORT;
+                    }
+                    else if (!quic->is_port_blocking_disabled && picoquic_check_addr_blocked(addr_from)) {
+                        /* Port is blocked, do not create a connection */
+                        ret = PICOQUIC_ERROR_PORT_BLOCKED;
                     }
                     else if (!quic->enforce_client_only) {
                         /* if listening is OK, listen */
@@ -779,7 +784,7 @@ int picoquic_parse_header_and_decrypt(
                     }
 
                     if (ret == 0) {
-                        decoded_length = picoquic_remove_packet_protection(*pcnx, (uint8_t *) bytes,
+                        decoded_length = picoquic_remove_packet_protection(*pcnx, (uint8_t*)bytes,
                             decrypted_data->data, ph, current_time, &already_received);
                     }
                     else {
@@ -790,7 +795,7 @@ int picoquic_parse_header_and_decrypt(
                         if (ph->ptype == picoquic_packet_1rtt_protected &&
                             length >= PICOQUIC_RESET_PACKET_MIN_SIZE &&
                             memcmp(bytes + length - PICOQUIC_RESET_SECRET_SIZE,
-                            (*pcnx)->path[0]->p_remote_cnxid->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0) {
+                                (*pcnx)->path[0]->p_remote_cnxid->reset_secret, PICOQUIC_RESET_SECRET_SIZE) == 0) {
                             ret = PICOQUIC_ERROR_STATELESS_RESET;
                             picoquic_log_app_message(*pcnx, "Decrypt error, matching reset secret, ret = %d", ret);
                         }
@@ -819,7 +824,10 @@ int picoquic_parse_header_and_decrypt(
                      * of registered secrets. If there is a match, the corresponding connection is
                      * found and the packet is marked as Stateless Reset */
 
-                    if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE) {
+                    if (!quic->is_port_blocking_disabled && picoquic_check_addr_blocked(addr_from)) {
+                        ret = PICOQUIC_ERROR_PORT_BLOCKED;
+                    }
+                    else if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE) {
                         *pcnx = picoquic_cnx_by_secret(quic, bytes + length - PICOQUIC_RESET_SECRET_SIZE, addr_from);
                         if (*pcnx != NULL) {
                             ret = PICOQUIC_ERROR_STATELESS_RESET;
@@ -2217,7 +2225,9 @@ int picoquic_incoming_segment(
     }
 
     if (ret == PICOQUIC_ERROR_VERSION_NOT_SUPPORTED) {
-        if (packet_length >= PICOQUIC_ENFORCED_INITIAL_MTU) {
+        if (packet_length >= PICOQUIC_ENFORCED_INITIAL_MTU &&
+            (quic->is_port_blocking_disabled ||
+            !picoquic_check_addr_blocked(addr_from))) {
             /* use the result of parsing to consider version negotiation */
             picoquic_prepare_version_negotiation(quic, addr_from, addr_to, if_index_to, &ph, raw_bytes);
         }
@@ -2360,6 +2370,7 @@ int picoquic_incoming_segment(
     } else if (ret == PICOQUIC_ERROR_AEAD_CHECK || ret == PICOQUIC_ERROR_INITIAL_TOO_SHORT ||
         ret == PICOQUIC_ERROR_PACKET_WRONG_VERSION ||
         ret == PICOQUIC_ERROR_INITIAL_CID_TOO_SHORT ||
+        ret == PICOQUIC_ERROR_PORT_BLOCKED ||
         ret == PICOQUIC_ERROR_UNEXPECTED_PACKET || 
         ret == PICOQUIC_ERROR_CNXID_CHECK || 
         ret == PICOQUIC_ERROR_RETRY || ret == PICOQUIC_ERROR_DETECTED ||

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -98,6 +98,7 @@ extern "C" {
 #define PICOQUIC_ERROR_VERSION_NEGOTIATION (PICOQUIC_ERROR_CLASS + 55)
 #define PICOQUIC_ERROR_PACKET_TOO_LONG (PICOQUIC_ERROR_CLASS + 56)
 #define PICOQUIC_ERROR_PACKET_WRONG_VERSION (PICOQUIC_ERROR_CLASS + 57)
+#define PICOQUIC_ERROR_PORT_BLOCKED (PICOQUIC_ERROR_CLASS + 58)
 
 /*
  * Protocol errors defined in the QUIC spec
@@ -457,6 +458,11 @@ typedef int (*picoquic_verify_certificate_cb_fn)(void* ctx, picoquic_cnx_t* cnx,
 
 /* Is called to free the verify certificate ctx */
 typedef void (*picoquic_free_verify_certificate_ctx)(void* ctx);
+
+/* Management of the blocked port list */
+int picoquic_check_port_blocked(uint16_t port);
+int picoquic_check_addr_blocked(const struct sockaddr* addr_from);
+void picoquic_disable_port_blocking(picoquic_quic_t* quic, int is_port_blocking_disabled);
 
 /* QUIC context create and dispose */
 picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -159,6 +159,7 @@
     <ClCompile Include="picoquic_lb.c" />
     <ClCompile Include="picosocks.c" />
     <ClCompile Include="picosplay.c" />
+    <ClCompile Include="port_blocking.c" />
     <ClCompile Include="quicctx.c" />
     <ClCompile Include="packet.c" />
     <ClCompile Include="picohash.c" />

--- a/picoquic/picoquic.vcxproj.filters
+++ b/picoquic/picoquic.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="picoquic_lb.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="port_blocking.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquic.h">

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -42,6 +42,7 @@ typedef enum {
     picoquic_option_DO_RETRY,
     picoquic_option_INITIAL_RANDOM,
     picoquic_option_RESET_SEED,
+    picoquic_option_DisablePortBlocking,
     picoquic_option_SOLUTION_DIR,
     picoquic_option_CC_ALGO,
     picoquic_option_SPINBIT,
@@ -103,6 +104,7 @@ typedef struct st_picoquic_quic_config_t {
     unsigned int use_long_log : 1;
     unsigned int do_preemptive_repeat : 1;
     unsigned int do_not_use_gso : 1;
+    unsigned int disable_port_blocking : 1;
     /* Server only */
     char const* www_dir;
     uint64_t reset_seed[2];

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -644,6 +644,7 @@ typedef struct st_picoquic_quic_t {
     unsigned int enforce_client_only : 1; /* Do not authorize incoming connections */
     unsigned int is_flow_control_limited : 1; /* Enforce flow control limit for tests */
     unsigned int test_large_server_flight : 1; /* Use TP to ensure server flight is at least 8K */
+    unsigned int is_port_blocking_disabled : 1; /* Do not check client port on incoming connections */
 
     picoquic_stateless_packet_t* pending_stateless_packet;
 

--- a/picoquic/port_blocking.c
+++ b/picoquic/port_blocking.c
@@ -1,0 +1,162 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2022, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* 
+* The blocked port list used in this document is copied from the msquic
+* implementation by Microsoft and from the list published by Cloudflare.
+*/
+
+#include "picoquic_internal.h"
+#include "picoquic_unified_log.h"
+#include "tls_api.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* Picoquic servers running over UDP can be both victims and enablers
+ * of reflection attacks.
+ *
+ * Servers may be targeted by DDOS attacks, which often use reflection
+ * through an unwitting UDP-based server to hide the actual source of
+ * the attack, and often to amplify the volume of the attack. The
+ * reflected attacks will appear as coming from the address and port
+ * of the server, such as NTP, DNS, other popular services, and also
+ * port number 0 in case of fragmented UDP datagrams. The code
+ * protect against those by just dropping packets from a list of
+ * such ports. This protection is described in this message to the
+ * HTTP WG list:
+ * https://lists.w3.org/Archives/Public/ietf-http-wg/2021JulSep/0053.html
+ * 
+ * The blog entry https://blog.cloudflare.com/reflections-on-reflections/
+ * provides a list of UDP ports that Cloudflare saw used in
+ * reflection attacks:
+ * Count  Proto  Src port
+ *  3774   udp    123        NTP
+ *  1692   udp    1900       SSDP
+ *   438   udp    0          IP fragmentation
+ *   253   udp    53         DNS
+ *    42   udp    27015      SRCDS
+ *    20   udp    19         Chargen
+ *    19   udp    20800      Call Of Duty
+ *    16   udp    161        SNMP
+ *    12   udp    389        CLDAP
+ *    11   udp    111        Sunrpc
+ *    10   udp    137        Netbios
+ *     6   tcp    80         HTTP
+ *     5   udp    27005      SRCDS
+ *     2   udp    520        RIP
+ * 
+ * Nick Banks at Microsoft pointed to the filtering list implemented
+ * in msquic:
+ * https://github.com/microsoft/msquic/blob/main/src/core/binding.c#L1399
+ * The list contains a different set than the one defined by cloudflare,
+ * with the inclusion of services like mDNS, NetBIOS, etc. 
+ *       11211,  // memcache
+ *       5353,   // mDNS
+ *       1900,   // SSDP
+ *       500,    // IKE
+ *       389,    // CLDAP
+ *       161,    // SNMP
+ *       137,    // NETBIOS Name Service
+ *       128,    // NETBIOS Datagram Service
+ *       123,    // NTP
+ *       111,    // Portmap
+ *       53,     // DNS
+ *       19,     // Chargen
+ *       17,     // Quote of the Day
+ *       0,      // Unusable
+ * Services like mDNS or SSDp are typical local, and thus unlikely to be
+ * used for DDOS amplification. Attackers would have difficulties reaching
+ * these services from outside the local network. However, the attackers
+ * could forge the source address and cause the QUIC servers to bounce 
+ * packets towards these services. This kind of "request forgery attacks"
+ * is discussed in section 21.5 of RFC 9000. Blocking the port numbers
+ * of servers targeted by such attacks provides a layer of protection.
+ * 
+ * There are a couple of downsides to this protection:
+ * - Some of the ports listed here are part of the randomly assigned range,
+ *   and a unlucky client could end up using one of these ports.
+ * - Even if clients do not use a reserved port, NATs might. Not much recourse
+ *   there.
+ * - New vulnerable protocols are likely to be created in the future, which
+ *   means that the list will have to be updated.
+ * - If the server sits behind a firewall, the firewall might be a better
+ *   place for maintaining a list of blocked ports.
+ * 
+ * The implementation provides teo mitigations against these downsides:
+ * 
+ * - Servers can disable the protection if they don't want it.
+ * - Clients can test the port number assigned to their sockets and
+ *   pick a new one if they find a collision.
+ * 
+ */
+
+const uint16_t picoquic_blocked_port_list[] = {
+        27015,  /* SRCDS */
+        20800,  /* Call Of Duty */
+        11211,  /* memcache */
+        5353,   /* mDNS */
+        1900,   /* SSDP */
+        520,    /* RIP */
+        500,    /* IKE */
+        389,    /* CLDAP */
+        161,    /* SNMP */
+        138,    /* NETBIOS Datagram Service */
+        137,    /* NETBIOS Name Service */
+        123,    /* NTP */
+        111,    /* Portmap -- used by SUN RPC */
+        53,     /* DNS */
+        19,     /* Chargen */
+        17,     /* Quote of the Day */
+        0,      /* Unusable */
+};
+
+const size_t nb_picoquic_blocked_port_list = sizeof(picoquic_blocked_port_list) / sizeof(uint16_t);
+
+int picoquic_check_port_blocked(uint16_t port)
+{
+    int ret = 0;
+
+    for (size_t i = 0; i < nb_picoquic_blocked_port_list && port <= picoquic_blocked_port_list[i]; i++) {
+        if (port == picoquic_blocked_port_list[i]){
+            ret = 1;
+            break;
+        }
+    }
+
+    return ret;
+}
+
+int picoquic_check_addr_blocked(const struct sockaddr* addr_from)
+{
+    uint16_t port = UINT16_MAX;
+
+    if (addr_from->sa_family == AF_INET) {
+        port = ((struct sockaddr_in*)addr_from)->sin_port;
+    }
+    else if (addr_from->sa_family == AF_INET6) {
+        /* configure an IPv6 sockaddr */
+        port = ((struct sockaddr_in6*)addr_from)->sin6_port;
+    }
+    return picoquic_check_port_blocked(ntohs(port));
+}
+
+void picoquic_disable_port_blocking(picoquic_quic_t * quic, int is_port_blocking_disabled)
+{
+    quic->is_port_blocking_disabled = is_port_blocking_disabled;
+}

--- a/picoquic/port_blocking.c
+++ b/picoquic/port_blocking.c
@@ -72,8 +72,8 @@
  *       500,    // IKE
  *       389,    // CLDAP
  *       161,    // SNMP
+ *       138,    // NETBIOS Datagram Service
  *       137,    // NETBIOS Name Service
- *       128,    // NETBIOS Datagram Service
  *       123,    // NTP
  *       111,    // Portmap
  *       53,     // DNS

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -346,6 +346,7 @@ static const picoquic_test_def_t test_table[] = {
     { "grease_quic_bit", grease_quic_bit_test },
     { "grease_quic_bit_one_way", grease_quic_bit_one_way_test },
     { "pn_random", pn_random_test },
+    { "port_blocked", port_blocked_test },
     { "cplusplus", cplusplustest },
     { "stress", stress_test },
     { "fuzz", fuzz_test },

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:S:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:VU:0j:h";
+static char* ref_option_text = "c:k:K:p:v:o:w:x:rRs:XS:G:P:O:M:e:C:E:i:l:Lb:q:m:n:a:t:zI:DQT:N:B:F:VU:0j:h";
 
 int config_option_letters_test()
 {
@@ -71,6 +71,7 @@ static picoquic_quic_config_t param1 = {
     1, /* unsigned int use_long_log : 1; */
     1, /* unsigned int do_preemptive_repeat : 1; */
     1, /* unsigned int do_not_use_gso : 1 */
+    0, /* disable port blocking */
     /* Server only */
     "/data/www/", /* char const* www_dir; */
     { 0x012345678abcdef, 0xfedcba9876543210}, /* uint64_t reset_seed[2]; */
@@ -152,6 +153,7 @@ static picoquic_quic_config_t param2 = {
     0, /* unsigned int use_long_log : 1; */
     0, /* unsigned int do_preemptive_repeat : 1; */
     0, /* unsigned int do_not_use_gso : 1 */
+    1, /* disable port blocking */
     /* Server only */
     NULL, /* char const* www_dir; */
     {0, 0}, /* uint64_t reset_seed[2]; */
@@ -185,6 +187,7 @@ static const char* config_argv2[] = {
     "-z",
     "-D",
     "-Q",
+    "-X",
     "-I", "5",
     "-T", "/data/tickets.bin",
     "-N", "/data/tokens.bin",

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -347,6 +347,7 @@ int token_reuse_api_test();
 int grease_quic_bit_test();
 int grease_quic_bit_one_way_test();
 int pn_random_test();
+int port_blocked_test();
 int red_cc_test();
 int multi_segment_test();
 int pacing_cc_test();


### PR DESCRIPTION
This PR starts addressing the issue #1012 by silently dropping packets sent from a list of "forbidden ports".