### PR TITLE
Implementation and test of Prague congestion control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(PICOQUIC_LIBRARY_FILES
     picoquic/picosocks.c
     picoquic/picosplay.c
     picoquic/port_blocking.c
+    picoquic/prague.c
     picoquic/quicctx.c
     picoquic/sacks.c
     picoquic/sender.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ set(PICOQUIC_TEST_LIBRARY_FILES
     picoquictest/hashtest.c
     picoquictest/high_latency_test.c
     picoquictest/intformattest.c
+    picoquictest/l4s_test.c
     picoquictest/multipath_test.c
     picoquictest/netperf_test.c
     picoquictest/parseheadertest.c

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1577,6 +1577,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(l4s_reno)
+        {
+            int ret = l4s_reno_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(long_rtt)
         {
             int ret = long_rtt_test();

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1584,6 +1584,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(l4s_prague)
+        {
+            int ret = l4s_prague_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(long_rtt)
         {
             int ret = long_rtt_test();

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -3327,21 +3327,6 @@ const uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, const uint8_t* byt
     }
 
     if (bytes != 0 && is_ecn) {
-        if (largest > pkt_ctx->l3s_epoch_send) {
-            /* The packet sent at the beginning of the epoch is now acknowledged */
-            uint64_t delta_ect0 = ecnx3[0] - pkt_ctx->l3s_epoch_ect0;
-            uint64_t delta_ce = ecnx3[2] - pkt_ctx->l3s_epoch_ce;
-
-            if (delta_ce > 0) {
-                pkt_ctx->l3s_frac = (delta_ce * 1024) / (delta_ce + delta_ect0);
-            }
-            else {
-                pkt_ctx->l3s_frac = 0;
-            }
-            pkt_ctx->l3s_epoch_send = pkt_ctx->send_sequence;
-            pkt_ctx->l3s_epoch_ect0 = ecnx3[0];
-            pkt_ctx->l3s_epoch_ce = ecnx3[2];
-        }
         if (ecnx3[0] > pkt_ctx->ecn_ect0_total_remote) {
             pkt_ctx->ecn_ect0_total_remote = ecnx3[0];
         }
@@ -3358,6 +3343,7 @@ const uint8_t* picoquic_decode_ack_frame(picoquic_cnx_t* cnx, const uint8_t* byt
 
     return bytes;
 }
+
 
 uint8_t* picoquic_format_ack_frame_in_context(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max,
     int* more_data, uint64_t current_time, picoquic_ack_context_t* ack_ctx, int* need_time_stamp,

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -52,6 +52,7 @@ static void picoquic_newreno_sim_enter_recovery(
     uint64_t current_time)
 {
     nr_state->ssthresh = nr_state->cwin / 2;
+
     if (nr_state->ssthresh < PICOQUIC_CWIN_MINIMUM) {
         nr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
     }
@@ -108,7 +109,8 @@ void picoquic_newreno_sim_notify(
             break;
         case picoquic_newreno_alg_congestion_avoidance:
         default: {
-            uint64_t complete_delta = nb_bytes_acknowledged * path_x->send_mtu + nr_state->residual_ack;
+            uint64_t complete_delta;
+            complete_delta = nb_bytes_acknowledged * path_x->send_mtu + nr_state->residual_ack;
             nr_state->residual_ack = complete_delta % nr_state->cwin;
             nr_state->cwin += complete_delta / nr_state->cwin;
             break;

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -52,7 +52,6 @@ static void picoquic_newreno_sim_enter_recovery(
     uint64_t current_time)
 {
     nr_state->ssthresh = nr_state->cwin / 2;
-
     if (nr_state->ssthresh < PICOQUIC_CWIN_MINIMUM) {
         nr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
     }
@@ -109,8 +108,7 @@ void picoquic_newreno_sim_notify(
             break;
         case picoquic_newreno_alg_congestion_avoidance:
         default: {
-            uint64_t complete_delta;
-            complete_delta = nb_bytes_acknowledged * path_x->send_mtu + nr_state->residual_ack;
+            uint64_t complete_delta = nb_bytes_acknowledged * path_x->send_mtu + nr_state->residual_ack;
             nr_state->residual_ack = complete_delta % nr_state->cwin;
             nr_state->cwin += complete_delta / nr_state->cwin;
             break;

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1061,7 +1061,7 @@ typedef enum {
     picoquic_congestion_notification_ecn_ec,
     picoquic_congestion_notification_cwin_blocked,
     picoquic_congestion_notification_seed_cwin,
-    picoquic_congestion_notification_reset
+    picoquic_congestion_notification_reset,
 } picoquic_congestion_notification_t;
 
 typedef void (*picoquic_congestion_algorithm_init)(picoquic_path_t* path_x, uint64_t current_time);
@@ -1092,6 +1092,7 @@ extern picoquic_congestion_algorithm_t* picoquic_cubic_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_dcubic_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_fastcc_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_bbr_algorithm;
+extern picoquic_congestion_algorithm_t* picoquic_prague_algorithm;
 
 #define PICOQUIC_DEFAULT_CONGESTION_ALGORITHM picoquic_newreno_algorithm;
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1061,7 +1061,7 @@ typedef enum {
     picoquic_congestion_notification_ecn_ec,
     picoquic_congestion_notification_cwin_blocked,
     picoquic_congestion_notification_seed_cwin,
-    picoquic_congestion_notification_reset,
+    picoquic_congestion_notification_reset
 } picoquic_congestion_notification_t;
 
 typedef void (*picoquic_congestion_algorithm_init)(picoquic_path_t* path_x, uint64_t current_time);

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -160,6 +160,7 @@
     <ClCompile Include="picosocks.c" />
     <ClCompile Include="picosplay.c" />
     <ClCompile Include="port_blocking.c" />
+    <ClCompile Include="prague.c" />
     <ClCompile Include="quicctx.c" />
     <ClCompile Include="packet.c" />
     <ClCompile Include="picohash.c" />

--- a/picoquic/picoquic.vcxproj.filters
+++ b/picoquic/picoquic.vcxproj.filters
@@ -111,6 +111,9 @@
     <ClCompile Include="port_blocking.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="prague.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquic.h">

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -850,6 +850,11 @@ typedef struct st_picoquic_packet_context_t {
     uint64_t ecn_ect0_total_remote;
     uint64_t ecn_ect1_total_remote;
     uint64_t ecn_ce_total_remote;
+    /* L3S/ECN values */
+    uint64_t l3s_epoch_send;
+    uint64_t l3s_epoch_ect0;
+    uint64_t l3s_epoch_ce;
+    uint64_t l3s_frac;
     /* Flags */
     unsigned int ack_of_ack_requested : 1; /* TODO: Initialized, unused */
 } picoquic_packet_context_t;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -104,6 +104,8 @@ extern "C" {
 #define PICOQUIC_CC_ALGO_NUMBER_DCUBIC 3
 #define PICOQUIC_CC_ALGO_NUMBER_FAST 4
 #define PICOQUIC_CC_ALGO_NUMBER_BBR 5
+#define PICOQUIC_CC_ALGO_NUMBER_PRAGUE 6
+
 
 #define PICOQUIC_MAX_ACK_RANGE_REPEAT 4
 #define PICOQUIC_MIN_ACK_RANGE_REPEAT 2
@@ -850,11 +852,6 @@ typedef struct st_picoquic_packet_context_t {
     uint64_t ecn_ect0_total_remote;
     uint64_t ecn_ect1_total_remote;
     uint64_t ecn_ce_total_remote;
-    /* L3S/ECN values */
-    uint64_t l3s_epoch_send;
-    uint64_t l3s_epoch_ect0;
-    uint64_t l3s_epoch_ce;
-    uint64_t l3s_frac;
     /* Flags */
     unsigned int ack_of_ack_requested : 1; /* TODO: Initialized, unused */
 } picoquic_packet_context_t;

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -246,6 +246,7 @@ typedef struct st_picoquictest_sim_packet_t {
     size_t length;
     struct sockaddr_storage addr_from;
     struct sockaddr_storage addr_to;
+    uint8_t ecn_mark;
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquictest_sim_packet_t;
 
@@ -253,6 +254,7 @@ typedef struct st_picoquictest_sim_link_t {
     uint64_t next_send_time;
     uint64_t queue_time;
     uint64_t queue_delay_max;
+    uint64_t l4s_delay;
     uint64_t picosec_per_byte;
     uint64_t microsec_latency;
     uint64_t* loss_mask;
@@ -266,6 +268,8 @@ typedef struct st_picoquictest_sim_link_t {
     /* Variables for random early drop simulation */
     uint64_t red_drop_mask;
     uint64_t red_queue_max;
+    /* L4S MAX sets the ECN mark threshold if doing L4S or DCTCP style ECN marking. */
+    uint64_t l4s_max;
     /* Variables for rate limiter simulation */
     double bucket_increase_per_microsec;
     uint64_t bucket_max;

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -254,7 +254,6 @@ typedef struct st_picoquictest_sim_link_t {
     uint64_t next_send_time;
     uint64_t queue_time;
     uint64_t queue_delay_max;
-    uint64_t l4s_delay;
     uint64_t picosec_per_byte;
     uint64_t microsec_latency;
     uint64_t* loss_mask;

--- a/picoquic/prague.c
+++ b/picoquic/prague.c
@@ -1,0 +1,444 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2017, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "picoquic_internal.h"
+#include <stdlib.h>
+#include <string.h>
+#include "cc_common.h"
+
+/* Implementation of L4S/Prague, derived from New Reno
+ */
+
+/*
+ * We implement here the Prague algotithm as a simple modification of New Reno,
+ * with the following changes:
+ * 
+ * - maintain a coefficient "alpha", exponentially smoothed value of "frac", the
+ *   fraction of EC/(ECT+ECT1) notifications in previous RTT.
+ *       As a slight deviation from the base prague specification, we set
+ *       alpha to frac if frac is more than alpha + 0.5. This addresses the
+ *       issue of sudden onset of congestion.
+ * - modify HyStart to not exit immediately on ECN notification, unless "frac"
+ *   is larger than 0.5 (i.e., 512 since computations are fixed point with 10
+ *   bits of precision)
+ * - use alpha in HyStart, i.e. increase window by (1-alpha)*acked_data instead
+ *   of full increase.
+ * - use alpha in New Reno: control amount of window increase or decrease, as
+ *   in Prague spec.
+ * 
+ */
+
+/* Observations and issues:
+ *
+ * Exit hystart one RTT too late. Hystart ends when the first EC markings appear.
+ * These are the marks cause by traffic of epoch N-1. The traffic of epoch N
+ * is already in flight, will cause congestion and losses. Increasing 
+ * the pacing rate or the quantum value does cause an earlier exit from
+ * slow start, but the window ends up too small -- maybe due to the
+ * redundant loss signal mentioned above.
+ * 
+ * Window shrinking after idle. There are no data in flight at the beginning
+ * of the epoch. The leaky-bucket based pacing allows a quick initial flight
+ * to come in. The queue increases, many packets are marked. As a consequence,
+ * the window shrinks, even in the absence of losses.
+ * 
+ * This variant overrides the smoothing if there are sudden onset of marks.
+ * Not doing that improves performance, but also causes a sharp increase in
+ * the number of losses.
+ * 
+ * Redundant loss signals. Marks are detected at epoch[N]. Very likely, this 
+ * correlates with losses one RTO timer later. The window shrunk once because
+ * of the marks, shrinks again when the loss happens -- value is then too low.
+ * Something similar happens in the other direction as well. Slow start exits
+ * due to increased delays, observed before the end of the epoch. Shortly
+ * after that, congestion marks are reported at end of epoch, causing window
+ * to shrink further. Same could happen if losses are observed, followed
+ * by CE marks.
+ * 
+ * Correlated CE marks. If CE marks happen at epoch N, the traffic in flight
+ * correpond to the old window, before the window is reduced. CE marks will
+ * very likely be detected in next window, causing too much reduction. This
+ * effect is much reduced if dirctly using "frac" instead of computing "alpha".
+ * 
+ * L4S threshold is hard to set for the AQM. Too low, and the throughput
+ * drops. Too high, and the amount of losses increases too much. In the
+ * tests, the threshold is set approximately BDP/4. This may be dues to
+ * inefficient solutions of the issues mentioned above.
+ * 
+ * Current implementation relies on stack to measure "frac". This is probably
+ * a bad idea, as the "frac" epoch is not synchronized with other signals,
+ * such as exit of hystart, delay detections, or packet losses. It would
+ * be better to move that computation inside the "prague" code.
+ * 
+ * Restarted the implementation using the code from the prague PR. Issue:
+ * the callbacks for ECN do not seem to happen! Also, the computation seems
+ * to only work by computing "acknowledged data", but the frequency indices
+ * correspond to number of marks, not number of bytes.
+ */
+
+#include "picoquic_internal.h"
+#include <stdlib.h>
+#include <string.h>
+
+typedef enum {
+    picoquic_prague_alg_slow_start = 0,
+    picoquic_prague_alg_congestion_avoidance
+} picoquic_prague_alg_state_t;
+
+#define NB_RTT_RENO 4
+#define PRAGUE_SHIFT_G 4 /* g = 1/2^4, gain parameter for alpha EWMA */
+#define PRAGUE_G_INV (1<<PRAGUE_SHIFT_G)
+
+typedef struct st_picoquic_prague_state_t {
+    picoquic_prague_alg_state_t alg_state;
+    // double alpha;
+    uint64_t alpha_shifted;
+    uint64_t alpha;
+    uint64_t acked_bytes_ecn;
+    uint64_t acked_bytes_total;
+    uint64_t loss_cwnd;
+    uint64_t residual_ack;
+    uint64_t ssthresh;
+    uint64_t recovery_start;
+    uint64_t min_rtt;
+    uint64_t last_rtt[NB_RTT_RENO];
+
+    uint64_t l4s_epoch_send;
+    uint64_t l4s_epoch_ect0;
+    uint64_t l4s_epoch_ce;
+    int nb_rtt;
+    
+    picoquic_min_max_rtt_t rtt_filter;
+
+    uint64_t flags;
+} picoquic_prague_state_t;
+
+void picoquic_prague_init(picoquic_path_t* path_x, uint64_t current_time)
+{
+    /* Initialize the state of the congestion control algorithm */
+    picoquic_prague_state_t* pr_state = (picoquic_prague_state_t*)malloc(sizeof(picoquic_prague_state_t));
+
+    if (pr_state != NULL) {
+        memset(pr_state, 0, sizeof(picoquic_prague_state_t));
+        path_x->congestion_alg_state = (void*)pr_state;
+        pr_state->alg_state = picoquic_prague_alg_slow_start;
+        pr_state->ssthresh = (uint64_t)((int64_t)-1);
+        pr_state->alpha = 0;
+        path_x->cwin = PICOQUIC_CWIN_INITIAL;
+    }
+    else {
+        path_x->congestion_alg_state = NULL;
+    }
+}
+
+/* The recovery state last 1 RTT, during which parameters will be frozen
+ */
+static void picoquic_prague_enter_recovery(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* path_x,
+    picoquic_congestion_notification_t notification,
+    picoquic_prague_state_t* pr_state,
+    uint64_t current_time)
+{
+    pr_state->ssthresh = path_x->cwin / 2;
+    if (pr_state->ssthresh < PICOQUIC_CWIN_MINIMUM) {
+        pr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
+    }
+
+    if (notification == picoquic_congestion_notification_timeout) {
+        path_x->cwin = PICOQUIC_CWIN_MINIMUM;
+        pr_state->alg_state = picoquic_prague_alg_slow_start;
+    }
+    else {
+        path_x->cwin = pr_state->ssthresh;
+        pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+    }
+
+    pr_state->recovery_start = current_time;
+
+    pr_state->residual_ack = 0;
+    
+    picoquic_packet_context_t* pkt_ctx = &cnx->pkt_ctx[picoquic_packet_context_application];
+
+    /* Reset the L3S measurement context to the current value */
+    if (cnx->is_multipath_enabled) {
+        /* TODO: if the RCID index has changed, reset the counters. */
+        picoquic_remote_cnxid_t* r_cid = path_x->p_remote_cnxid;
+
+        if (r_cid != NULL) {
+            pkt_ctx = &r_cid->pkt_ctx;
+        }
+    }
+    pr_state->l4s_epoch_send = pkt_ctx->send_sequence;
+    pr_state->l4s_epoch_ect0 = pkt_ctx->ecn_ect0_total_remote;
+    pr_state->l4s_epoch_ce = pkt_ctx->ecn_ce_total_remote;
+    pr_state->alpha = 0;
+    pr_state->alpha_shifted = 0;
+}
+
+
+static void picoquic_prague_reset(picoquic_prague_state_t* pr_state)
+{
+    pr_state->acked_bytes_ecn = 0;
+    pr_state->acked_bytes_total = 0;
+}
+
+static void picoquic_prague_update_alpha(picoquic_cnx_t* cnx,
+    picoquic_path_t* path_x, picoquic_prague_state_t* pr_state, uint64_t nb_bytes_acknowledged, uint64_t current_time)
+{
+    /* Check the L4S epoch, based on first number sent in previous epoch */
+    picoquic_packet_context_t* pkt_ctx = &cnx->pkt_ctx[picoquic_packet_context_application];
+
+    if (cnx->is_multipath_enabled) {
+        /* TODO: if the RCID index has changed, reset the counters. */
+        picoquic_remote_cnxid_t* r_cid = path_x->p_remote_cnxid;
+
+        if (r_cid != NULL) {
+            pkt_ctx = &r_cid->pkt_ctx;
+        }
+    }
+
+    if (path_x->path_packet_acked_number >= pr_state->l4s_epoch_send) {
+        /* The epoch packet has been acked. Time to update alpha. */
+        uint64_t frac = 0;
+        pr_state->l4s_epoch_send = pkt_ctx->send_sequence;
+        uint64_t delta_ect0 = pkt_ctx->ecn_ect0_total_remote - pr_state->l4s_epoch_ect0;
+        uint64_t delta_ce = pkt_ctx->ecn_ce_total_remote - pr_state->l4s_epoch_ce;
+
+        if (delta_ce > 0) {
+            frac = (delta_ce * 1024) / (delta_ce + delta_ect0);
+        }
+        else {
+            frac = 0;
+        }
+
+        if (delta_ce > 0 || delta_ect0 > 0) {
+            if (frac > 512) {
+                pr_state->alpha = frac;
+                pr_state->alpha_shifted = frac << PRAGUE_SHIFT_G;
+            }
+            else {
+                int64_t delta_frac = frac - pr_state->alpha;
+
+                pr_state->alpha_shifted += delta_frac;
+                pr_state->alpha = pr_state->alpha_shifted >> PRAGUE_SHIFT_G;
+            }
+        }
+
+        pr_state->l4s_epoch_send = pkt_ctx->send_sequence;
+        pr_state->l4s_epoch_ect0 = pkt_ctx->ecn_ect0_total_remote;
+        pr_state->l4s_epoch_ce = pkt_ctx->ecn_ce_total_remote;
+
+        if (delta_ce > 0) {
+            if (pr_state->alpha > 512) {
+                /* If we got many ECN marks in the last RTT, treat as full on congestion */
+                picoquic_prague_enter_recovery(cnx, path_x, picoquic_congestion_notification_ecn_ec, pr_state, current_time);
+            }
+            else {
+                /* If we got ECN marks in the last RTT, update the ssthresh and the CWIN */
+                pr_state->loss_cwnd = path_x->cwin;
+                uint64_t reduction = (path_x->cwin * pr_state->alpha) / 2048;
+                pr_state->ssthresh = path_x->cwin - reduction;
+                if (pr_state->ssthresh < PICOQUIC_CWIN_MINIMUM) {
+                    pr_state->ssthresh = PICOQUIC_CWIN_MINIMUM;
+                }
+                uint64_t old_cwin = path_x->cwin;
+                path_x->cwin = pr_state->ssthresh;
+                pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+
+                picoquic_log_app_message(cnx, "Prague alpha: %" PRIu64 ", cwin, was % " PRIu64 " is now % " PRIu64 "\n",
+                    pr_state->alpha, old_cwin, path_x->cwin);
+            }
+        }
+    }
+}
+
+/* Callback management for Prague
+ */
+void picoquic_prague_notify(
+    picoquic_cnx_t* cnx,
+    picoquic_path_t* path_x,
+    picoquic_congestion_notification_t notification,
+    uint64_t rtt_measurement,
+    uint64_t one_way_delay,
+    uint64_t nb_bytes_acknowledged,
+    uint64_t lost_packet_number,
+    uint64_t current_time)
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(lost_packet_number);
+#endif
+    picoquic_prague_state_t* pr_state = (picoquic_prague_state_t*)path_x->congestion_alg_state;
+
+    if (pr_state != NULL) {
+        switch (notification) {
+        case picoquic_congestion_notification_acknowledgement: {
+            if (nb_bytes_acknowledged) {
+                pr_state->acked_bytes_total += nb_bytes_acknowledged;
+            }
+            // Regardless of the alg state, update alpha
+            picoquic_prague_update_alpha(cnx, path_x, pr_state, nb_bytes_acknowledged, current_time);
+            switch (pr_state->alg_state) {
+            case picoquic_prague_alg_slow_start:
+                if (path_x->smoothed_rtt <= PICOQUIC_TARGET_RENO_RTT) {
+                    path_x->cwin += (nb_bytes_acknowledged * (1024 - pr_state->alpha)) / 1024;
+                }
+                else {
+                    uint64_t delta = nb_bytes_acknowledged;
+                    delta *= path_x->smoothed_rtt;
+                    delta *= (1024 - pr_state->alpha);
+                    delta /= PICOQUIC_TARGET_RENO_RTT;
+                    delta /= 1024;
+                    path_x->cwin += delta;
+                }
+                /* if cnx->cwin exceeds SSTHRESH, exit and go to CA */
+                if (path_x->cwin >= pr_state->ssthresh) {
+                    pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+                }
+                break;
+            case picoquic_prague_alg_congestion_avoidance:
+            default: {
+                uint64_t complete_delta = nb_bytes_acknowledged * path_x->send_mtu + pr_state->residual_ack;
+                pr_state->residual_ack = complete_delta % path_x->cwin;
+                uint64_t delta = complete_delta / path_x->cwin;
+                delta = (delta * (1024 - pr_state->alpha)) / 1024;
+                path_x->cwin += delta;
+                break;
+            }
+            }
+            break;
+        }
+        case picoquic_congestion_notification_ecn_ec:
+            // picoquic_prague_update_alpha(cnx, path_x, pr_state, nb_bytes_acknowledged, current_time);
+            if (pr_state->alg_state == picoquic_prague_alg_slow_start &&
+                pr_state->ssthresh == UINT64_MAX) {
+                if (path_x->cwin > path_x->send_mtu) {
+                    path_x->cwin -= path_x->send_mtu;
+                }
+                pr_state->ssthresh = path_x->cwin;
+                pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+                path_x->is_ssthresh_initialized = 1;
+            }
+            break;
+        case picoquic_congestion_notification_repeat:
+        case picoquic_congestion_notification_timeout:
+            /* enter recovery */
+            if (current_time - pr_state->recovery_start > path_x->smoothed_rtt) {
+                picoquic_prague_enter_recovery(cnx, path_x, notification, pr_state, current_time);
+            }
+            break;
+        case picoquic_congestion_notification_spurious_repeat:
+            if (current_time - pr_state->recovery_start < path_x->smoothed_rtt) {
+                /* If spurious repeat of initial loss detected,
+                 * exit recovery and reset threshold to pre-entry cwin.
+                 */
+                if (path_x->cwin < 2 * pr_state->ssthresh) {
+                    path_x->cwin = 2 * pr_state->ssthresh;
+                    pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+                }
+            }
+            break;
+        case picoquic_congestion_notification_rtt_measurement:
+            /* Using RTT increases as signal to get out of initial slow start */
+            if (pr_state->alg_state == picoquic_prague_alg_slow_start &&
+                pr_state->ssthresh == UINT64_MAX) {
+
+                if (path_x->rtt_min > PICOQUIC_TARGET_RENO_RTT) {
+                    uint64_t min_win;
+
+                    if (path_x->rtt_min > PICOQUIC_TARGET_SATELLITE_RTT) {
+                        min_win = (uint64_t)((double)PICOQUIC_CWIN_INITIAL * (double)PICOQUIC_TARGET_SATELLITE_RTT / (double)PICOQUIC_TARGET_RENO_RTT);
+                    }
+                    else {
+                        /* Increase initial CWIN for long delay links. */
+                        min_win = (uint64_t)((double)PICOQUIC_CWIN_INITIAL * (double)path_x->rtt_min / (double)PICOQUIC_TARGET_RENO_RTT);
+                    }
+                    if (min_win > path_x->cwin) {
+                        path_x->cwin = min_win;
+                    }
+                }
+
+                if (picoquic_hystart_test(&pr_state->rtt_filter, (cnx->is_time_stamp_enabled) ? one_way_delay : rtt_measurement,
+                    cnx->path[0]->pacing_packet_time_microsec, current_time,
+                    cnx->is_time_stamp_enabled)) {
+                    /* RTT increased too much, get out of slow start! */
+                    pr_state->ssthresh = path_x->cwin;
+                    pr_state->alg_state = picoquic_prague_alg_congestion_avoidance;
+                    path_x->is_ssthresh_initialized = 1;
+                }
+            }
+            break;
+        case picoquic_congestion_notification_bw_measurement:
+            if (pr_state->alg_state == picoquic_prague_alg_slow_start &&
+                pr_state->ssthresh == UINT64_MAX) {
+                /* RTT measurements will happen after the bandwidth is estimated */
+                uint64_t max_win = path_x->max_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
+                uint64_t min_win = max_win /= 2;
+                if (path_x->cwin < min_win) {
+                    path_x->cwin = min_win;
+                }
+            }
+            break;
+        case picoquic_congestion_notification_reset:
+            picoquic_prague_reset(pr_state);
+            break;
+        default:
+            /* ignore */
+            break;
+        }
+    }
+
+    /* Compute pacing data */
+    picoquic_update_pacing_data(cnx, path_x, pr_state->alg_state == picoquic_prague_alg_slow_start &&
+        pr_state->ssthresh == UINT64_MAX);
+}
+
+/* Release the state of the congestion control algorithm */
+void picoquic_prague_delete(picoquic_path_t* path_x)
+{
+    if (path_x->congestion_alg_state != NULL) {
+        free(path_x->congestion_alg_state);
+        path_x->congestion_alg_state = NULL;
+    }
+}
+
+/* Observe the state of congestion control */
+
+void picoquic_prague_observe(picoquic_path_t* path_x, uint64_t* cc_state, uint64_t* cc_param)
+{
+    picoquic_prague_state_t* pr_state = (picoquic_prague_state_t*)path_x->congestion_alg_state;
+    *cc_state = (uint64_t)pr_state->alg_state;
+    *cc_param = (pr_state->ssthresh == UINT64_MAX) ? 0 : pr_state->ssthresh;
+}
+
+/* Definition record for the Prague algorithm */
+
+#define PICOQUIC_PRAGUE_ID "prague" 
+
+picoquic_congestion_algorithm_t picoquic_prague_algorithm_struct = {
+    PICOQUIC_PRAGUE_ID, PICOQUIC_CC_ALGO_NUMBER_PRAGUE,
+    picoquic_prague_init,
+    picoquic_prague_notify,
+    picoquic_prague_delete,
+    picoquic_prague_observe
+};
+
+picoquic_congestion_algorithm_t* picoquic_prague_algorithm = &picoquic_prague_algorithm_struct;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -4066,6 +4066,9 @@ picoquic_congestion_algorithm_t const* picoquic_get_congestion_algorithm(char co
         else if (strcmp(alg_name, "bbr") == 0) {
             alg = picoquic_bbr_algorithm;
         }
+        else if (strcmp(alg_name, "prague") == 0) {
+            alg = picoquic_prague_algorithm;
+        }
         else {
             alg = NULL;
         }

--- a/picoquic/sim_link.c
+++ b/picoquic/sim_link.c
@@ -31,6 +31,7 @@
 
 #include "picoquic_internal.h"
 #include "picoquic_utils.h"
+#include "picosocks.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -85,6 +86,7 @@ picoquictest_sim_packet_t* picoquictest_sim_link_create_packet()
         packet->next_packet = NULL;
         packet->arrival_time = 0;
         packet->length = 0;
+        packet->ecn_mark = 0;
     }
 
     return packet;
@@ -183,9 +185,11 @@ void picoquictest_sim_link_submit(picoquictest_sim_link_t* link, picoquictest_si
     }
 
     if (!should_drop) {
-
         link->queue_time = current_time + queue_delay + transmit_time;
-
+        /* TODO: proper simulation of marking policy */
+        if (link->l4s_delay > 0 && queue_delay >= link->l4s_delay) {
+            packet->ecn_mark = PICOQUIC_ECN_CE;
+        }
         if (packet->length > link->path_mtu || picoquictest_sim_link_testloss(link->loss_mask) != 0 ||
             link->is_switched_off) {
             link->packets_dropped++;

--- a/picoquic/sim_link.c
+++ b/picoquic/sim_link.c
@@ -187,7 +187,7 @@ void picoquictest_sim_link_submit(picoquictest_sim_link_t* link, picoquictest_si
     if (!should_drop) {
         link->queue_time = current_time + queue_delay + transmit_time;
         /* TODO: proper simulation of marking policy */
-        if (link->l4s_delay > 0 && queue_delay >= link->l4s_delay) {
+        if (link->l4s_max > 0 && queue_delay >= link->l4s_max) {
             packet->ecn_mark = PICOQUIC_ECN_CE;
         }
         if (packet->length > link->path_mtu || picoquictest_sim_link_testloss(link->loss_mask) != 0 ||

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -264,6 +264,7 @@ static const picoquic_test_def_t test_table[] = {
     { "bbr_asym100_nodelay", bbr_asym100_nodelay_test },
     { "bbr_asym400", bbr_asym400_test },
     { "l4s_reno", l4s_reno_test },
+    { "l4s_prague", l4s_prague_test },
     { "long_rtt", long_rtt_test },
     { "high_latency_basic", high_latency_basic_test },
     { "high_latency_bbr", high_latency_bbr_test },

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -263,6 +263,7 @@ static const picoquic_test_def_t test_table[] = {
     { "bbr_asym100", bbr_asym100_test },
     { "bbr_asym100_nodelay", bbr_asym100_nodelay_test },
     { "bbr_asym400", bbr_asym400_test },
+    { "l4s_reno", l4s_reno_test },
     { "long_rtt", long_rtt_test },
     { "high_latency_basic", high_latency_basic_test },
     { "high_latency_bbr", high_latency_bbr_test },

--- a/picoquictest/l4s_test.c
+++ b/picoquictest/l4s_test.c
@@ -64,10 +64,12 @@ static int l4s_congestion_test(picoquic_congestion_algorithm_t* ccalgo, uint64_t
         picoquic_set_default_congestion_algorithm(test_ctx->qserver, ccalgo);
         picoquic_set_congestion_algorithm(test_ctx->cnx_client, ccalgo);
 
-        test_ctx->c_to_s_link->l4s_max = l4s_max;
-        test_ctx->s_to_c_link->l4s_max = l4s_max;
-        test_ctx->packet_ecn_default = PICOQUIC_ECN_ECT_0;
 
+        if (strcmp(ccalgo->congestion_algorithm_id, "prague") == 0) {
+            test_ctx->c_to_s_link->l4s_max = l4s_max;
+            test_ctx->s_to_c_link->l4s_max = l4s_max;
+            test_ctx->packet_ecn_default = PICOQUIC_ECN_ECT_0;
+        }
         picoquic_set_binlog(test_ctx->qserver, ".");
 
         ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
@@ -103,11 +105,23 @@ static int l4s_congestion_test(picoquic_congestion_algorithm_t* ccalgo, uint64_t
     return ret;
 }
 
+/* This test is used for reference. Perf is bad, because each CE mark is
+ * a congestion mark.
+ */
 int l4s_reno_test()
 {
     picoquic_congestion_algorithm_t* ccalgo = picoquic_newreno_algorithm;
 
-    int ret = l4s_congestion_test(ccalgo, 4000000, 50, 6000);
+    int ret = l4s_congestion_test(ccalgo, 3850000, 50, 6000);
+
+    return ret;
+}
+
+int l4s_prague_test()
+{
+    picoquic_congestion_algorithm_t* ccalgo = picoquic_prague_algorithm;
+
+    int ret = l4s_congestion_test(ccalgo, 3700000, 5, 6000);
 
     return ret;
 }

--- a/picoquictest/l4s_test.c
+++ b/picoquictest/l4s_test.c
@@ -89,7 +89,7 @@ static int l4s_congestion_test(picoquic_congestion_algorithm_t* ccalgo, uint64_t
             ret = -1;
         }
         else if (test_ctx->cnx_server->path[0]->rtt_variant > max_rttvar) {
-            DBG_PRINTF("RTT variant %" PRIu64 ", expected maximum %" PRIu64, test_ctx->cnx_server->path[0]->rtt_variant > max_rttvar);
+            DBG_PRINTF("RTT variant %" PRIu64 ", expected maximum %" PRIu64, test_ctx->cnx_server->path[0]->rtt_variant, max_rttvar);
             ret = -1;
         }
     }

--- a/picoquictest/l4s_test.c
+++ b/picoquictest/l4s_test.c
@@ -121,7 +121,7 @@ int l4s_prague_test()
 {
     picoquic_congestion_algorithm_t* ccalgo = picoquic_prague_algorithm;
 
-    int ret = l4s_congestion_test(ccalgo, 3700000, 5, 6000);
+    int ret = l4s_congestion_test(ccalgo, 3500000, 5, 6000);
 
     return ret;
 }

--- a/picoquictest/l4s_test.c
+++ b/picoquictest/l4s_test.c
@@ -1,0 +1,113 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2022, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdlib.h>
+#include <string.h>
+#include "picoquic.h"
+#include "picoquic_utils.h"
+#include "picosocks.h"
+#include "picoquic_internal.h"
+#include "picoquictest_internal.h"
+#include "tls_api.h"
+#include "picoquic_binlog.h"
+#include "logreader.h"
+#include "qlog.h"
+
+static test_api_stream_desc_t test_scenario_l4s[] = {
+    { 4, 0, 257, 1000000 },
+    { 8, 4, 257, 1000000 },
+    { 12, 8, 257, 1000000 },
+    { 16, 12, 257, 1000000 }
+};
+
+
+static int l4s_congestion_test(picoquic_congestion_algorithm_t* ccalgo, uint64_t max_completion_time, uint64_t max_losses, uint64_t max_rttvar)
+{
+    uint64_t simulated_time = 0;
+    uint64_t queue_delay_max = 20000;
+    uint64_t l4s_max = queue_delay_max / 4;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_connection_id_t initial_cid = { {0x45, 0xcc, 0, 0, 0, 0, 0, 0}, 8 };
+    int ret;
+
+    initial_cid.id[2] = ccalgo->congestion_algorithm_number;
+
+    ret = tls_api_init_ctx_ex(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 1, 0, &initial_cid);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = -1;
+    }
+
+    /* Set the congestion algorithm to specified value.
+     * Initialize L4S behavior.
+     * Request a packet trace */
+    if (ret == 0) {
+
+        picoquic_set_default_congestion_algorithm(test_ctx->qserver, ccalgo);
+        picoquic_set_congestion_algorithm(test_ctx->cnx_client, ccalgo);
+
+        test_ctx->c_to_s_link->l4s_max = l4s_max;
+        test_ctx->s_to_c_link->l4s_max = l4s_max;
+        test_ctx->packet_ecn_default = PICOQUIC_ECN_ECT_0;
+
+        picoquic_set_binlog(test_ctx->qserver, ".");
+
+        ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
+            test_scenario_l4s, sizeof(test_scenario_l4s), 0, 0, 0, queue_delay_max, max_completion_time);
+    }
+
+    /* Verify that L4S ECN feedback was received properly */
+    /* verify that the delay meets target requirements */
+    /* Verify that the losses are as expected, "low loss" part of L4S */
+    if (ret == 0) {
+        if (test_ctx->cnx_server == NULL) {
+            DBG_PRINTF("%s", "Cannot assess server connection");
+            ret = -1;
+        }
+        else if (test_ctx->cnx_server->nb_retransmission_total > max_losses) {
+            DBG_PRINTF("Noted %" PRIu64 " losses, expected maximum %" PRIu64, test_ctx->cnx_server->nb_retransmission_total, max_losses);
+            ret = -1;
+        }
+        else if (test_ctx->cnx_server->path[0]->rtt_variant > max_rttvar) {
+            DBG_PRINTF("RTT variant %" PRIu64 ", expected maximum %" PRIu64, test_ctx->cnx_server->path[0]->rtt_variant > max_rttvar);
+            ret = -1;
+        }
+    }
+
+    /* Free the resource, which will close the log file.
+     */
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
+}
+
+int l4s_reno_test()
+{
+    picoquic_congestion_algorithm_t* ccalgo = picoquic_newreno_algorithm;
+
+    int ret = l4s_congestion_test(ccalgo, 4000000, 50, 6000);
+
+    return ret;
+}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -289,6 +289,7 @@ int bbr_asym100_test();
 int bbr_asym100_nodelay_test();
 int bbr_asym400_test();
 int l4s_reno_test();
+int l4s_prague_test();
 int large_client_hello_test();
 int fast_nat_rebinding_test();
 int datagram_test();

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -288,6 +288,7 @@ int gbps_performance_test();
 int bbr_asym100_test();
 int bbr_asym100_nodelay_test();
 int bbr_asym400_test();
+int l4s_reno_test();
 int large_client_hello_test();
 int fast_nat_rebinding_test();
 int datagram_test();

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -160,6 +160,7 @@
     <ClCompile Include="hashtest.c" />
     <ClCompile Include="high_latency_test.c" />
     <ClCompile Include="intformattest.c" />
+    <ClCompile Include="l4s_test.c" />
     <ClCompile Include="multipath_test.c" />
     <ClCompile Include="netperf_test.c" />
     <ClCompile Include="parseheadertest.c" />

--- a/picoquictest/picoquictest.vcxproj.filters
+++ b/picoquictest/picoquictest.vcxproj.filters
@@ -108,6 +108,9 @@
     <ClCompile Include="edge_cases.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="l4s_test.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquictest.h">

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -149,6 +149,7 @@ typedef struct st_picoquic_test_tls_api_ctx_t {
     uint64_t blackhole_end;
 
     /* ECN simulation */
+    uint8_t packet_ecn_default;
     uint8_t recv_ecn_client;
     uint8_t recv_ecn_server;
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -11103,16 +11103,17 @@ int excess_repeat_test_one(picoquic_congestion_algorithm_t* cc_algo, int repeat_
 int excess_repeat_test()
 {
     const int nb_repeat_max = 128;
-    picoquic_congestion_algorithm_t* algo_list[5] = {
+    picoquic_congestion_algorithm_t* algo_list[6] = {
         picoquic_newreno_algorithm,
         picoquic_cubic_algorithm,
         picoquic_dcubic_algorithm,
         picoquic_fastcc_algorithm,
-        picoquic_bbr_algorithm
+        picoquic_bbr_algorithm,
+        picoquic_prague_algorithm
     };
     int ret = 0;
 
-    for (int i = 0; i < 5 && ret == 0; i++) {
+    for (int i = 0; i < 6 && ret == 0; i++) {
         ret = excess_repeat_test_one(algo_list[i], nb_repeat_max);
         if (ret != 0) {
             DBG_PRINTF("Excess repeat test fails for CC=%s", algo_list[i]->congestion_algorithm_id);

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1186,6 +1186,9 @@ static int tls_api_one_sim_link_arrival(picoquictest_sim_link_t* sim_link, struc
         /* Check the destination address  before submitting the packet */
         if (picoquic_compare_addr(target_addr, (struct sockaddr*) & packet->addr_to) == 0 ||
             (packet->addr_to.ss_family == target_addr->sa_family  && multiple_address)) {
+            if (recv_ecn == 0) {
+                recv_ecn = packet->ecn_mark;
+            }
             if (packet->length > 16) {
                 ret = picoquic_incoming_packet(quic, packet->bytes, (uint32_t)packet->length,
                     (struct sockaddr*) & packet->addr_from,
@@ -1441,6 +1444,7 @@ int tls_api_one_sim_round(picoquic_test_tls_api_ctx_t* test_ctx,
                         else {
                             picoquic_store_addr(&packet->addr_from, (struct sockaddr*) & addr_from);
                             picoquic_store_addr(&packet->addr_to, (struct sockaddr*) & addr_to);
+                            packet->ecn_mark = test_ctx->packet_ecn_default;
                             packet->length = send_length - size_sent;
                             if (packet->length > segment_size) {
                                 packet->length = segment_size;


### PR DESCRIPTION
Originally based on a PR submitted by @qdeconinck in 2019. Changed the way the L4S coefficients are accessed by directly reading the ECN counters, added an L4S specific test, fixed a number of issues. More of those issues need fixing before the PR can be checked in. However, even without those fixes, the implementation shows the promise of L4S: compared to a regular Reno implementation, we see the following changes in the first test:

* way fewer packet losses - 5 instead of 35 in the tests.
* much lower latency after slow start - the saw  tooth pattern is much smoothed, RTT peaks at min RTT + 6ms, instead of min RTT + 25ms
* better overall usage of the link - test completest in 3.7 seconds instead of 4.