### PR TITLE
adding some basic CLI usage info to help bootstrap picoquic use

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ behavior on other architecture, e.g. M1. Thanks to @defermelowie  for testing on
 Same build steps as Linux. Picoquic probably also works on other BSD variants, but only FreeBSD
 has been tested so far.
 
+## Using Picoquic in CLI mode
+
+See [Usage](doc/usage.md) for how to use various commands from shell.
+
 ## Developing applications
 
 Sorry, not all that much documentation yet. This will come as we populate the wiki. Your

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -5,7 +5,7 @@ On Linux after building, the following executables are available in the project 
 * picoquic_ct: runs various QUIC tests
 	* with no arguments, runs all tests.
 * picoquicdemo: QUIC/HTTP demo client and server for HTTP/3, HTTP/0.9, QUIC performance tests and Siduck(simple ping-pong)
-* picoquic_sample: QUIC/HTTP demo client and server. See sample/README.md for detailed usage
+* picoquic_sample: QUIC/HTTP sample demonstrating how to write an application using the picoquic stack. It is not meant to be actually used. See sample/README.md for detailed usage
 
 ## HTTP Client and Server Usage
 * client: ./picoquicdemo servername serverportnumber HTTPpath

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -4,7 +4,7 @@ On Linux after building, the following executables are available in the project 
 * picohttp_ct: runs various HTTP tests
 * picoquic_ct: runs various QUIC tests
 	* with no arguments, runs all tests.
-* picoquicdemo: QUIC/HTTP demo client and server for HTTP/3, HTTP/0.9, QUIC performance tests and Siduck(simple ping-pong)
+* picoquicdemo: QUIC/HTTP demo client and server for HTTP/3, HTTP/0.9, QUIC performance tests and Siduck(simple test of Datagram support)
 * picoquic_sample: QUIC/HTTP sample demonstrating how to write an application using the picoquic stack. It is not meant to be actually used. See sample/README.md for detailed usage
 
 ## HTTP Client and Server Usage

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -1,0 +1,22 @@
+# Picoquic CLI Usage
+On Linux after building, the following executables are available in the project root directory. All support "-h" argument to get the detailed usage:
+
+* picohttp_ct: runs various HTTP tests
+* picoquic_ct: runs various QUIC tests
+	* with no arguments, runs all tests.
+* picoquicdemo: QUIC/HTTP demo client and server
+* picoquic_sample: QUIC/HTTP demo client and server. See sample/README.md for detailed usage
+
+## HTTP CLI
+* client: ./picoquicdemo servername serverportnumber HTTPpath
+  * downloaded files will be in current directory. use -o for another folder 
+  * exemple: ./picoquicdemo -o ../received 192.0.2.1 4433 index.html
+* server: ./picoquicdemo -p portnumber
+  * -p argument tells the program that it is acting as a server
+  * HTML root folder is current directory by default. use -w for another folder
+  * exemple: ./picoquicdemo -w ../htmlroot -p 4433
+
+# QUIC Logging
+* add -q $folder to cli commands so that QUIC logs are generated in that folder 
+* you may use https://qvis.quictools.info/ by uploading the QLOG files and visualize the flows.
+

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -14,6 +14,7 @@ On Linux after building, the following executables are available in the project 
 * server: ./picoquicdemo -p portnumber
   * -p argument tells the program that it is acting as a server
   * HTML root folder is current directory by default. use -w for another folder
+  * keys and certs are specified by -k and -c. See -h for more details.
   * exemple: ./picoquicdemo -w ../htmlroot -p 4433
 
 # QUIC Logging

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -16,6 +16,10 @@ On Linux after building, the following executables are available in the project 
   * HTML root folder is current directory by default. use -w for another folder
   * keys and certs are specified by -k and -c. See -h for more details.
   * exemple: ./picoquicdemo -w ../htmlroot -p 4433
+* additional useful information for HTTP usage is available at:
+  * [Without DNS Names Or Certs](https://github.com/private-octopus/picoquic/wiki/Testing-without-DNS-names-or-Certificates)
+  * [Certs Using Lets Encrypt] (https://github.com/private-octopus/picoquic/wiki/Import-key-and-cert-on-server-from-Let's-encrypt)
+  * [Absolute Path] (https://github.com/private-octopus/picoquic/wiki/Running-picoquicdemo-with-absolute-path)
 
 # QUIC Logging
 * add -q $folder to cli commands so that QUIC logs are generated in that folder 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -4,10 +4,10 @@ On Linux after building, the following executables are available in the project 
 * picohttp_ct: runs various HTTP tests
 * picoquic_ct: runs various QUIC tests
 	* with no arguments, runs all tests.
-* picoquicdemo: QUIC/HTTP demo client and server
+* picoquicdemo: QUIC/HTTP demo client and server for HTTP/3, HTTP/0.9, QUIC performance tests and Siduck(simple ping-pong)
 * picoquic_sample: QUIC/HTTP demo client and server. See sample/README.md for detailed usage
 
-## HTTP CLI
+## HTTP Client and Server Usage
 * client: ./picoquicdemo servername serverportnumber HTTPpath
   * downloaded files will be in current directory. use -o for another folder 
   * exemple: ./picoquicdemo -o ../received 192.0.2.1 4433 index.html


### PR DESCRIPTION
- took me some time to find out, with the help of Christian!
- not sure what picohttp_ct does since its -h is not useful.
- location of binaries are for linux. might need to edit for other platforms.