### PR TITLE
fix sni when server address is IP

### DIFF
--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -494,7 +494,7 @@ int quic_client(const char* ip_address_text, int server_port,
 
     if (ret == 0) {
         ret = picoquic_get_server_address(ip_address_text, server_port, &loop_cb.server_address, &is_name);
-        if (sni == NULL && is_name != 0) {
+        if (sni == NULL) {
             sni = ip_address_text;
         }
     }


### PR DESCRIPTION
When `sni == NULL` and `ip_address_text` is a valid IP format, `is_name` would be `0`, thus `sni` should be `ip_address_text` either. So checking whether `is_name != 0` is redundant or is there any other consideration?