### PR TITLE
Remove references to sqrt() in tests

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -160,6 +160,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(sqrt_for_test)
+        {
+            int ret = sqrt_for_test_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(ack_sack)
         {
             int ret = sacktest();

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -58,6 +58,7 @@ static const picoquic_test_def_t test_table[] = {
     { "pn2pn64", pn2pn64test },
     { "intformat", intformattest },
     { "varint", varint_test },
+    { "sqrt_for_test", sqrt_for_test_test },
     { "ack_sack", sacktest },
     { "skip_frames", skip_frame_test },
     { "parse_frames", parse_frame_test },

--- a/picoquictest/intformattest.c
+++ b/picoquictest/intformattest.c
@@ -323,3 +323,63 @@ int varint_test()
  
     return ret;
 }
+
+/* Simple implementation of SQRT using UINT64, so we do not have to link 
+ * the math library
+ */
+
+uint64_t picoquic_sqrt_for_tests(uint64_t y)
+{
+    const uint64_t sqrt_6[16] = { 0, 1, 1, 1, 2, 2 };
+    uint64_t x = 0;
+    if (y < 6) {
+        x = sqrt_6[y];
+    }
+    else {
+        uint64_t x_min = 2;
+        uint64_t x_max = ((y / 2) > 0xffffffff) ? 0xffffffff : y / 2;
+        uint64_t x_min_2 = x_min * x_min;
+        uint64_t x_max_2 = x_max * x_max;
+
+        for (int i = 0; i < 64; i++) {
+            uint64_t x2;
+            x = (x_min + x_max) / 2;
+            if (x_min + 1 >= x_max) {
+                break;
+            }
+            x2 = x * x;
+            if (x2 < y) {
+                x_min = x;
+            }
+            else if (x2 > y) {
+                x_max = x;
+            }
+            else
+            {
+                x_min = x;
+                x_max = x;
+                break;
+            }
+        }
+    }
+    return x;
+}
+
+int sqrt_for_test_test()
+{
+    int ret = 0;
+    uint64_t x_base = 0;
+
+    while (x_base < 0xffffffff && ret == 0) {
+        for (uint64_t i = 0; i < 2; i++) {
+            uint64_t y = x_base * (x_base+i);
+            uint64_t x = picoquic_sqrt_for_tests(y);
+            if (x != x_base) {
+                ret = -1;
+                break;
+            }
+        }
+        x_base = 2 * x_base + 1;
+    }
+    return ret;
+}

--- a/picoquictest/mediatest.c
+++ b/picoquictest/mediatest.c
@@ -324,7 +324,7 @@ int mediatest_check_stats(mediatest_ctx_t* mt_ctx, media_test_type_enum media_ty
         else if (stats->nb_frames != 0) {
             uint64_t average = stats->sum_delays / stats->nb_frames;
             uint64_t variance = (stats->sum_square_delays / stats->nb_frames) - (average * average);
-            uint64_t sigma = (uint64_t)sqrt((double)variance);
+            uint64_t sigma = picoquic_sqrt_for_tests(variance);
 
             if (average > 25000 || sigma > 12500 || stats->max_delay > 100000) {
                 ret = -1;

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -94,6 +94,7 @@ int tls_api_two_connections_test();
 int cleartext_aead_test();
 int tls_api_multiple_versions_test();
 int varint_test();
+int sqrt_for_test_test();
 int tls_api_client_losses_test();
 int tls_api_server_losses_test();
 int skip_frame_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -318,6 +318,8 @@ int tls_api_one_scenario_test(test_api_stream_desc_t* scenario,
 
 void qlog_trace_cid_fn(picoquic_quic_t* quic, picoquic_connection_id_t cnx_id_local, picoquic_connection_id_t cnx_id_remote, void* cnx_id_cb_data, picoquic_connection_id_t* cnx_id_returned);
 
+uint64_t picoquic_sqrt_for_tests(uint64_t y);
+
 #ifdef __cplusplus
 }
 #endif

--- a/picoquictest/warptest.c
+++ b/picoquictest/warptest.c
@@ -643,7 +643,7 @@ int warptest_check_stats(warptest_ctx_t* mt_ctx, warptest_type_enum media_type)
         else if (stats->nb_frames != 0) {
             uint64_t average = stats->sum_delays / stats->nb_frames;
             uint64_t variance = (stats->sum_square_delays / stats->nb_frames) - (average * average);
-            uint64_t sigma = (uint64_t)sqrt((double)variance);
+            uint64_t sigma = picoquic_sqrt_for_tests(variance);
 
             if (average > 25000 || sigma > 12500 || stats->max_delay > 100000) {
                 ret = -1;


### PR DESCRIPTION
Using sqrt() in test evaluations seemed like a good idea, but linking to the math library is apparently an issue on some platform. This PR adds our own implementation of sqrt for uint64_t, removing the dependency on math library. The replacement function is not optimized -- it uses a simple binary search. But it is good enough for tests.

Close #1503