### PR TITLE
Fix connection wake list comparator function to avoid integer overflow

### DIFF
--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1285,7 +1285,11 @@ static void* picoquic_wake_list_node_value(picosplay_node_t* cnx_wake_node)
 }
 
 static int64_t picoquic_wake_list_compare(void* l, void* r) {
-    return (int64_t)((picoquic_cnx_t*)l)->next_wake_time - ((picoquic_cnx_t*)r)->next_wake_time;
+    const uint64_t ltime = ((picoquic_cnx_t*)l)->next_wake_time;
+    const uint64_t rtime = ((picoquic_cnx_t*)r)->next_wake_time;
+    if (ltime < rtime) return -1;
+    if (ltime > rtime) return 1;
+    return 0;
 }
 
 static picosplay_node_t* picoquic_wake_list_create_node(void* v_cnx)


### PR DESCRIPTION
I've been experimenting with the library for a while. And found the following a bug. When a peer closes it's connection, client-side connection goes through a set of finalization states and ends up in a disconnected state, which is OK. After that on exit from the `picoquic_prepare_packet_ex` the connection will be reinserted with the `UINT64_MAX` time code. The problem is that the comparator for those time codes is written in such a way, that `UINT64_MAX` value will cause an integer overflow and will always compare as "less". It means, this zombie connection will always be selected on the next cycle and will do nothing, because it's due time will be always in the future. As a result all processing cycle will stuck on that connection.
I've provided a fix for the comparator function, but I am not sure whether the previous behavior was intended or not.