### PR TITLE
Fix source IP address when sending packets

### DIFF
--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -627,7 +627,7 @@ void picoquic_socks_cmsg_format(
             struct in_pktinfo* pktinfo = (struct in_pktinfo*)cmsg_format_header_return_data_ptr(msg, &last_cmsg,
                 &control_length, IPPROTO_IP, IP_PKTINFO, sizeof(struct in_pktinfo));
             if (pktinfo != NULL) {
-                pktinfo->ipi_addr.s_addr = ((struct sockaddr_in*)addr_from)->sin_addr.s_addr;
+                pktinfo->ipi_spec_dst.s_addr = ((struct sockaddr_in*)addr_from)->sin_addr.s_addr;
                 pktinfo->ipi_ifindex = (unsigned long)dest_if;
             }
             else {


### PR DESCRIPTION
I think that currently the source IP address is not set correctly on Linux. When having several network interfaces, in my experience, setting the source IP address has no effect and packets are sent with another source IP address, not the one specified. 

My change seems to fix this problem. I tested it with some live machines with multiple network interfaces. I think my changed version is also consistent with the documentation of [Linux's IP implementation](https://man7.org/linux/man-pages/man7/ip.7.html).

> If IP_PKTINFO is passed to [sendmsg(2)](https://man7.org/liman-pages/man2/sendmsg.2.html)
> and **ipi_spec_dst** is not zero, then it is used as the local
> source address for the routing table lookup and for
> setting up IP source route options.  When ipi_ifindex is
> not zero, the primary local address of the interface
> specified by the index overwrites **ipi_spec_dst** for the
> routing table lookup.

I guess for IPv6 this isn't a problem as `in6_pktinfo` has only one IP address inside of it. 