### PR TITLE
add ifindex option to picoquicdemo cmdline for multipath

### DIFF
--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -907,9 +907,9 @@ void picoquic_config_clear(picoquic_quic_config_t* config)
     {
         free((void*)config->cnx_id_cbdata);
     }
-    if (config->multipath_alternative_ip != NULL)
+    if (config->multipath_alt_config != NULL)
     {
-        free((void*)config->multipath_alternative_ip);
+        free((void*)config->multipath_alt_config);
     }
     if (config->www_dir != NULL)
     {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1130,6 +1130,10 @@ uint64_t picoquic_get_pacing_rate(picoquic_cnx_t* cnx);
 uint64_t picoquic_get_cwin(picoquic_cnx_t* cnx);
 uint64_t picoquic_get_rtt(picoquic_cnx_t* cnx);
 
+/* Probing new path for multipath scenarios.*/
+int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_from,
+        const struct sockaddr* addr_to, int if_index, uint64_t current_time, int to_preferred_address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -97,7 +97,8 @@ typedef struct st_picoquic_quic_config_t {
     picoquic_spinbit_version_enum spinbit_policy; /* control spin bit */
     picoquic_lossbit_version_enum lossbit_policy; /* control loss bit */
     int multipath_option;
-    char *multipath_alternative_ip;
+    /* TODO: support more than one alternative path */
+    char *multipath_alt_config;
     int bdp_frame_option;
     /* TODO: control other extensions, e.g. time stamp, ack delay */
     /* Common flags */

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1432,8 +1432,6 @@ int picoquic_find_path_by_id(picoquic_cnx_t* cnx, picoquic_path_t* path_x, int i
     uint64_t path_id_type, uint64_t path_id_value);
 int picoquic_assign_peer_cnxid_to_path(picoquic_cnx_t* cnx, int path_id);
 void picoquic_reset_path_mtu(picoquic_path_t* path_x);
-int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_from,
-    const struct sockaddr* addr_to, uint64_t current_time, int to_preferred_address);
 
 /* Management of the CNX-ID stash */
 int picoquic_init_cnxid_stash(picoquic_cnx_t* cnx);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1894,7 +1894,7 @@ int picoquic_assign_peer_cnxid_to_path(picoquic_cnx_t* cnx, int path_id)
 
 /* Create a new path in order to trigger a migration */
 int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_from,
-    const struct sockaddr* addr_to, uint64_t current_time, int to_preferred_address)
+    const struct sockaddr* addr_to, int if_index, uint64_t current_time, int to_preferred_address)
 {
     int ret = 0;
     int partial_match_path = -1;
@@ -1937,6 +1937,7 @@ int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_
             picoquic_set_path_challenge(cnx, path_id, current_time);
             cnx->path[path_id]->path_is_preferred_path = to_preferred_address;
             cnx->path[path_id]->is_nat_challenge = 0;
+            cnx->path[path_id]->if_index_dest = if_index;
         }
     }
 
@@ -1946,7 +1947,7 @@ int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_
 int picoquic_probe_new_path(picoquic_cnx_t* cnx, const struct sockaddr* addr_from,
     const struct sockaddr* addr_to, uint64_t current_time)
 {
-    return picoquic_probe_new_path_ex(cnx, addr_from, addr_to, current_time, 0);
+    return picoquic_probe_new_path_ex(cnx, addr_from, addr_to, 0, current_time, 0);
 }
 
 int picoquic_abandon_path(picoquic_cnx_t* cnx, int path_id, uint64_t reason, char const * phrase)

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2481,7 +2481,7 @@ int picoquic_prepare_server_address_migration(picoquic_cnx_t* cnx)
                     local_addr = (struct sockaddr*) & cnx->path[0]->local_addr;
                 }
 
-                ret = picoquic_probe_new_path_ex(cnx, (struct sockaddr *)&dest_addr, local_addr,
+                ret = picoquic_probe_new_path_ex(cnx, (struct sockaddr *)&dest_addr, local_addr, 0,
                     picoquic_get_quic_time(cnx->quic), 1);
             }
         }

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -320,7 +320,7 @@ int picoquic_parse_client_multipath_config(char *mp_config, int *src_if, struct 
     struct sockaddr_storage ip;
     while ((token = picoquic_strsep(&str, "/"))) {
         if (picoquic_store_text_addr(&ip, token, 0) == 0) {
-            *alt_ip = ip;
+            memcpy(alt_ip, &ip, sizeof(struct sockaddr_storage));
         }
         if (atoi(token) > 0) {
             *src_if = atoi(token);


### PR DESCRIPTION
Per the discussion from https://github.com/private-octopus/picoquic/issues/1134#issuecomment-1146838889, this PR adds `ifindex` to `-A` option on the client side of `picoquicdemo`. 

Option description for `-A`:

```
-A ifindex,ip         Interface index and ip for multipath alternative path, e.g. 3,10.0.0.2
```

Since `-A` only exists for `picoquicdemo`, we cannot utilize `option_table_line_t.nb_params_required` and `static int config_set_option` to control the number of parameters. Therefore, the only solution I can come up with is to use ',' as the delimiter and manually parse the parameter string by the function `picoquic_parse_client_multipath_config` I added. 

Only the scenario of IPv4 with H3 has been tested, although IPv6 is expected to work as well. 
The current implementation only supports one alternative path. 