### PR TITLE
Ensure Dockerfile works with current picotls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
+    apt-get update && \
     apt-get install -y build-essential git cmake software-properties-common \
     openssl libssl-dev pkg-config clang
 
@@ -25,3 +27,4 @@ RUN git clone https://github.com/h2o/picotls.git && \
 RUN cd /src/picoquic && \
     cmake . && \
     make
+


### PR DESCRIPTION
Upgrade Ubuntu to 20.04 and set timezone non-interactively.

Otherwise the following cc errors occur:
```
cc: error: unrecognized command line option '-mvaes'; did you mean '-maes'?
cc: error: unrecognized command line option '-mvpclmulqdq'; did you mean '-mpclmul'?
```

In addition the version of CMake in Ubuntu 18.04 is too old so another error would occur while building picotls.