### PR TITLE
support multiple alt paths in picoquicdemo

### DIFF
--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -97,7 +97,6 @@ typedef struct st_picoquic_quic_config_t {
     picoquic_spinbit_version_enum spinbit_policy; /* control spin bit */
     picoquic_lossbit_version_enum lossbit_policy; /* control loss bit */
     int multipath_option;
-    /* TODO: support more than one alternative path */
     char *multipath_alt_config;
     int bdp_frame_option;
     /* TODO: control other extensions, e.g. time stamp, ack delay */

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -409,8 +409,8 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
 
                 if (picoquic_get_cnx_state(cb_ctx->cnx_client) == picoquic_state_ready && cb_ctx->multipath_probe_done == 0) {
                     for (int i = 0; i < cb_ctx->nb_alt_paths; i++) {
-                        if (picoquic_probe_new_path_ex(cb_ctx->cnx_client, (struct sockaddr *)&cb_ctx->server_address,
-                                                       (struct sockaddr *)&cb_ctx->client_alt_address[i], cb_ctx->client_alt_if[i], picoquic_get_quic_time(quic), 0)) {
+                        if ((ret = picoquic_probe_new_path_ex(cb_ctx->cnx_client, (struct sockaddr *)&cb_ctx->server_address,
+                                (struct sockaddr *)&cb_ctx->client_alt_address[i], cb_ctx->client_alt_if[i], picoquic_get_quic_time(quic), 0)) != 0) {
                             picoquic_log_app_message(cb_ctx->cnx_client, "Probe new path failed with exit code %d\n", ret);
                         } else {
                             picoquic_log_app_message(cb_ctx->cnx_client, "New path added, total path available %d\n", cb_ctx->cnx_client->nb_paths);


### PR DESCRIPTION
This PR adds support to specify multiple alternative paths in picoquicdemo by extending #1369.

The syntax for option `-A` changes to

```
-A ip/ifindex[,ip/ifindex]  IP and interface index for multipath alternative path, e.g. 10.0.0.2/3,10.0.0.3/4
```

The maximum number of alternative paths allowed is specified by reusing `PICOQUIC_NB_PATH_TARGET`.