### PR TITLE
Adding an immediate close API.

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -626,6 +626,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(immediate_close)
+        {
+            int ret = immediate_close_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
 		TEST_METHOD(test_very_long_stream)
 		{
 			int ret = tls_api_very_long_stream_test();

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -658,17 +658,21 @@ int picoquic_start_client_cnx(picoquic_cnx_t* cnx);
  * The function "picoquic_close" performs an ordered close. The "reason code"
  * is sent to the peer, and should be visible by the peer's application,
  * unless of course the peer discards the connection before receiving
- * the closing message.
+ * the closing message. The action is delayed until the next
+ * packet can be sent.
  * 
  * The function "picoquic_close_immediate" performs an abrupt close. The
  * connection will immediately move to a "draining" state, no more
  * packets will be sent, no information will be provided to the peer.
  * The connection context will be kept for a very
  * limited time, until it can be safely deleted.
+ * This should be safe to use inclduing inside a picoquic callback,
+ * but it is a bit experimental. Please file an issue if you see a problem.
  * 
  * The function "picoquic_delete_cnx" deletes all the resource associated
  * with the connection, including the connection context. Any reference
- * to the context after making this call will cause an error.
+ * to the context after making this call will cause an error, which
+ * makes it unsafe to use inside a callback.
  */
 int picoquic_close(picoquic_cnx_t* cnx, uint16_t application_reason_code);
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -653,9 +653,28 @@ picoquic_cnx_t* picoquic_create_client_cnx(picoquic_quic_t* quic,
 
 int picoquic_start_client_cnx(picoquic_cnx_t* cnx);
 
-void picoquic_delete_cnx(picoquic_cnx_t* cnx);
-
+/* Closing the quic connection can be done in one of three ways.
+ *
+ * The function "picoquic_close" performs an ordered close. The "reason code"
+ * is sent to the peer, and should be visible by the peer's application,
+ * unless of course the peer discards the connection before receiving
+ * the closing message.
+ * 
+ * The function "picoquic_close_immediate" performs an abrupt close. The
+ * connection will immediately move to a "draining" state, no more
+ * packets will be sent, no information will be provided to the peer.
+ * The connection context will be kept for a very
+ * limited time, until it can be safely deleted.
+ * 
+ * The function "picoquic_delete_cnx" deletes all the resource associated
+ * with the connection, including the connection context. Any reference
+ * to the context after making this call will cause an error.
+ */
 int picoquic_close(picoquic_cnx_t* cnx, uint16_t application_reason_code);
+
+void picoquic_close_immediate(picoquic_cnx_t* cnx);
+
+void picoquic_delete_cnx(picoquic_cnx_t* cnx);
 
 /* Support for version negotiation:
  * Setting the "desired version" parameter will trigger compatible version

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -127,6 +127,7 @@ static const picoquic_test_def_t test_table[] = {
     { "stateless_reset_bad", stateless_reset_bad_test },
     { "stateless_reset_client", stateless_reset_client_test },
     { "stateless_reset_handshake", stateless_reset_handshake_test },
+    { "immediate_close", immediate_close_test },
     { "tls_api_very_long_stream", tls_api_very_long_stream_test },
     { "tls_api_very_long_max", tls_api_very_long_max_test },
     { "tls_api_very_long_with_err", tls_api_very_long_with_err_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -72,6 +72,7 @@ int stateless_reset_test();
 int stateless_reset_bad_test();
 int stateless_reset_client_test();
 int stateless_reset_handshake_test();
+int immediate_close_test();
 int sim_link_test();
 int tls_api_very_long_stream_test();
 int tls_api_very_long_max_test();


### PR DESCRIPTION
This should address issue #1363 

@victorstewart I understand that part of your problem regards callbacks and using the API from within a callback. This is very hard to test. I could do a simulation, but the simulation would only prove that the particular code in the simulation does not cause problem. I do believe that it works, because the state variable is never overwritten, and because the actual clearing of resource will only happen after a timeout. But...