### PR TITLE
Verify reported crash does not repro.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ set(PICOQUIC_TEST_LIBRARY_FILES
     picoquictest/parseheadertest.c
     picoquictest/picoquic_lb_test.c
     picoquictest/pn2pn64test.c
+    picoquictest/quic_tester.c
     picoquictest/sacktest.c
     picoquictest/satellite_test.c
     picoquictest/skip_frame_test.c

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -446,6 +446,20 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(initial_ping)
+        {
+            int ret = initial_ping_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
+        TEST_METHOD(initial_ping_ack)
+        {
+            int ret = initial_ping_ack_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(datagram)
         {
             int ret = datagram_test();

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1272,7 +1272,7 @@ int picoquic_incoming_client_initial(
             (*pcnx)->initial_validated = 1;
         }
 
-        if (!(*pcnx)->initial_validated && (*pcnx)->pkt_ctx[picoquic_packet_context_initial].retransmit_oldest != NULL
+        if (!(*pcnx)->initial_validated && (*pcnx)->pkt_ctx[picoquic_packet_context_initial].pending_first != NULL
             && packet_length >= PICOQUIC_ENFORCED_INITIAL_MTU) {
             /* In most cases, receiving more than 1 initial packets before validation indicates that the
              * client is repeating data that it believes is lost. We set the initial_repeat_needed flag
@@ -2349,11 +2349,11 @@ int picoquic_incoming_segment(
         (cnx->cnx_state == picoquic_state_client_init_sent || cnx->cnx_state == picoquic_state_client_init_resent))
     {
         /* Indicates that the server probably sent initial and handshake but initial was lost */
-        if (cnx->pkt_ctx[picoquic_packet_context_initial].retransmit_oldest != NULL &&
+        if (cnx->pkt_ctx[picoquic_packet_context_initial].pending_first != NULL &&
             cnx->path[0]->nb_retransmit == 0) {
             /* Reset the retransmit timer to start retransmission immediately */
             cnx->path[0]->retransmit_timer = current_time -
-                cnx->pkt_ctx[picoquic_packet_context_initial].retransmit_oldest->send_time;
+                cnx->pkt_ctx[picoquic_packet_context_initial].pending_first->send_time;
         }
     }
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -376,8 +376,8 @@ typedef struct st_picoquic_stream_queue_node_t {
  */
 
 typedef struct st_picoquic_packet_t {
-    struct st_picoquic_packet_t* previous_packet;
-    struct st_picoquic_packet_t* next_packet;
+    struct st_picoquic_packet_t* packet_next;
+    struct st_picoquic_packet_t* packet_previous;
     struct st_picoquic_path_t* send_path;
     struct st_picoquic_packet_t* path_packet_next;
     struct st_picoquic_packet_t* path_packet_previous;
@@ -876,8 +876,8 @@ typedef struct st_picoquic_packet_context_t {
     uint64_t highest_acknowledged;
     uint64_t latest_time_acknowledged; /* time at which the highest acknowledged was sent */
     uint64_t highest_acknowledged_time; /* time at which the highest ack was received */
-    picoquic_packet_t* retransmit_newest;
-    picoquic_packet_t* retransmit_oldest;
+    picoquic_packet_t* pending_last;
+    picoquic_packet_t* pending_first;
     picoquic_packet_t* retransmitted_newest;
     picoquic_packet_t* retransmitted_oldest;
     picoquic_packet_t* preemptive_repeat_ptr;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1629,6 +1629,8 @@ uint64_t picoquic_get_packet_number64(uint64_t highest, uint64_t mask, uint32_t 
 
 void picoquic_log_pn_dec_trial(picoquic_cnx_t* cnx); /* For debugging potential PN_ENC corruption */
 
+size_t picoquic_pad_to_target_length(uint8_t* bytes, size_t length, size_t target);
+
 void picoquic_finalize_and_protect_packet(picoquic_cnx_t *cnx, picoquic_packet_t * packet, int ret,
     size_t length, size_t header_length, size_t checksum_overhead,
     size_t * send_length, uint8_t * send_buffer, size_t send_buffer_max,

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -113,6 +113,8 @@ static const picoquic_test_def_t test_table[] = {
     { "client_losses", tls_api_client_losses_test },
     { "server_losses", tls_api_server_losses_test },
     { "many_losses", tls_api_many_losses },
+    { "initial_ping", initial_ping_test },
+    { "initial_ping_ack", initial_ping_ack_test },
     { "datagram", datagram_test },
     { "datagram_rt", datagram_rt_test },
     { "datagram_rt_skip", datagram_rt_skip_test },

--- a/picoquictest/edge_cases.c
+++ b/picoquictest/edge_cases.c
@@ -547,10 +547,10 @@ int ec9a_preemptive_amok_test()
         }
         else if ( test_ctx->cnx_server->cnx_state != picoquic_state_ready ||
             !test_ctx->test_finished || 
-            test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].retransmit_oldest == NULL){
+            test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].pending_first == NULL){
             DBG_PRINTF("Unexpected state, server: %d, test finished: %d, queue for repeat %s",
                 test_ctx->cnx_server->cnx_state, test_ctx->test_finished, 
-                (test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].retransmit_oldest == NULL)?"empty":"full");
+                (test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].pending_first == NULL)?"empty":"full");
             ret = -1;
         }
     }

--- a/picoquictest/parseheadertest.c
+++ b/picoquictest/parseheadertest.c
@@ -1127,7 +1127,7 @@ static int header_length_test_one(header_length_case_t * hlc)
         /* Reset the retransmit queue to simulate unack */
         if (hlc->sequence_unack != hlc->sequence_unack_after) {
             if (hlc->sequence_unack != UINT64_MAX) {
-                picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, pkt_ctx->retransmit_oldest, 1, 0);
+                picoquic_dequeue_retransmit_packet(cnx, pkt_ctx, pkt_ctx->pending_first, 1, 0);
             }
             if (hlc->sequence_unack_after != UINT64_MAX) {
                 ret = header_length_test_set_queue(cnx, hlc, hlc->sequence_unack_after, pc, pkt_ctx, simulated_time);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -62,6 +62,8 @@ int tls_api_client_first_loss_test();
 int tls_api_client_second_loss_test();
 int tls_api_server_first_loss_test();
 int tls_api_many_losses();
+int initial_ping_test();
+int initial_ping_ack_test();
 int code_version_test();
 int tls_api_version_negotiation_test();
 int tls_api_version_invariant_test();

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -170,6 +170,7 @@
     <ClCompile Include="parseheadertest.c" />
     <ClCompile Include="picoquic_lb_test.c" />
     <ClCompile Include="pn2pn64test.c" />
+    <ClCompile Include="quic_tester.c" />
     <ClCompile Include="sacktest.c" />
     <ClCompile Include="satellite_test.c" />
     <ClCompile Include="skip_frame_test.c" />

--- a/picoquictest/picoquictest.vcxproj.filters
+++ b/picoquictest/picoquictest.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="wifitest.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="quic_tester.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquictest.h">

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -267,6 +267,9 @@ int tls_api_one_scenario_init(
 int tls_api_connection_loop(picoquic_test_tls_api_ctx_t* test_ctx,
     uint64_t* loss_mask, uint64_t queue_delay_max, uint64_t* simulated_time);
 
+int tls_api_test_with_loss_final(picoquic_test_tls_api_ctx_t* test_ctx, uint32_t proposed_version,
+    char const* sni, char const* alpn, uint64_t* simulated_time);
+
 int test_api_init_send_recv_scenario(picoquic_test_tls_api_ctx_t* test_ctx,
     test_api_stream_desc_t* stream_desc, size_t size_of_scenarios);
 

--- a/picoquictest/quic_tester.c
+++ b/picoquictest/quic_tester.c
@@ -1,0 +1,349 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2017, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* This file contains a set of tests copied from the "QUIC Tester"
+*/
+
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include "picoquic.h"
+#include "picoquic_internal.h"
+#include "picoquictest_internal.h"
+#include "tls_api.h"
+#include "picoquic_binlog.h"
+#include "logreader.h"
+#include "qlog.h"
+#include "autoqlog.h"
+
+/* Wait until handshake key is ready */
+int tester_wait_handshake_key(picoquic_test_tls_api_ctx_t* test_ctx, uint64_t* simulated_time)
+{
+    int ret = 0;
+    uint64_t time_out = *simulated_time + 4000000;
+    int nb_trials = 0;
+    int nb_inactive = 0;
+    int was_active = 0;
+
+    while (*simulated_time < time_out &&
+        nb_trials < 1024 &&
+        nb_inactive < 64 &&
+        ret == 0) {
+        was_active = 0;
+        nb_trials++;
+        
+        if (test_ctx->cnx_client->cnx_state >= picoquic_state_client_handshake_start &&
+            test_ctx->cnx_client->crypto_context[picoquic_epoch_handshake].aead_encrypt != NULL) {
+            break;
+        }
+
+        ret = tls_api_one_sim_round(test_ctx, simulated_time, time_out, &was_active);
+
+        if (was_active) {
+            nb_inactive = 0;
+            *simulated_time += 1000;
+        }
+        else {
+            nb_inactive++;
+        }
+    }
+
+    return ret;
+}
+/* Format a minimalistic ACK frame
+ */
+size_t tester_simple_ack_frame(uint8_t* bytes, size_t bytes_size, uint64_t last_packet_number)
+{
+    size_t length = 0;
+    uint8_t* bytes_max = bytes + bytes_size;
+    uint8_t* bytes_first = bytes;
+
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, picoquic_frame_type_ack)) != NULL &&
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, last_packet_number)) != NULL &&
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, 0 /* ack delay */)) != NULL &&
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, 0 /* range count */)) != NULL &&
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, 0 /* first ack range */)) != NULL) {
+        length = bytes - bytes_first;
+    }
+    return length;
+}
+
+
+/* Forcefully insert a packet in the client flow
+ */
+
+picoquic_packet_t* tester_init_packet(picoquic_cnx_t* cnx, picoquic_packet_type_enum ptype)
+{
+    picoquic_packet_t* packet = picoquic_create_packet(cnx->quic);
+
+    if (packet != NULL) {
+        packet->checksum_overhead = 16;
+        packet->ptype = ptype;
+        switch (ptype) {
+        case picoquic_packet_initial:
+            packet->pc = picoquic_packet_context_initial;
+            break;
+        case picoquic_packet_handshake:
+            packet->pc = picoquic_packet_context_handshake;
+            break;
+        case picoquic_packet_0rtt_protected:
+            packet->pc = picoquic_packet_context_application;
+            break;
+        case picoquic_packet_1rtt_protected:
+            packet->pc = picoquic_packet_context_application;
+            break;
+        default:
+            picoquic_recycle_packet(cnx->quic, packet);
+            break;
+        }
+    }
+    if (packet != NULL) {
+        packet->offset = picoquic_predict_packet_header_length(cnx, ptype, &cnx->pkt_ctx[packet->pc]);
+        packet->length = packet->offset;
+        packet->send_path = cnx->path[0];
+    }
+    return (packet);
+}
+
+void tester_add_frame(picoquic_packet_t* packet, uint8_t* frame, size_t frame_length)
+{
+    if (packet->length + frame_length < sizeof(packet->bytes)) {
+        memcpy(&packet->bytes[packet->length], frame, frame_length);
+        packet->length += frame_length;
+    }
+}
+
+void tester_finalize_packet(picoquic_cnx_t* cnx,
+    picoquic_packet_t* packet, size_t length, uint64_t current_time,
+    size_t* send_length,
+    uint8_t* send_buffer, size_t send_buffer_max)
+{
+    size_t header_length = packet->offset;
+    size_t checksum_overhead = 16;
+    picoquic_path_t* path_x = cnx->path[0];
+    packet->length = length;
+
+    picoquic_finalize_and_protect_packet(cnx, packet,
+        0, length, packet->offset, packet->checksum_overhead,
+        send_length, send_buffer, send_buffer_max,
+        path_x, current_time);
+}
+
+int tester_push_frame_packet(picoquic_test_tls_api_ctx_t* test_ctx,
+    picoquic_packet_type_enum ptype, uint8_t* frame, size_t frame_length,
+    int shall_pad, int shall_queue, uint64_t current_time)
+{
+    int ret = 0;
+    picoquic_packet_t* packet = tester_init_packet(test_ctx->cnx_client,
+        ptype);
+
+    if (packet == NULL) {
+        ret = -1;
+    }
+    else {
+        tester_add_frame(packet, frame, frame_length);
+    }
+
+    if (shall_pad) {
+        packet->length = picoquic_pad_to_target_length(
+            packet->bytes, packet->length,
+            packet->send_path->send_mtu - packet->checksum_overhead);
+    }
+
+    if (ret == 0) {
+        picoquictest_sim_packet_t* sim_packet = picoquictest_sim_link_create_packet();
+
+        if (sim_packet != NULL) {
+            uint8_t* send_buffer = sim_packet->bytes;
+            size_t send_length = 0;
+
+            tester_finalize_packet(test_ctx->cnx_client,
+                packet, packet->length, current_time,
+                &send_length, send_buffer, PICOQUIC_MAX_PACKET_SIZE);
+
+            if (shall_queue) {
+                picoquic_store_addr(&sim_packet->addr_from, (struct sockaddr*)&test_ctx->client_addr);
+                picoquic_store_addr(&sim_packet->addr_to, (struct sockaddr*)&test_ctx->server_addr);
+                sim_packet->ecn_mark = test_ctx->packet_ecn_default;
+                sim_packet->length = send_length;
+                picoquictest_sim_link_submit(test_ctx->c_to_s_link, sim_packet, current_time);
+            }
+            else {
+                picoquic_incoming_packet(test_ctx->qserver, send_buffer, send_length,
+                    (struct sockaddr*)&test_ctx->client_addr, (struct sockaddr*)&test_ctx->server_addr, 0,
+                    0, current_time);
+                free(sim_packet);
+            }
+        }
+    }
+    return ret;
+}
+
+/*
+Initial ping test.
+The QUIC tester sends a "ping" frame before sending the
+client hello. The test checks what happens, whether the
+server responds properly, or at all.
+*/
+
+int initial_ping_test()
+{
+    uint64_t simulated_time = 0;
+    uint64_t loss_mask = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_packet_t* ping_packet = NULL;
+    uint8_t ping_frame[1] = { 1 };
+    picoquic_connection_id_t initial_cid = { {0x4e, 0x54, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11}, 8 };
+    int ret = tls_api_init_ctx_ex(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 0, 0, &initial_cid);
+
+    if (ret != 0)
+    {
+        DBG_PRINTF("Could not create the QUIC test contexts for V=%x\n", PICOQUIC_INTERNAL_TEST_VERSION_1);
+    }
+    else {
+        picoquic_set_qlog(test_ctx->qserver, ".");
+    }
+
+    /*
+    Insert a ping frame at the client, pass it to the server.
+    */
+    if (ret == 0) {
+        ret = tester_push_frame_packet(test_ctx,
+            picoquic_packet_initial,
+            ping_frame, sizeof(ping_frame),
+            1, 0, simulated_time);
+    }
+
+    /*
+    * Finish the test
+    */
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+
+        if (ret != 0)
+        {
+            DBG_PRINTF("Connection loop returns %d\n", ret);
+        }
+    }
+
+    if (ret == 0) {
+        ret = tls_api_test_with_loss_final(test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time);
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
+}
+
+/*
+Initial ping and ack test.
+The QUIC tester sends a "ping" frame before sending the
+client hello. Then, it sends an initial ACK and a handshake ACK
+as soon as the server hello has been received.
+
+The test checks what happens, whether the
+server responds properly, or at all.
+*/
+
+int initial_ping_ack_test()
+{
+    uint64_t simulated_time = 0;
+    uint64_t loss_mask = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_packet_t* ping_packet = NULL;
+    uint8_t ping_frame[1] = { 1 };
+    picoquic_connection_id_t initial_cid = { {0x4e, 0x54, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12}, 8 };
+    int ret = tls_api_init_ctx_ex(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 0, 0, &initial_cid);
+
+    if (ret != 0)
+    {
+        DBG_PRINTF("Could not create the QUIC test contexts for V=%x\n", PICOQUIC_INTERNAL_TEST_VERSION_1);
+    }
+    else {
+        picoquic_set_qlog(test_ctx->qserver, ".");
+        test_ctx->s_to_c_link->microsec_latency = 1;
+        test_ctx->c_to_s_link->microsec_latency = 1;
+    }
+
+    /*
+    Insert a ping frame at the client, pass it to the server.
+    */
+    if (ret == 0) {
+        ret = tester_push_frame_packet(test_ctx,
+            picoquic_packet_initial,
+            ping_frame, sizeof(ping_frame),
+            1, 1, simulated_time);
+    }
+
+    /*
+    * Wait until the server hello has been received and the handshake key has
+    * been computed.
+    */
+    if (ret == 0) {
+        ret = tester_wait_handshake_key(test_ctx, &simulated_time);
+    }
+
+    /* Insert Initial ACK packet as specified in issue report. */
+
+    if (ret == 0) {
+        uint8_t ack_frame[128];
+        size_t ack_frame_length = tester_simple_ack_frame(ack_frame, sizeof(ack_frame), 1);
+
+        ret = tester_push_frame_packet(test_ctx, picoquic_packet_initial,
+            ack_frame, ack_frame_length, 1, 0, simulated_time);
+    }
+
+    /* Insert Handshake ack packets, as specified.
+     */
+    if (ret == 0) {
+        uint8_t ack_frame[128];
+        size_t ack_frame_length = tester_simple_ack_frame(ack_frame, sizeof(ack_frame), 1);
+        ret = tester_push_frame_packet(test_ctx, picoquic_packet_handshake,
+            ack_frame, ack_frame_length, 0, 0, simulated_time);
+    }
+
+    /*
+    * Finish the test
+    */
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+
+        if (ret != 0)
+        {
+            DBG_PRINTF("Connection loop returns %d\n", ret);
+        }
+    }
+
+    if (ret == 0) {
+        ret = tls_api_test_with_loss_final(test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time);
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+        test_ctx = NULL;
+    }
+
+    return ret;
+}

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1828,7 +1828,7 @@ static int tls_api_attempt_to_close(
     return tls_api_close_with_losses(test_ctx, simulated_time, 0);
 }
 
-static int tls_api_test_with_loss_final(picoquic_test_tls_api_ctx_t* test_ctx, uint32_t proposed_version,
+int tls_api_test_with_loss_final(picoquic_test_tls_api_ctx_t* test_ctx, uint32_t proposed_version,
     char const* sni, char const* alpn, uint64_t * simulated_time)
 {
     int ret = 0;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2912,11 +2912,11 @@ int implicit_ack_test()
     }
 
     for (int i = 0; ret == 0 && i < 2; i++) {
-        if (test_ctx->cnx_client->pkt_ctx[pc[i]].retransmit_oldest != NULL) {
+        if (test_ctx->cnx_client->pkt_ctx[pc[i]].pending_first != NULL) {
             DBG_PRINTF("Retransmit queue type %d not empty on client", pc[i]);
             ret = -1;
         }
-        else if (test_ctx->cnx_server->pkt_ctx[pc[i]].retransmit_oldest != NULL) {
+        else if (test_ctx->cnx_server->pkt_ctx[pc[i]].pending_first != NULL) {
             DBG_PRINTF("Retransmit queue type %d not empty on server", pc[i]);
             ret = -1;
         }
@@ -2924,7 +2924,7 @@ int implicit_ack_test()
             DBG_PRINTF("Retransmitted queue type %d not empty on client", pc[i]);
             ret = -1;
         }
-        else if (test_ctx->cnx_server->pkt_ctx[pc[i]].retransmit_oldest != NULL) {
+        else if (test_ctx->cnx_server->pkt_ctx[pc[i]].pending_first != NULL) {
             DBG_PRINTF("Retransmitted queue type %d not empty on server", pc[i]);
             ret = -1;
         }
@@ -9224,7 +9224,7 @@ int optimistic_ack_test_one(int shall_spoof_ack)
 
             /* find whether there was a new hole inserted */
             if (test_ctx->cnx_server != NULL) {
-                picoquic_packet_t * packet = test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].retransmit_oldest;
+                picoquic_packet_t * packet = test_ctx->cnx_server->pkt_ctx[picoquic_packet_context_application].pending_first;
 
                 while (packet != NULL && packet->sequence_number > hole_number) {
                     if (packet->is_ack_trap) {
@@ -9240,7 +9240,7 @@ int optimistic_ack_test_one(int shall_spoof_ack)
                         nb_holes++;
                         break;
                     }
-                    packet = packet->previous_packet;
+                    packet = packet->packet_next;
                 }
             }
 


### PR DESCRIPTION
There was a potential crash reported in issue #1527. It turns out that the test was conducted on a previous version of Picoquic, and that the issue was already fixed. The additional test verifies that.