### PR TITLE
Add test of reset_stream loss and repeat

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -908,6 +908,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(stop_sending_loss)
+        {
+            int ret = stop_sending_loss_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(discard_stream)
         {
             int ret = discard_stream_test();

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -175,6 +175,7 @@ static const picoquic_test_def_t test_table[] = {
     { "zero_rtt", zero_rtt_test },
     { "zero_rtt_loss", zero_rtt_loss_test },
     { "stop_sending", stop_sending_test },
+    { "stop_sending_loss", stop_sending_loss_test },
     { "discard_stream", discard_stream_test },
     { "unidir", unidir_test },
     { "mtu_discovery", mtu_discovery_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -114,6 +114,7 @@ int session_resume_test();
 int zero_rtt_test();
 int zero_rtt_loss_test();
 int stop_sending_test();
+int stop_sending_loss_test();
 int discard_stream_test();
 int unidir_test();
 int mtu_discovery_test();

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4251,7 +4251,7 @@ int zero_rtt_delay_test()
  * and a stop sending in a single call.
  */
 
-int stop_sending_test_one(int discard)
+int stop_sending_test_one(int discard, int reset_loss)
 {
     uint64_t simulated_time = 0;
     const uint64_t stop_sending_latency = 100000;
@@ -4305,6 +4305,13 @@ int stop_sending_test_one(int discard)
 
     /* resume the sending scenario */
     if (ret == 0) {
+        if (reset_loss) {
+            /* Mask is calibrated to cause loss of the reset packet.
+             * This could be replaced by a specialized wait loop up to the
+             * point when the stop sending packet has been received.
+             */
+            loss_mask = 0x00FC0000000ull;
+        }
         ret = tls_api_data_sending_loop(test_ctx, &loss_mask, &simulated_time, 0);
     }
 
@@ -4349,13 +4356,19 @@ int stop_sending_test_one(int discard)
 
 int stop_sending_test()
 {
-    int ret = stop_sending_test_one(0);
+    int ret = stop_sending_test_one(0, 0);
+    return ret;
+}
+
+int stop_sending_loss_test()
+{
+    int ret = stop_sending_test_one(0, 1);
     return ret;
 }
 
 int discard_stream_test()
 {
-    int ret = stop_sending_test_one(1);
+    int ret = stop_sending_test_one(1, 0);
     return ret;
 }
 


### PR DESCRIPTION
This is part of debugging the perceived increase of memory in issue #1499. Debugging so far shows that the `reset_stream` was not received by the application, so we add a test to verify that `reset_stream` frames are correctly repeated after packet loss. 