### PR TITLE
Add CWIN_MAX API and test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.7.0
+        VERSION 1.1.8.0
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1796,6 +1796,11 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(cwin_max) {
+            int ret = cwin_max_test();
+
+            Assert::AreEqual(ret, 0);
+        }
         TEST_METHOD(initial_race) {
             int ret = initial_race_test();
 

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -93,6 +93,7 @@ static option_table_line_t option_table[] = {
     { picoquic_option_Version_Upgrade, 'U', "version_upgrade", 1, "", "Version upgrade if server agrees, e.g. -U 6b3343cf" },
     { picoquic_option_No_GSO, '0', "no_gso", 0, "", "Do not use UDP GSO or equivalent" },
     { picoquic_option_BDP_frame, 'j', "bdp", 1, "number", "use bdp extension frame(1) or don\'t (0). Default=0" },
+    { picoquic_option_CWIN_MAX, 'W', "cwin_max", 1, "bytes", "Max value for CWIN. Default=UINT64_MAX"},
     { picoquic_option_HELP, 'h', "help", 0, "This help message" }
 };
 
@@ -504,6 +505,17 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
         }
         break;
     }
+    case picoquic_option_CWIN_MAX:{
+        int v = config_atoi(params, nb_params, 0, &ret);
+        if (ret != 0 || v < 0) {
+            fprintf(stderr, "Invalid cwin max option: %s\n", config_optval_param_string(opval_buffer, 256, params, nb_params, 0));
+            ret = (ret == 0) ? -1 : ret;
+        }
+        else {
+            config->cwin_max = (v==0)?UINT64_MAX:v;
+        }
+        break;
+    }
     case picoquic_option_HELP:
         ret = -1;
         break;
@@ -780,6 +792,7 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
         if (cc_algo == NULL) {
             cc_algo = picoquic_bbr_algorithm;
         }
+
         picoquic_set_default_congestion_algorithm(quic, cc_algo);
 
         picoquic_set_default_spinbit_policy(quic, config->spinbit_policy);
@@ -787,6 +800,8 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
 
         picoquic_set_default_multipath_option(quic, config->multipath_option);
         picoquic_set_default_idle_timeout(quic, (uint64_t)config->idle_timeout);
+
+        picoquic_set_cwin_max(quic, config->cwin_max);
 
         if (config->token_file_name) {
             if (picoquic_load_retry_tokens(quic, config->token_file_name) != 0) {
@@ -868,6 +883,7 @@ void picoquic_config_init(picoquic_quic_config_t* config)
     config->cnx_id_length = -1;
     config->nb_connections = 256;
     config->initial_random = 3;
+    config->cwin_max = UINT64_MAX;
 }
 
 void picoquic_config_clear(picoquic_quic_config_t* config)

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.7.0"
+#define PICOQUIC_VERSION "1.1.8.0"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -587,6 +587,9 @@ void picoquic_set_default_lossbit_policy(picoquic_quic_t* quic, picoquic_lossbit
 
 /* Set the multipath option for the context */
 void picoquic_set_default_multipath_option(picoquic_quic_t* quic, int multipath_option);
+
+/* set a maximum value for the congestion window (default: UINT64_MAX) */
+void picoquic_set_cwin_max(picoquic_quic_t* quic, uint64_t cwin_max);
 
 /* Set the idle timeout parameter for the context. Value is in milliseconds. */
 void picoquic_set_default_idle_timeout(picoquic_quic_t* quic, uint64_t idle_timeout);

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -71,6 +71,7 @@ typedef enum {
     picoquic_option_Version_Upgrade,
     picoquic_option_No_GSO,
     picoquic_option_BDP_frame,
+    picoquic_option_CWIN_MAX,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -97,6 +98,7 @@ typedef struct st_picoquic_quic_config_t {
     int multipath_option;
     char *multipath_alt_config;
     int bdp_frame_option;
+    uint64_t cwin_max;
     /* TODO: control other extensions, e.g. time stamp, ack delay */
     /* Common flags */
     unsigned int initial_random;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -626,6 +626,7 @@ typedef struct st_picoquic_quic_t {
     uint32_t max_number_connections;
     uint64_t stateless_reset_next_time; /* Next time Stateless Reset or VN packet can be sent */
     uint64_t stateless_reset_min_interval; /* Enforced interval between two stateless reset packets */
+    uint64_t cwin_max; /* max value of cwin per connection */
     /* Flags */
     unsigned int check_token : 1;
     unsigned int force_check_token : 1;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -629,6 +629,7 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
         quic->stateless_reset_next_time = current_time;
         quic->stateless_reset_min_interval = PICOQUIC_MICROSEC_STATELESS_RESET_INTERVAL_DEFAULT;
         quic->default_stream_priority = PICOQUIC_DEFAULT_STREAM_PRIORITY;
+        quic->cwin_max = UINT64_MAX;
 
         quic->random_initial = 1;
         picoquic_wake_list_init(quic);
@@ -787,6 +788,11 @@ void picoquic_set_default_multipath_option(picoquic_quic_t* quic, int multipath_
             quic->default_tp->enable_simple_multipath = 1;
         }
     }
+}
+
+void picoquic_set_cwin_max(picoquic_quic_t* quic, uint64_t cwin_max)
+{
+    quic->cwin_max = (cwin_max == 0) ? UINT64_MAX : cwin_max;
 }
 
 void picoquic_set_default_idle_timeout(picoquic_quic_t* quic, uint64_t idle_timeout)

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -318,6 +318,7 @@ static const picoquic_test_def_t test_table[] = {
     { "quality_update", quality_update_test },
     { "direct_receive", direct_receive_test },
     { "app_limit_cc", app_limit_cc_test },
+    { "cwin_max", cwin_max_test },
     { "initial_race", initial_race_test },
     { "chacha20", chacha20_test },
     { "cnx_limit", cnx_limit_test },

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -26,7 +26,7 @@
 #include "picoquic_utils.h"
 #include "picoquic_config.h"
 
-static char* ref_option_text = "c:k:p:v:o:w:x:rR:s:XS:G:P:O:M:e:C:i:l:Lb:q:m:n:a:t:zI:d:DQT:N:B:F:VU:0j:h";
+static char* ref_option_text = "c:k:p:v:o:w:x:rR:s:XS:G:P:O:M:e:C:i:l:Lb:q:m:n:a:t:zI:d:DQT:N:B:F:VU:0j:W:h";
 
 int config_option_letters_test()
 {
@@ -66,6 +66,7 @@ static picoquic_quic_config_t param1 = {
     3,
     "127.0.0.1",
     1,
+    UINT64_MAX, /* Do not limit CWIN */
     /* Common flags */
     1, /* unsigned int initial_random : 1; */
     1, /* unsigned int use_long_log : 1; */
@@ -146,6 +147,7 @@ static picoquic_quic_config_t param2 = {
     0,
     "127.0.0.1",
     0,
+    1000000, /* Limit CWIN to 1 million bytes */
     /* Common flags */
     3, /* unsigned int initial_random : 1; */
     0, /* unsigned int use_long_log : 1; */
@@ -191,6 +193,7 @@ static const char* config_argv2[] = {
     "-T", "/data/tickets.bin",
     "-N", "/data/tokens.bin",
     "-U", "00000002",
+    "-W", "1000000",
     NULL
 };
 
@@ -226,7 +229,16 @@ int config_test_compare_int(const char* title, int expected, int actual)
     return ret;
 }
 
+int config_test_compare_uint64(const char* title, uint64_t expected, uint64_t actual)
+{
+    int ret = 0;
 
+    if (expected != actual) {
+        DBG_PRINTF("Expected %s = %" PRIu64 ", got %" PRIu64, title, actual, expected);
+        ret = -1;
+    }
+    return ret;
+}
 
 int config_test_compare_uint32(const char* title, uint32_t expected, uint32_t actual)
 {
@@ -281,7 +293,7 @@ int config_test_compare(const picoquic_quic_config_t* expected, const picoquic_q
     ret |= config_test_compare_int("cnx_id_length", expected->cnx_id_length, actual->cnx_id_length);
     ret |= config_test_compare_int("bdp", expected->bdp_frame_option, actual->bdp_frame_option);
     ret |= config_test_compare_int("idle_timeout", expected->idle_timeout, actual->idle_timeout);
-
+    ret |= config_test_compare_uint64("cwin_max", expected->cwin_max, actual->cwin_max);
     return ret;
 }
 

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -322,6 +322,7 @@ int pacing_update_test();
 int quality_update_test();
 int direct_receive_test();
 int app_limit_cc_test();
+int cwin_max_test();
 int initial_race_test();
 int pacing_test();
 int chacha20_test();

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -10428,6 +10428,152 @@ int app_limit_cc_test()
     return ret;
 }
 
+/* Test the effectiveness of the CWIN MAX option
+ */
+
+#define CWIN_MAX_TRACE_CSV "cwin_max_trace.csv"
+#define CWIN_MAX_TRACE_BIN "c9149a0102030405.server.log"
+
+int cwin_max_test_one(
+    picoquic_congestion_algorithm_t* ccalgo, uint64_t cwin_limit, uint64_t max_completion_time)
+{
+    uint64_t simulated_time = 0;
+    uint64_t latency = 300000;
+    uint64_t picoseq_per_byte_1 = (1000000ull * 8) / 100;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_tp_t client_parameters;
+    picoquic_connection_id_t initial_cid = { {0xc9, 0x14, 0x9a, 1, 2, 3, 4, 5}, 8 };
+    int ret = 0;
+
+    (void)picoquic_file_delete(APP_LIMIT_TRACE_BIN, NULL);
+
+    memset(&client_parameters, 0, sizeof(picoquic_tp_t));
+    picoquic_init_transport_parameters(&client_parameters, 1);
+
+    ret = tls_api_one_scenario_init_ex(&test_ctx, &simulated_time, PICOQUIC_INTERNAL_TEST_VERSION_1, &client_parameters,
+        NULL, &initial_cid, 0);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = -1;
+    }
+
+    if (ret == 0) {
+
+        picoquic_set_default_congestion_algorithm(test_ctx->qserver, ccalgo);
+        picoquic_set_congestion_algorithm(test_ctx->cnx_client, ccalgo);
+        picoquic_set_cwin_max(test_ctx->qserver, 0x10000);
+        picoquic_set_binlog(test_ctx->qserver, ".");
+        test_ctx->qserver->use_long_log = 1;
+        test_ctx->cnx_client->is_flow_control_limited = 1;
+
+        test_ctx->c_to_s_link->jitter = 0;
+        test_ctx->c_to_s_link->microsec_latency = latency;
+        test_ctx->c_to_s_link->picosec_per_byte = picoseq_per_byte_1;
+        test_ctx->s_to_c_link->microsec_latency = latency;
+        test_ctx->s_to_c_link->picosec_per_byte = picoseq_per_byte_1;
+        test_ctx->s_to_c_link->jitter = 0;
+
+        if (ret == 0) {
+            ret = tls_api_one_scenario_body(test_ctx, &simulated_time,
+                test_scenario_very_long, sizeof(test_scenario_very_long), 0, 0, 0, 2 * latency, max_completion_time);
+        }
+    }
+
+    /* Free the resource, which will close the log file.
+    */
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    /* Create a CSV file from the .bin log file */
+    if (ret == 0) {
+        ret = picoquic_cc_log_file_to_csv(CWIN_MAX_TRACE_BIN, CWIN_MAX_TRACE_CSV);
+    }
+
+    /* Compute the max CWIN from the trace file */
+    if (ret == 0)
+    {
+        FILE* F = picoquic_file_open(CWIN_MAX_TRACE_CSV, "r");
+        uint64_t bytes_in_flight_max = 0;
+
+        if (F == NULL) {
+            DBG_PRINTF("Cannot open <%s>", CWIN_MAX_TRACE_CSV);
+            ret = -1;
+        }
+        else {
+            char buffer[512];
+            uint64_t bytes_in_flight_max = 0;
+
+            while (fgets(buffer, 512, F) != NULL) {
+                /* only consider number lines line */
+                if (buffer[0] >= '0' && buffer[0] <= '9') {
+                    uint64_t bytes_in_flight = 0;
+                    int nb_comma = 0;
+                    int c_index = 0;
+
+                    while (nb_comma < 23 && c_index < 512 && buffer[c_index] != 0) {
+                        if (buffer[c_index] == ',') {
+                            nb_comma++;
+                        }
+                        c_index++;
+                    }
+                    while (c_index < 512 && buffer[c_index] == ' ') {
+                        c_index++;
+                    }
+                    while (c_index < 512 && buffer[c_index] >= '0' && buffer[c_index] <= '9') {
+                        bytes_in_flight *= 10;
+                        bytes_in_flight += (uint64_t)buffer[c_index] - '0';
+                        c_index++;
+                    }
+                    if (bytes_in_flight > bytes_in_flight_max) {
+                        bytes_in_flight_max = bytes_in_flight;
+                    }
+                }
+            }
+
+            (void)picoquic_file_close(F);
+
+            if (bytes_in_flight_max > cwin_limit) {
+                DBG_PRINTF("MAX In Flight = %" PRIu64 ", larger than %" PRIu64, bytes_in_flight_max, cwin_limit);
+                ret = -1;
+            }
+        }
+    }
+
+    return ret;
+}
+
+int cwin_max_test()
+{
+    picoquic_congestion_algorithm_t* ccalgos[] = {
+        picoquic_newreno_algorithm,
+        picoquic_cubic_algorithm,
+        picoquic_dcubic_algorithm,
+        picoquic_bbr_algorithm,
+        picoquic_fastcc_algorithm };
+    uint64_t max_completion_times[] = {
+        11000000,
+        12000000,
+        11000000,
+        11000000,
+        13000000 };
+    int ret = 0;
+
+    for (size_t i = 0; i < sizeof(ccalgos) / sizeof(picoquic_congestion_algorithm_t*); i++) {
+        ret = cwin_max_test_one(ccalgos[i], 68000, max_completion_times[i]);
+        if (ret != 0) {
+            DBG_PRINTF("CWIN Max test fails for <%s>", ccalgos[i]->congestion_algorithm_id);
+            break;
+        }
+    }
+
+    return ret;
+}
+
+
+
 /* Initial race condition.
 * What happens if the client immediately repeats the Initial packet?
 */


### PR DESCRIPTION
Add a new API:
```
/* set a maximum value for the congestion window (default: UINT64_MAX) */
void picoquic_set_cwin_max(picoquic_quic_t* quic, uint64_t cwin_max);
```
This is meant to limit the memory used by QUIC connections, at the cost of limiting the maximum data-rate of these connections. The default value is `UINT64_MAX`. If an application wants to limit the memory, it should compute the maximum BDP using the formula:
```
bandwidth_delay_product = RTT_in_seconds * data_rate_in_bits_per_second / 8
```
 And then set the BDP to that value. Or, set the BDP to a lower value if that's too much memory, but accept some lower data rates.

This is meant to mitigate issue #1499.
