### PR TITLE
non ending '/' should pass is_path_sane check

### DIFF
--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -211,9 +211,12 @@ int demo_server_is_path_sane(const uint8_t* path, size_t path_length)
         if ((c >= 'a' && c <= 'z') ||
             (c >= 'A' && c <= 'Z') ||
             (c >= '0' && c <= '9') ||
-            c == '-' || c == '_' || c == '/') {
+            c == '-' || c == '_') {
             nb_good++;
             past_is_dot = 0;
+        }
+        else if (c == '/' && i < path_length - 1 && nb_good > 0) {
+            nb_good++;
         }
         else if (c == '.' && !past_is_dot && nb_good > 0){
             past_is_dot = 1;

--- a/picohttp/demoserver.c
+++ b/picohttp/demoserver.c
@@ -211,7 +211,7 @@ int demo_server_is_path_sane(const uint8_t* path, size_t path_length)
         if ((c >= 'a' && c <= 'z') ||
             (c >= 'A' && c <= 'Z') ||
             (c >= '0' && c <= '9') ||
-            c == '-' || c == '_') {
+            c == '-' || c == '_' || c == '/') {
             nb_good++;
             past_is_dot = 0;
         }

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -2010,7 +2010,7 @@ int demo_file_sanitize_test()
 {
     int ret = 0;
     char const* good[] = {
-        "/index.html", "/example.com.txt", "/5000000", "/123_45.png", "/a-b-C-Z"
+        "/index.html", "/example.com.txt", "/5000000", "/123_45.png", "/a-b-C-Z", "/dir/index.html"
     };
     size_t nb_good = sizeof(good) / sizeof(char const*);
     char const* bad[] = {

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -2014,7 +2014,7 @@ int demo_file_sanitize_test()
     };
     size_t nb_good = sizeof(good) / sizeof(char const*);
     char const* bad[] = {
-        "/../index.html", "example.com.txt", "/5000000/", "/.123_45.png", "/a-b-C-Z\\..\\password.txt"
+        "/../index.html", "example.com.txt", "/5000000/", "/.123_45.png", "/a-b-C-Z\\..\\password.txt", "//remote-server/example"
     };
     size_t nb_bad = sizeof(bad) / sizeof(char const*);
 


### PR DESCRIPTION
Fix #1374 

`'/'` should pass `demo_server_is_path_sane` check. 

However, what about `'\\'` on Windows? Since there is also only `path[0] == '/'` check in the code right now. 