### PR TITLE
Fix IPv4 loopback address

### DIFF
--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -531,7 +531,7 @@ int picoquic_store_loopback_addr(struct sockaddr_storage* stored_addr, int addr_
 {
     int ret = -1;
     if (addr_family == AF_INET) {
-        ret = picoquic_store_text_addr(stored_addr, "128.0.0.1", port);
+        ret = picoquic_store_text_addr(stored_addr, "127.0.0.1", port);
     }
     else if (addr_family == AF_INET6) {
         ret = picoquic_store_text_addr(stored_addr, "::1", port);


### PR DESCRIPTION
Seems like the IPv4 address used by the `picoquic_store_loopback_addr` helper function was incorrectly using 128.0.0.1 rather than 127.0.0.1. This will fix that.