### PR TITLE
fix-variable-name-confusion

### DIFF
--- a/picoquic/bbr.c
+++ b/picoquic/bbr.c
@@ -501,8 +501,8 @@ void BBRUpdateBtlBw(picoquic_bbr_state_t* bbr_state, picoquic_path_t* path_x, ui
     uint64_t bandwidth_estimate = path_x->bandwidth_estimate;
 
     if (bbr_state->state == picoquic_bbr_alg_startup &&
-        bandwidth_estimate < (path_x->max_bandwidth_estimate / 2)) {
-        bandwidth_estimate = path_x->max_bandwidth_estimate/2;
+        bandwidth_estimate < (path_x->peak_bandwidth_estimate / 2)) {
+        bandwidth_estimate = path_x->peak_bandwidth_estimate/2;
     }
 
     if (bbr_state->rt_prop > 0) {
@@ -1098,7 +1098,7 @@ static void picoquic_bbr_notify(
                 }
                 bbr_state->bytes_delivered = 0;
 
-                max_win = path_x->max_bandwidth_estimate * bbr_state->rt_prop / 1000000;
+                max_win = path_x->peak_bandwidth_estimate * bbr_state->rt_prop / 1000000;
                 min_win = max_win /= 2;
 
                 if (path_x->cwin < min_win) {

--- a/picoquic/cubic.c
+++ b/picoquic/cubic.c
@@ -295,7 +295,7 @@ static void picoquic_cubic_notify(
                 break;
             case picoquic_congestion_notification_bw_measurement: {
                 /* RTT measurements will happen after the bandwidth is estimated */
-                uint64_t max_win = path_x->max_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
+                uint64_t max_win = path_x->peak_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
                 uint64_t min_win = max_win /= 2;
                 if (path_x->cwin < min_win) {
                     path_x->cwin = min_win;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2206,8 +2206,8 @@ void picoquic_estimate_max_path_bandwidth(picoquic_cnx_t* cnx, picoquic_path_t* 
                 bw_estimate = delivered * 1000000;
                 bw_estimate /= receive_interval;
                 /* Retain if larger than previous estimate */
-                if (bw_estimate > path_x->max_bandwidth_estimate) {
-                    path_x->max_bandwidth_estimate = bw_estimate;
+                if (bw_estimate > path_x->peak_bandwidth_estimate) {
+                    path_x->peak_bandwidth_estimate = bw_estimate;
                 }
 
                 /* Change the reference point if estimate duration is long enough */

--- a/picoquic/logwriter.c
+++ b/picoquic/logwriter.c
@@ -1172,7 +1172,7 @@ void binlog_cc_dump(picoquic_cnx_t* cnx, uint64_t current_time)
             bytewrite_vint(ps_msg, cc_param);
         }
 
-        bytewrite_vint(ps_msg, path->max_bandwidth_estimate);
+        bytewrite_vint(ps_msg, path->peak_bandwidth_estimate);
         bytewrite_vint(ps_msg, path->bytes_in_transit);
 
         bytestream_buf stream_head;

--- a/picoquic/newreno.c
+++ b/picoquic/newreno.c
@@ -281,7 +281,7 @@ static void picoquic_newreno_notify(
             if (nr_state->nrss.alg_state == picoquic_newreno_alg_slow_start &&
                 nr_state->nrss.ssthresh == UINT64_MAX) {
                 /* RTT measurements will happen after the bandwidth is estimated */
-                uint64_t max_win = path_x->max_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
+                uint64_t max_win = path_x->peak_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
                 uint64_t min_win = max_win /= 2;
                 if (nr_state->nrss.cwin < min_win) {
                     nr_state->nrss.cwin = min_win;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1070,11 +1070,11 @@ typedef struct st_picoquic_path_t {
     uint64_t delivered_limited_index;
     uint64_t delivered_last_packet;
     uint64_t bandwidth_estimate; /* In bytes per second */
-    uint64_t bandwidth_estimate_max;
+    uint64_t bandwidth_estimate_max; /* Maximum of bandwidth estimate over life of path */
     uint64_t max_sample_acked_time; /* Time max sample was delivered */
     uint64_t max_sample_sent_time; /* Time max sample was sent */
     uint64_t max_sample_delivered; /* Delivered value at time of max sample */
-    uint64_t max_bandwidth_estimate; /* In bytes per second */
+    uint64_t peak_bandwidth_estimate; /* In bytes per second, measured on short interval with highest bandwidth */
 
     uint64_t bytes_sent; /* Total amount of bytes sent on the path */
     uint64_t received; /* Total amount of bytes received from the path */

--- a/picoquic/prague.c
+++ b/picoquic/prague.c
@@ -399,7 +399,7 @@ void picoquic_prague_notify(
             if (pr_state->alg_state == picoquic_prague_alg_slow_start &&
                 pr_state->ssthresh == UINT64_MAX) {
                 /* RTT measurements will happen after the bandwidth is estimated */
-                uint64_t max_win = path_x->max_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
+                uint64_t max_win = path_x->peak_bandwidth_estimate * path_x->smoothed_rtt / 1000000;
                 uint64_t min_win = max_win /= 2;
                 if (path_x->cwin < min_win) {
                     path_x->cwin = min_win;


### PR DESCRIPTION
In addition to `bandwidth_estimate`, we had two path variables, `bandwidth_estimate_max` and `max_bandwidth_estimate`. Renamed the latter for clarity, so now we have:

* `bandwidth_estimate`: measured every RTT, average data rate delivered during that RTT
* `bandwidth_estimate_max`: maximum over time of `bandwidth_estimate`. Used to predict the likely bandwidth of future connection on the same path.
* `peak_bandwidth_estimate`: maximum bandwidth estimated over a short interval. Should predict the peak bandwidth of the path, in the absence of competing traffic. (Was named `max_bandwidth_estimate` before.)