### PR TITLE
Simple optimistic ack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.9.0
+        VERSION 1.1.9.1
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.9.0"
+#define PICOQUIC_VERSION "1.1.9.1"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -1268,9 +1268,16 @@ uint8_t* picoquic_provide_datagram_buffer(void* context, size_t length);
 uint8_t* picoquic_provide_datagram_buffer_ex(void* context, size_t length, picoquic_datagram_active_enum is_active);
 
 /* 
- * Set the optimistic ack policy. The holes will be inserted at random locations,
- * which in average will be separated by the pseudo period. By default,
- * the pseudo perio is 0, which means no hole insertion.
+ * Set the optimistic ack policy. This is a security feature that prevents
+ * peer from "faking" acknowledgements of packets that they have not
+ * received by inserting "holes" in the sequence of packet numbers.
+ * Acknowledging a hole is a protocol error, resulting in connection
+ * closure.
+ * 
+ * The holes are inserted at random, based on
+ * a period that doubles after each hole insertion in a given number space.
+ * By default, the initial period is 256. Setting it to 0 suppresses further
+ * hole insertion.
  */
 void picoquic_set_optimistic_ack_policy(picoquic_quic_t* quic, uint32_t sequence_hole_pseudo_period);
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -114,6 +114,8 @@ extern "C" {
 #define PICOQUIC_MAX_ACK_RANGE_REPEAT 4
 #define PICOQUIC_MIN_ACK_RANGE_REPEAT 2
 
+#define PICOQUIC_DEFAULT_HOLE_PERIOD 256
+
 /*
  * Types of frames.
  */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -630,6 +630,7 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
         quic->stateless_reset_min_interval = PICOQUIC_MICROSEC_STATELESS_RESET_INTERVAL_DEFAULT;
         quic->default_stream_priority = PICOQUIC_DEFAULT_STREAM_PRIORITY;
         quic->cwin_max = UINT64_MAX;
+        quic->sequence_hole_pseudo_period = PICOQUIC_DEFAULT_HOLE_PERIOD;
 
         quic->random_initial = 1;
         picoquic_wake_list_init(quic);

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -1193,7 +1193,7 @@ void picoquic_insert_hole_in_send_sequence_if_needed(picoquic_cnx_t* cnx, picoqu
         pkt_ctx->next_sequence_hole = UINT64_MAX;
     } else if (cnx->cnx_state == picoquic_state_ready &&
         pkt_ctx->retransmit_newest != NULL &&
-        pkt_ctx->send_sequence >= cnx->pkt_ctx[0].next_sequence_hole) {
+        pkt_ctx->send_sequence >= pkt_ctx->next_sequence_hole) {
         if (pkt_ctx->next_sequence_hole != 0 &&
             !pkt_ctx->retransmit_newest->is_ack_trap) {
             /* Insert a hole in sequence */
@@ -1216,7 +1216,7 @@ void picoquic_insert_hole_in_send_sequence_if_needed(picoquic_cnx_t* cnx, picoqu
             }
         }
         /* Predict the next hole*/
-        pkt_ctx->next_sequence_hole = pkt_ctx->send_sequence + 3 + picoquic_public_uniform_random(cnx->quic->sequence_hole_pseudo_period);
+        pkt_ctx->next_sequence_hole = pkt_ctx->send_sequence + 3 + picoquic_public_uniform_random(((uint64_t)cnx->quic->sequence_hole_pseudo_period)<<cnx->nb_packet_holes_inserted);
     }
 }
 

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -1144,7 +1144,7 @@ int monopath_test_one(monopath_test_enum_t test_case)
 
         if (test_case == monopath_test_hole) {
             /* set the optimistic ack policy, to trigger hole insertion at the server */
-            picoquic_set_optimistic_ack_policy(test_ctx->qserver, 29);
+            picoquic_set_optimistic_ack_policy(test_ctx->qserver, PICOQUIC_DEFAULT_HOLE_PERIOD);
             /* Reset the uniform random test */
             picoquic_public_random_seed_64(RANDOM_PUBLIC_TEST_SEED, 1);
         }

--- a/picoquictest/satellite_test.c
+++ b/picoquictest/satellite_test.c
@@ -123,6 +123,7 @@ static int satellite_test_one(picoquic_congestion_algorithm_t* ccalgo, size_t da
         picoquic_set_preemptive_repeat_policy(test_ctx->qserver, do_preemptive);
         picoquic_set_preemptive_repeat_per_cnx(test_ctx->cnx_client, do_preemptive);
 
+
         test_ctx->c_to_s_link->jitter = jitter;
         test_ctx->c_to_s_link->microsec_latency = latency;
         test_ctx->c_to_s_link->picosec_per_byte = picoseq_per_byte_up;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1177,6 +1177,9 @@ int tls_api_init_ctx_ex2(picoquic_test_tls_api_ctx_t** pctx, uint32_t proposed_v
                 {
                     test_ctx->qclient->client_zero_share = 1;
                 }
+                /* Do not use hole insertion by default */
+                picoquic_set_optimistic_ack_policy(test_ctx->qclient, 0);
+                picoquic_set_optimistic_ack_policy(test_ctx->qserver, 0);
 
                 /* Create a client connection */
                 test_ctx->cnx_client = picoquic_create_cnx(test_ctx->qclient,
@@ -9137,8 +9140,8 @@ int optimistic_ack_test_one(int shall_spoof_ack)
         0, NULL, NULL, &initial_cid, 0);
 
     if (ret == 0) {
-        /* set the optimistic ack policy*/
-        picoquic_set_optimistic_ack_policy(test_ctx->qserver, 29);
+        /* set the optimistic ack policy to the default value */
+        picoquic_set_optimistic_ack_policy(test_ctx->qserver, PICOQUIC_DEFAULT_HOLE_PERIOD);
         /* add a log request for debugging */
         picoquic_set_binlog(test_ctx->qserver, ".");
 


### PR DESCRIPTION
Set the default optimistic ack policy to the strategy suggested by Marten Seeman:

* first skip one packet number within the first 256 packets (randomly)
* next, skip a packet number within the next 512 packets
* … double the period every time

Fix the test suite to set the default to "no hole", except for tests that explicitly require hole insertion, because additional randomization does not help test repeatability.