### PR TITLE
fix picoquic_socket_error_implies_unreachable comment

### DIFF
--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -233,12 +233,11 @@ int picoquic_get_server_address(const char* ip_address_text, int server_port,
  * of the file is passed in the environment variable SSLKEYLOGFILE,
  * which is accessed through system dependent API.
  */
-
- /* Some socket errors, but not all, indicate that a destination is
-  * unreachable and that the corresponding "path" should be abandoned.
-  */
 void picoquic_set_key_log_file_from_env(picoquic_quic_t* quic);
 
+/* Some socket errors, but not all, indicate that a destination is
+ * unreachable and that the corresponding "path" should be abandoned.
+ */
 int picoquic_socket_error_implies_unreachable(int sock_err);
 
 /* Utility functions for implementing async sockets


### PR DESCRIPTION
picoquic_socket_error_implies_unreachable function description is put before picoquic_set_key_log_file_from_env