### PR TITLE
Align to picotls as of 7/21/22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if(PICOQUIC_FETCH_PTLS)
     include(FetchContent)
     FetchContent_Declare(picotls
         GIT_REPOSITORY      https://github.com/h2o/picotls.git
-        GIT_TAG             74feba44643ed905317be7a64a689f0d49120860)
+        GIT_TAG             7970614ad049d194fe1691bdf0cc66c6930a3a2f)
     FetchContent_MakeAvailable(picotls)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Picoquic is developed in C, and can be built under Windows or Linux. Building th
 project requires first managing the dependencies, [Picotls](https://github.com/h2o/picotls)
 and OpenSSL. Please note that you will need a recent version of Picotls --
 the Picotls API has eveolved recently to support the latest version of QUIC. The
-current code is tested against the Picotls version of Tue Jul 12 09:17:21 2022 +0900,
-after commit `74feba44643ed905317be7a64a689f0d49120860`. The code uses OpenSSL
+current code is tested against the Picotls version of Thu Jul 21 19:15:14 2022 +0900,
+after commit `7970614ad049d194fe1691bdf0cc66c6930a3a2f`. The code uses OpenSSL
 version 1.1.1.
 
 ## Picoquic on Windows

--- a/ci/build_picotls.ps1
+++ b/ci/build_picotls.ps1
@@ -1,5 +1,5 @@
 # Build at a known-good commit
-$COMMIT_ID="74feba44643ed905317be7a64a689f0d49120860"
+$COMMIT_ID="7970614ad049d194fe1691bdf0cc66c6930a3a2f"
 
 # Match expectations of picotlsvs project.
 mkdir $dir\include\

--- a/ci/build_picotls.sh
+++ b/ci/build_picotls.sh
@@ -2,7 +2,7 @@
 #build last picotls master (for Travis)
 
 # Build at a known-good commit
-COMMIT_ID=74feba44643ed905317be7a64a689f0d49120860
+COMMIT_ID=7970614ad049d194fe1691bdf0cc66c6930a3a2f
 
 cd ..
 # git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags https://github.com/h2o/picotls

--- a/picoquictest/multipath_qlog_ref.txt
+++ b/picoquictest/multipath_qlog_ref.txt
@@ -6,7 +6,7 @@
 "events": [
 [0, 0, "transport", "datagram_received", { "byte_length": 1252, "addr_from" : {"ip_v4": "10.0.0.2", "port_v4":1234}, "addr_to" : {"ip_v4": "10.0.0.1", "port_v4":4321}}],
 [0, 0, "transport", "packet_received", { "packet_type": "initial", "header": { "packet_size": 1252, "packet_number": 0, "version": "50435130", "payload_length": 1206, "scid": "0908070605040302", "dcid": "0807060504030201" }, "frames": [{ 
-    "frame_type": "crypto", "offset": 0, "length": 297}, { 
+    "frame_type": "crypto", "offset": 0, "length": 291}, { 
     "frame_type": "padding"}]}],
 [0, 0, "info", "message", { "message": "ALPN[0] matches default alpn (picoquic-test)"}],
 [0, 0, "transport", "parameters_set", {

--- a/picoquictest/qlog_trace_ecn_ref.txt
+++ b/picoquictest/qlog_trace_ecn_ref.txt
@@ -6,7 +6,7 @@
 "events": [
 [0, "transport", "datagram_received", { "byte_length": 1252, "addr_from" : {"ip_v4": "10.0.0.2", "port_v4":1234}, "addr_to" : {"ip_v4": "10.0.0.1", "port_v4":4321}}],
 [0, "transport", "packet_received", { "packet_type": "initial", "header": { "packet_size": 1252, "packet_number": 0, "version": "50435130", "payload_length": 1206, "scid": "0203040506070809", "dcid": "0102030405060708" }, "frames": [{ 
-    "frame_type": "crypto", "offset": 0, "length": 285}, { 
+    "frame_type": "crypto", "offset": 0, "length": 279}, { 
     "frame_type": "padding"}]}],
 [0, "info", "message", { "message": "ALPN[0] matches default alpn (picoquic-test)"}],
 [0, "transport", "parameters_set", {

--- a/picoquictest/qlog_trace_ref.txt
+++ b/picoquictest/qlog_trace_ref.txt
@@ -6,7 +6,7 @@
 "events": [
 [0, "transport", "datagram_received", { "byte_length": 1252, "addr_from" : {"ip_v4": "10.0.0.2", "port_v4":1234}, "addr_to" : {"ip_v4": "10.0.0.1", "port_v4":4321}}],
 [0, "transport", "packet_received", { "packet_type": "initial", "header": { "packet_size": 1252, "packet_number": 0, "version": "50435130", "payload_length": 1206, "scid": "0203040506070809", "dcid": "0102030405060708" }, "frames": [{ 
-    "frame_type": "crypto", "offset": 0, "length": 285}, { 
+    "frame_type": "crypto", "offset": 0, "length": 279}, { 
     "frame_type": "padding"}]}],
 [0, "info", "message", { "message": "ALPN[0] matches default alpn (picoquic-test)"}],
 [0, "transport", "parameters_set", {

--- a/picoquictest/simple_multipath_qlog_ref.txt
+++ b/picoquictest/simple_multipath_qlog_ref.txt
@@ -6,7 +6,7 @@
 "events": [
 [0, 0, "transport", "datagram_received", { "byte_length": 1252, "addr_from" : {"ip_v4": "10.0.0.2", "port_v4":1234}, "addr_to" : {"ip_v4": "10.0.0.1", "port_v4":4321}}],
 [0, 0, "transport", "packet_received", { "packet_type": "initial", "header": { "packet_size": 1252, "packet_number": 0, "version": "50435130", "payload_length": 1206, "scid": "0908070605040302", "dcid": "0807060504030201" }, "frames": [{ 
-    "frame_type": "crypto", "offset": 0, "length": 297}, { 
+    "frame_type": "crypto", "offset": 0, "length": 291}, { 
     "frame_type": "padding"}]}],
 [0, 0, "info", "message", { "message": "ALPN[0] matches default alpn (picoquic-test)"}],
 [0, 0, "transport", "parameters_set", {


### PR DESCRIPTION
One of the recent Picotls commit reduces the size of the "Client Hello", by removing the negotiation of obsolete draft versions.
The change of size causes a minor change in the log file. This PR updates the reference files accordingly.