### PR TITLE
Add wakeup call for queued datagrams

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -3666,6 +3666,7 @@ int picoquic_prepare_packet_almost_ready(picoquic_cnx_t* cnx, picoquic_path_t* p
                         /* Start of CC controlled frames */
                         if (ret == 0 && length <= header_length && cnx->first_datagram != NULL) {
                             bytes_next = picoquic_format_first_datagram_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
+                            more_data |= (cnx->first_datagram != NULL);
                         }
 
                         if (ret == 0){
@@ -3814,6 +3815,7 @@ static uint8_t* picoquic_prepare_datagram_ready(picoquic_cnx_t* cnx, uint8_t* by
 
     if (cnx->first_datagram != NULL) {
         bytes_next = picoquic_format_first_datagram_frame(cnx, bytes_next, bytes_max, more_data, is_pure_ack);
+        *more_data |= (cnx->first_datagram != NULL);
     }
     else {
         while (cnx->is_datagram_ready) {


### PR DESCRIPTION
This is motivated by user reports that in some conditions the sending loop does no wake up, even if there are queued datagrams.