### PR TITLE
Linux IP_MTU_DISCOVER/IPV6_MTU_DISCOVER

### DIFF
--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -318,6 +318,9 @@ int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port)
             if (ret == 0) {
                 ret = picoquic_bind_to_port(sockets->s_socket[i], sock_af[i], port);
             }
+            if (ret == 0) {
+                ret = picoquic_socket_set_pmtud_options(sockets->s_socket[i], sock_af[i]);
+            }
         }
     }
 

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -240,7 +240,7 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
     return ret;
 }
 
-int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
+int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd)
 {
     int ret = 0;
 #if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_PROBE)
@@ -270,7 +270,7 @@ SOCKET_TYPE picoquic_open_client_socket(int af)
         if (picoquic_socket_set_ecn_options(sd, af, &recv_set, &send_set) != 0) {
             DBG_PRINTF("Cannot set ECN options (af=%d)\n", af);
         }
-        if (picoquic_socket_set_pmtud_options(sd, af) != 0) {
+        if (picoquic_socket_set_pmtud_options(sd) != 0) {
             DBG_PRINTF("Cannot set PMTUD options (af=%d)\n", af);
         }
     }
@@ -319,7 +319,7 @@ int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port)
                 ret = picoquic_bind_to_port(sockets->s_socket[i], sock_af[i], port);
             }
             if (ret == 0) {
-                ret = picoquic_socket_set_pmtud_options(sockets->s_socket[i], sock_af[i]);
+                ret = picoquic_socket_set_pmtud_options(sockets->s_socket[i]);
             }
         }
     }

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -240,12 +240,17 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
     return ret;
 }
 
-int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd)
+int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
 {
     int ret = 0;
-#if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_PROBE)
+#if (defined(IP_MTU_DISCOVER) || defined(IPV6_MTU_DISCOVER)) && defined(IP_PMTUDISC_PROBE)
     int val = IP_PMTUDISC_PROBE;
-    ret = setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(int));
+    if (af == AF_INET6) {
+        ret = setsockopt(sd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &val, sizeof(int));
+    }
+    else {
+        ret = setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(int));
+    }
 #endif
     return ret;
 }
@@ -270,7 +275,7 @@ SOCKET_TYPE picoquic_open_client_socket(int af)
         if (picoquic_socket_set_ecn_options(sd, af, &recv_set, &send_set) != 0) {
             DBG_PRINTF("Cannot set ECN options (af=%d)\n", af);
         }
-        if (picoquic_socket_set_pmtud_options(sd) != 0) {
+        if (picoquic_socket_set_pmtud_options(sd, af) != 0) {
             DBG_PRINTF("Cannot set PMTUD options (af=%d)\n", af);
         }
     }
@@ -319,7 +324,7 @@ int picoquic_open_server_sockets(picoquic_server_sockets_t* sockets, int port)
                 ret = picoquic_bind_to_port(sockets->s_socket[i], sock_af[i], port);
             }
             if (ret == 0) {
-                ret = picoquic_socket_set_pmtud_options(sockets->s_socket[i]);
+                ret = picoquic_socket_set_pmtud_options(sockets->s_socket[i], sock_af[i]);
             }
         }
     }

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -240,6 +240,16 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
     return ret;
 }
 
+int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
+{
+    int ret = 0;
+#if defined(IP_MTU_DISCOVER) && defined(IP_PMTUDISC_PROBE)
+    int val = IP_PMTUDISC_PROBE;
+    ret = setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(int));
+#endif
+    return ret;
+}
+
 SOCKET_TYPE picoquic_open_client_socket(int af)
 {
 #ifdef _WINDOWS
@@ -259,6 +269,9 @@ SOCKET_TYPE picoquic_open_client_socket(int af)
         }
         if (picoquic_socket_set_ecn_options(sd, af, &recv_set, &send_set) != 0) {
             DBG_PRINTF("Cannot set ECN options (af=%d)\n", af);
+        }
+        if (picoquic_socket_set_pmtud_options(sd, af) != 0) {
+            DBG_PRINTF("Cannot set PMTUD options (af=%d)\n", af);
         }
     }
     else {

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -252,8 +252,10 @@ int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
         ret = setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(int));
     }
 #else
+#ifdef UNREFERENCED_PARAMETER
     UNREFERENCED_PARAMETER(af);
     UNREFERENCED_PARAMETER(sd);
+#endif
 #endif  /* #if defined __linux && ... */
     return ret;
 }

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -243,7 +243,7 @@ int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int 
 int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
 {
     int ret = 0;
-#if (defined(IP_MTU_DISCOVER) || defined(IPV6_MTU_DISCOVER)) && defined(IP_PMTUDISC_PROBE)
+#if defined __linux && defined(IP_MTU_DISCOVER) && defined(IPV6_MTU_DISCOVER) && defined(IP_PMTUDISC_PROBE)
     int val = IP_PMTUDISC_PROBE;
     if (af == AF_INET6) {
         ret = setsockopt(sd, IPPROTO_IPV6, IPV6_MTU_DISCOVER, &val, sizeof(int));
@@ -251,7 +251,10 @@ int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af)
     else {
         ret = setsockopt(sd, IPPROTO_IP, IP_MTU_DISCOVER, &val, sizeof(int));
     }
-#endif
+#else
+    UNREFERENCED_PARAMETER(af);
+    UNREFERENCED_PARAMETER(sd);
+#endif  /* #if defined __linux && ... */
     return ret;
 }
 

--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -184,7 +184,7 @@ void picoquic_close_server_sockets(picoquic_server_sockets_t* sockets);
 
 int picoquic_socket_set_pkt_info(SOCKET_TYPE sd, int af);
 int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int * send_set);
-int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd);
+int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd, int af);
 
 int picoquic_select(SOCKET_TYPE* sockets, int nb_sockets,
     struct sockaddr_storage* addr_from,

--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -184,6 +184,7 @@ void picoquic_close_server_sockets(picoquic_server_sockets_t* sockets);
 
 int picoquic_socket_set_pkt_info(SOCKET_TYPE sd, int af);
 int picoquic_socket_set_ecn_options(SOCKET_TYPE sd, int af, int * recv_set, int * send_set);
+int picoquic_socket_set_pmtud_options(SOCKET_TYPE sd);
 
 int picoquic_select(SOCKET_TYPE* sockets, int nb_sockets,
     struct sockaddr_storage* addr_from,

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -140,7 +140,7 @@ int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE 
             picoquic_socket_set_pkt_info(s_socket[i], sock_af[i]) != 0 ||
             picoquic_bind_to_port(s_socket[i], sock_af[i], local_port) != 0 ||
             picoquic_get_local_address(s_socket[i], &local_address) != 0 ||
-            picoquic_socket_set_pmtud_options(s_socket[i]) != 0)
+            picoquic_socket_set_pmtud_options(s_socket[i], sock_af[i]) != 0)
         {
             DBG_PRINTF("Cannot set socket (af=%d, port = %d)\n", sock_af[i], local_port);
             for (int j = 0; j < i; j++) {

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -139,7 +139,8 @@ int picoquic_packet_loop_open_sockets(int local_port, int local_af, SOCKET_TYPE 
             picoquic_socket_set_ecn_options(s_socket[i], sock_af[i], &recv_set, &send_set) != 0 ||
             picoquic_socket_set_pkt_info(s_socket[i], sock_af[i]) != 0 ||
             picoquic_bind_to_port(s_socket[i], sock_af[i], local_port) != 0 ||
-            picoquic_get_local_address(s_socket[i], &local_address) != 0)
+            picoquic_get_local_address(s_socket[i], &local_address) != 0 ||
+            picoquic_socket_set_pmtud_options(s_socket[i]) != 0)
         {
             DBG_PRINTF("Cannot set socket (af=%d, port = %d)\n", sock_af[i], local_port);
             for (int j = 0; j < i; j++) {


### PR DESCRIPTION
On Linux, the default value for socket option IP_MTU_DISCOVER (given that sysctl net.ipv4.ip_no_pmtu_disc=0) or IPV6_MTU_DISCOVER is IP_PMTUDISC_WANT. With that, Linux's IP implementation fragments outgoing packets larger than the route MTU (as shown by ip route get DST-IP). Linux sets the route MTU upon an incoming ICMP Packet Too Big (PTB) message. Since picoquic does not process PTBs, a PTB reporting a smaller MTU leads to IP fragmentation for QUIC packets.

As picoquic already does PMTUD, I kind of disable PMTUD on IP level by setting IP_MTU_DISCOVER or IPV6_MTU_DISCOVER to IP_PMTUDISC_PROBE. With that, Linux ignores the route MTU.