### PR TITLE
Move certain targets so they build when tests are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,26 +281,27 @@ target_include_directories(picohttp-core
         picoquic)
 set_picoquic_compile_settings(picohttp-core)
 
+add_executable(picoquicdemo
+    picoquicfirst/picoquicdemo.c
+    picoquicfirst/getopt.c)
+target_link_libraries(picoquicdemo
+    PRIVATE
+        ${PTLS_LIBRARIES}
+        ${OPENSSL_LIBRARIES}
+        picoquic-log
+        picoquic-core
+        picohttp-core)
+target_include_directories(picoquicdemo PRIVATE picohttp)
+set_picoquic_compile_settings(picoquicdemo)
+
+add_executable(picolog_t picolog/picolog.c)
+target_link_libraries(picolog_t PRIVATE picoquic-log picoquic-core)
+target_include_directories(picolog_t PRIVATE loglib)
+set_picoquic_compile_settings(picolog_t)
+
 include(CTest)
 
 if(BUILD_TESTING AND picoquic_BUILD_TESTS)
-    add_executable(picoquicdemo
-        picoquicfirst/picoquicdemo.c
-        picoquicfirst/getopt.c)
-    target_link_libraries(picoquicdemo
-        PRIVATE
-            ${PTLS_LIBRARIES}
-            ${OPENSSL_LIBRARIES}
-            picoquic-log
-            picoquic-core
-            picohttp-core)
-    target_include_directories(picoquicdemo PRIVATE picohttp)
-    set_picoquic_compile_settings(picoquicdemo)
-
-    add_executable(picolog_t picolog/picolog.c)
-    target_link_libraries(picolog_t PRIVATE picoquic-log picoquic-core)
-    target_include_directories(picolog_t PRIVATE loglib)
-    set_picoquic_compile_settings(picolog_t)
 
     add_library(picoquic-test STATIC ${PICOQUIC_TEST_LIBRARY_FILES})
     target_link_libraries(picoquic-test PUBLIC picoquic-core picoquic-log)


### PR DESCRIPTION
This will ensure `picoquicdemo` and `picolog_t` are built even if tests are not built.  This is important since they are part of the INSTALL TARGETS.