### PR TITLE
Fix sample server FIN handling

### DIFF
--- a/sample/sample_server.c
+++ b/sample/sample_server.c
@@ -242,6 +242,11 @@ int sample_server_callback(picoquic_cnx_t* cnx,
             if (stream_ctx == NULL) {
                 /* Create and initialize stream context */
                 stream_ctx = sample_server_create_stream_context(server_ctx, stream_id);
+                if (picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx) != 0) {
+                    /* Internal error */
+                    (void) picoquic_reset_stream(cnx, stream_id, PICOQUIC_SAMPLE_INTERNAL_ERROR);
+                    return(-1);
+                }
             }
 
             if (stream_ctx == NULL) {


### PR DESCRIPTION
If the FIN does not arrive at the same time as the rest of the stream data then the stream_ctx gets forgotten. When creating a new stream_ctx we need to call picoquic_set_app_stream_ctx.