### PR TITLE
Decode settings, refactor and test

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -463,7 +463,7 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
             if (ret == 0 && length > 0) {
                 switch (ctx->alpn) {
                 case picoquic_alpn_http_3: {
-                    uint16_t error_found = 0;
+                    uint64_t error_found = 0;
                     size_t available_data = 0;
                     uint8_t * bytes_max = bytes + length;
                     while (bytes < bytes_max) {

--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -993,187 +993,43 @@ uint8_t* h3zero_create_bad_method_header_frame(uint8_t* bytes, uint8_t* bytes_ma
     return h3zero_create_bad_method_header_frame_ex(bytes, bytes_max, H3ZERO_USER_AGENT_STRING);
 }
 
-/* Parsing of a data stream. This is implemented as a filter, with a set of states:
+/* Read varint from stream.
+ * The H3 streams data structures often include series of varint for
+ * encoding of types, lengths, or property values. The size of
+ * the messages is not known in advance. Instead, the parser is called
+ * when bytes are received from the network.
  * 
- * - Reading frame length: obtaining the length and type of the next frame.
- * - Reading header frame: obtaining the bytes of the header frame.
- *   When all bytes are obtained, the header is parsed and the header
- *   structure is documented. State moves back to initial, with header-read
- *   flag set. Having two frame headers before a data frame is a bug.
- * - Reading unknown frame: unknown frames can happen at any point in
- *   the stream, and should just be ignored.
- * - Reading data frame: the frame header indicated a data frame of
- *   length N. Treat the following N bytes as data.
- * 
- * There may be several data frames in a stream. The application will pick
- * the bytes and treat them as data.
+ * The parser retains as state the number of bytes accumulated in 
+ * a buffer. If the first byte is read, this byte provides the
+ * length of the encoding. If there are zero bytes, the first byte
+ * to be read will be placed in the buffer.
  */
-
-uint8_t * h3zero_parse_data_stream(uint8_t * bytes, uint8_t * bytes_max,
-    h3zero_data_stream_state_t * stream_state, size_t * available_data, uint16_t * error_found)
+uint8_t * h3zero_varint_from_stream(uint8_t* bytes, uint8_t* bytes_max, uint64_t * result, uint8_t * buffer, size_t* buffer_length)
 {
-    *available_data = 0;
-    *error_found = 0;
+    uint8_t* bp = buffer + *buffer_length;
+    uint8_t* be;
+    int ret = 0;
 
-    if (bytes == NULL || bytes >= bytes_max) {
-        *error_found = H3ZERO_INTERNAL_ERROR;
-        return NULL;
+
+    if (bytes == bytes_max){
+        return bytes; /* continuing */
+    }
+    if (bp == buffer) {
+        *bp++ = *bytes++;
+    }
+    be = buffer + h3zero_varint_skip(buffer);
+
+    while (bytes < bytes_max && bp < be) {
+        *bp++ = *bytes++;
     }
 
-    if (!stream_state->frame_header_parsed) {
-        size_t frame_type_length;
-        size_t frame_header_length;
-
-        if (stream_state->frame_header_read < 1) {
-            stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
+    if (bp >= be) {
+        (void)h3zero_varint_decode(buffer, bp - buffer, result);
+        if ((*buffer_length = bp - be) > 0) {
+            memmove(buffer, be, *buffer_length);
         }
-        frame_type_length = h3zero_varint_skip(stream_state->frame_header);
-
-        while (stream_state->frame_header_read < frame_type_length && bytes < bytes_max) {
-            stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
-        }
-
-        if (stream_state->frame_header_read < frame_type_length) {
-            /* No change in state, wait for more bytes */
-            return bytes;
-        }
-
-        (void)h3zero_varint_decode(stream_state->frame_header, frame_type_length,
-            &stream_state->current_frame_type);
-
-        while (stream_state->frame_header_read < frame_type_length + 1 && bytes < bytes_max) {
-            stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
-        }
-
-        frame_header_length = h3zero_varint_skip(stream_state->frame_header + frame_type_length) + frame_type_length;
-
-        if (frame_header_length > sizeof(stream_state->frame_header)) {
-            *error_found = H3ZERO_INTERNAL_ERROR;
-            return NULL; /* This should never happen! */
-        }
-
-        while (stream_state->frame_header_read < frame_header_length && bytes < bytes_max) {
-            stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
-        }
-
-        if (stream_state->frame_header_read >= frame_header_length) {
-            (void)h3zero_varint_decode(stream_state->frame_header + frame_type_length, frame_header_length - frame_type_length,
-                &stream_state->current_frame_length);
-            stream_state->current_frame_read = 0;
-            stream_state->frame_header_parsed = 1;
-
-            if (stream_state->current_frame_type == h3zero_frame_data) {
-                if (!stream_state->header_found || stream_state->trailer_found || stream_state->is_web_transport) {
-                    /* protocol error */
-                    *error_found = H3ZERO_FRAME_UNEXPECTED;
-                    bytes = NULL;
-                }
-            }
-            else if (stream_state->current_frame_type == h3zero_frame_header) {
-                if (stream_state->header_found && (!stream_state->data_found || stream_state->trailer_found || stream_state->is_web_transport)) {
-                    /* protocol error */
-                    *error_found = H3ZERO_FRAME_UNEXPECTED;
-                    bytes = NULL;
-                }
-                else if (stream_state->current_frame_length > 0x10000) {
-                    /* error, excessive load */
-                    *error_found = H3ZERO_INTERNAL_ERROR;
-                    bytes = NULL;
-                }
-                else {
-                    stream_state->current_frame = (uint8_t *)malloc((size_t)stream_state->current_frame_length);
-                    if (stream_state->current_frame == NULL) {
-                        /* error, internal error */
-                        *error_found = H3ZERO_INTERNAL_ERROR;
-                        bytes = NULL;
-                    }
-                }
-            }
-            else if (stream_state->current_frame_type == h3zero_frame_webtransport_stream) {
-                if (stream_state->header_found) {
-                    /* protocol error */
-                    *error_found = H3ZERO_FRAME_UNEXPECTED;
-                    bytes = NULL;
-                }
-                else {
-                    stream_state->header_found = 1;
-                    stream_state->is_web_transport = 1;
-                    stream_state->control_stream_id = stream_state->current_frame_length;
-                    stream_state->current_frame_length = 0;
-                    stream_state->frame_header_parsed = 1;
-                }
-            }
-            else if (stream_state->current_frame_type == h3zero_frame_cancel_push || 
-                stream_state->current_frame_type == h3zero_frame_goaway ||
-                stream_state->current_frame_type == h3zero_frame_max_push_id) {
-                *error_found = H3ZERO_GENERAL_PROTOCOL_ERROR;
-                bytes = NULL;
-            }
-            else if (stream_state->current_frame_type == h3zero_frame_settings) {
-                *error_found = H3ZERO_FRAME_UNEXPECTED;
-                bytes = NULL;
-            }
-        }
-        return bytes;
+        ret = 1;
     }
-    else {
-        size_t available = bytes_max - bytes;
-        if (stream_state->is_web_transport) {
-            /* Bypass all processing if using web transport */
-            *available_data = (size_t) available;
-        }
-        else {
-            if (stream_state->current_frame_read + available > stream_state->current_frame_length) {
-                available = (size_t)(stream_state->current_frame_length - stream_state->current_frame_read);
-            }
-
-            if (stream_state->current_frame_type == h3zero_frame_header) {
-                memcpy(stream_state->current_frame + stream_state->current_frame_read, bytes, available);
-                stream_state->current_frame_read += available;
-                bytes += available;
-
-                if (stream_state->current_frame_read >= stream_state->current_frame_length) {
-                    uint8_t* parsed;
-                    h3zero_header_parts_t* parts = (stream_state->header_found) ?
-                        &stream_state->trailer : &stream_state->header;
-                    stream_state->trailer_found = stream_state->header_found;
-                    stream_state->header_found = 1;
-                    /* parse */
-                    parsed = h3zero_parse_qpack_header_frame(stream_state->current_frame,
-                        stream_state->current_frame + stream_state->current_frame_length, parts);
-                    if (parsed == NULL || (size_t)(parsed - stream_state->current_frame) != stream_state->current_frame_length) {
-                        /* protocol error */
-                        *error_found = H3ZERO_FRAME_ERROR;
-                        bytes = NULL;
-                    }
-                    /* free resource */
-                    stream_state->frame_header_parsed = 0;
-                    stream_state->frame_header_read = 0;
-                    free(stream_state->current_frame);
-                    stream_state->current_frame = NULL;
-                }
-            }
-            else if (stream_state->current_frame_type == h3zero_frame_data) {
-                *available_data = (size_t)available;
-                stream_state->current_frame_read += available;
-                if (stream_state->current_frame_read >= stream_state->current_frame_length) {
-                    stream_state->frame_header_parsed = 0;
-                    stream_state->frame_header_read = 0;
-                    stream_state->data_found = 1;
-                }
-            }
-            else {
-                /* Unknown frame type, should just be ignored */
-                stream_state->current_frame_read += available;
-                bytes += available;
-                if (stream_state->current_frame_read >= stream_state->current_frame_length) {
-                    stream_state->frame_header_parsed = 0;
-                    stream_state->frame_header_read = 0;
-                }
-            }
-        }
-    }
-
     return bytes;
 }
 

--- a/picohttp/h3zero_common.c
+++ b/picohttp/h3zero_common.c
@@ -129,18 +129,21 @@ h3zero_stream_ctx_t * h3zero_find_or_create_stream(
 		else {
 			memset(stream_ctx, 0, sizeof(h3zero_stream_ctx_t));
 			stream_ctx->stream_id = stream_id;
-			stream_ctx->control_stream_id = UINT64_MAX;
 			stream_ctx->is_h3 = is_h3;
 			stream_ctx->cnx = cnx;
-			if (!IS_BIDIR_STREAM_ID(stream_id)) {
-				if (IS_LOCAL_STREAM_ID(stream_id, picoquic_is_client(cnx))) {
-					stream_ctx->ps.stream_state.is_fin_received = 1;
-				}
-				else {
-					stream_ctx->ps.stream_state.is_fin_sent = 1;
+			if (is_h3) {
+				stream_ctx->ps.stream_state.h3_ctx = ctx;
+				stream_ctx->ps.stream_state.stream_type = UINT64_MAX;
+				stream_ctx->ps.stream_state.control_stream_id = UINT64_MAX;
+				if (!IS_BIDIR_STREAM_ID(stream_id)) {
+					if (IS_LOCAL_STREAM_ID(stream_id, picoquic_is_client(cnx))) {
+						stream_ctx->ps.stream_state.is_fin_received = 1;
+					}
+					else {
+						stream_ctx->ps.stream_state.is_fin_sent = 1;
+					}
 				}
 			}
-			
 			picosplay_insert(&ctx->h3_stream_tree, stream_ctx);
 		}
 	}
@@ -322,92 +325,452 @@ int h3zero_protocol_init(picoquic_cnx_t* cnx)
 	return ret;
 }
 
-/* Parse the first bytes of an unidir stream, and determine what to do with that stream.
+uint8_t* h3zero_load_frame_content(uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_data_stream_state_t* stream_state, uint64_t* error_found)
+{
+	size_t available = bytes_max - bytes;
+
+	if (stream_state->current_frame_length > 0x10000) {
+		/* error, excessive load */
+		*error_found = H3ZERO_INTERNAL_ERROR;
+		return NULL;
+	}
+	else if (stream_state->current_frame == NULL) {
+		stream_state->current_frame = (uint8_t*)malloc((size_t)stream_state->current_frame_length);
+	}
+
+	if (stream_state->current_frame == NULL) {
+		/* error, internal error */
+		*error_found = H3ZERO_INTERNAL_ERROR;
+		return NULL;
+	}
+	if (stream_state->current_frame_read + available > stream_state->current_frame_length) {
+		available = (size_t)(stream_state->current_frame_length - stream_state->current_frame_read);
+	}
+	memcpy(stream_state->current_frame + stream_state->current_frame_read, bytes, available);
+	stream_state->current_frame_read += available;
+	bytes += available;
+
+	return bytes;
+}
+
+uint8_t* h3zero_skip_frame_content(uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_data_stream_state_t* stream_state, uint64_t* error_found)
+{
+	size_t available = bytes_max - bytes;
+
+	if (stream_state->current_frame_read + available > stream_state->current_frame_length) {
+		available = (size_t)(stream_state->current_frame_length - stream_state->current_frame_read);
+	}
+	stream_state->current_frame_read += available;
+	bytes += available;
+
+	return bytes;
+}
+
+/* Parsing a control stream.
+* 
+* This requires:
+*     - read the frame type (bit "is_frame_type_read")
+*     - read the frame length (bit "is_frame_length_known")
+*     - check the the frame type is authorized for the stream.
+*     - if recognized and processed, load the frame content,
+*       then run the specific parser, which performs the specific
+*       actions for the frame.
+*     - else, just skip the content.
+* 
+* The settings frame must be the first on the control stream (property of H3 connection)
+* There should be just one setting frames.
+* 
+* Ending the control stream closes the connection.
+*/
+
+static void h3zero_reset_control_stream_state(h3zero_data_stream_state_t* stream_state)
+{
+	stream_state->current_frame_type = UINT64_MAX;
+	stream_state->current_frame_length = UINT64_MAX;
+	stream_state->current_frame_read = 0;
+	if (stream_state->current_frame != NULL) {
+		free(stream_state->current_frame);
+		stream_state->current_frame = NULL;
+	}
+}
+
+static uint8_t* h3zero_parse_control_stream(uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_data_stream_state_t* stream_state, h3zero_callback_ctx_t* ctx, uint64_t* error_found)
+{
+	while (bytes != NULL && bytes < bytes_max) {
+		/* If frame type not known yet, get it. */
+		if (stream_state->current_frame_type == UINT64_MAX) {
+			bytes = h3zero_varint_from_stream(bytes, bytes_max, &stream_state->current_frame_type, stream_state->frame_header, &stream_state->frame_header_read);
+			if (stream_state->current_frame_type == UINT64_MAX) {
+				/* frame type was not updated */
+				continue;
+			}
+			else {
+				if (ctx->settings.settings_received && stream_state->current_frame_type == h3zero_frame_settings) {
+					*error_found = H3ZERO_FRAME_UNEXPECTED;
+					bytes = NULL;
+					continue;
+				}
+				else if (!ctx->settings.settings_received && stream_state->current_frame_type != h3zero_frame_settings) {
+					*error_found = H3ZERO_MISSING_SETTINGS;
+					bytes = NULL;
+					continue;
+				}
+				/* Check that the type is acceptable, plus mark whether skipped or processed */
+				else if (stream_state->current_frame_type == h3zero_frame_data ||
+					stream_state->current_frame_type == h3zero_frame_header ||
+					stream_state->current_frame_type == h3zero_frame_push_promise ||
+					stream_state->current_frame_type == h3zero_frame_webtransport_stream) {
+					*error_found = H3ZERO_INTERNAL_ERROR;
+					bytes = NULL;
+					continue;
+				}
+				else if (stream_state->current_frame_type != h3zero_frame_settings) {
+					stream_state->is_current_frame_ignored = 1;
+				}
+			}
+		}
+		/* If frame length not known yet, get it. */
+		if (stream_state->current_frame_length == UINT64_MAX) {
+			bytes = h3zero_varint_from_stream(bytes, bytes_max, &stream_state->current_frame_length, stream_state->frame_header, &stream_state->frame_header_read);
+			if (stream_state->current_frame_length == UINT64_MAX) {
+				/* frame length was not updated */
+				return bytes;
+			}
+		}
+		if (stream_state->current_frame_length != UINT64_MAX) {
+			/* Load the frame. May need to allocate memory. */
+			if (stream_state->current_frame_read < stream_state->current_frame_length) {
+				/* Process or skip the frame */
+				if (stream_state->is_current_frame_ignored) {
+					bytes = h3zero_skip_frame_content(bytes, bytes_max, stream_state, error_found);
+				}
+				else {
+					bytes = h3zero_load_frame_content(bytes, bytes_max, stream_state, error_found);
+				}
+			}
+			/* Process the frame if needed, or free it */
+			if (stream_state->current_frame_read >= stream_state->current_frame_length) {
+				if (stream_state->current_frame_type == h3zero_frame_settings) {
+					/* TODO: actually parse the settings */
+					const uint8_t* decoded_last = h3zero_settings_components_decode(stream_state->current_frame,
+						stream_state->current_frame + stream_state->current_frame_length, &ctx->settings);
+					if (decoded_last == NULL) {
+						*error_found = H3ZERO_SETTINGS_ERROR;
+						bytes = NULL;
+					}
+					else {
+						ctx->settings.settings_received = 1;
+					}
+				}
+				h3zero_reset_control_stream_state(stream_state);
+			}
+		}
+	}
+	return bytes;
+}
+
+uint8_t* h3zero_parse_control_stream_id(
+	uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_data_stream_state_t* stream_state,
+	h3zero_stream_ctx_t* stream_ctx,
+	h3zero_callback_ctx_t* ctx,
+	uint64_t * error_found)
+{
+	if (stream_state->control_stream_id == UINT64_MAX) {
+		bytes = h3zero_varint_from_stream(bytes, bytes_max, &stream_state->control_stream_id, stream_state->frame_header, &stream_state->frame_header_read);
+		if (stream_state->current_frame_type == UINT64_MAX) {
+			/* frame type was not updated */
+			return bytes;
+		}
+		/* Just found the control stream ID */
+		h3zero_stream_prefix_t* stream_prefix;
+		stream_prefix = h3zero_find_stream_prefix(ctx, stream_state->control_stream_id);
+		if (stream_prefix == NULL) {
+			bytes = NULL;
+		}
+		else {
+			stream_ctx->path_callback = stream_prefix->function_call;
+			stream_ctx->path_callback_ctx = stream_prefix->function_ctx;
+		}
+	}
+	else {
+		/* header was fully parsed. act as passthrough */
+	}
+	return bytes;
+}
+
+/* The only support for remote bidir stream is for
+ * web transport. We expect the stream to start by a seb transport header:
+ *  - type h3zero_frame_webtransport_stream
+ *  - value control stream id.
  */
+uint8_t* h3zero_parse_remote_bidir_stream(
+	uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_stream_ctx_t* stream_ctx,
+	h3zero_callback_ctx_t* ctx,
+	uint64_t * error_found)
+{
+	h3zero_data_stream_state_t* stream_state = &stream_ctx->ps.stream_state;
+
+	if (stream_state->stream_type == UINT64_MAX) {
+		bytes = h3zero_varint_from_stream(bytes, bytes_max, &stream_state->stream_type, stream_state->frame_header, &stream_state->frame_header_read);
+		if (stream_state->current_frame_type == UINT64_MAX) {
+			/* frame type was not updated */
+			return bytes;
+		}
+	}
+	if (stream_state->stream_type == h3zero_frame_webtransport_stream) {
+		bytes = h3zero_parse_control_stream_id(bytes, bytes_max, stream_state, stream_ctx, ctx, error_found);
+	}
+	else {
+		/* Not and expected stream */
+		bytes = NULL;
+	}
+	return bytes;
+}
+
+uint8_t* h3zero_parse_remote_unidir_stream(
+	uint8_t* bytes, uint8_t* bytes_max,
+	h3zero_stream_ctx_t* stream_ctx,
+	h3zero_callback_ctx_t* ctx,
+	uint64_t * error_found)
+{
+	h3zero_data_stream_state_t* stream_state = &stream_ctx->ps.stream_state;
+
+	if (stream_state->stream_type == UINT64_MAX) {
+		bytes = h3zero_varint_from_stream(bytes, bytes_max, &stream_state->stream_type, stream_state->frame_header, &stream_state->frame_header_read);
+		if (stream_state->current_frame_type == UINT64_MAX) {
+			/* frame type was not updated */
+			return bytes;
+		}
+		if (stream_state->stream_type == h3zero_stream_type_control) {
+			/* TODO: verify that there is just one control stream. */
+			h3zero_reset_control_stream_state(stream_state);
+		}
+	}
+	switch (stream_state->stream_type) {
+	case h3zero_stream_type_control: /* used to send/receive setting frame and other control frames. */
+		bytes = h3zero_parse_control_stream(bytes, bytes_max, stream_state, ctx, error_found);
+		break;
+	case h3zero_stream_type_push: /* Push type not supported in current implementation */
+		bytes = bytes_max;
+		break;
+	case h3zero_stream_type_qpack_encoder: /* not required since not using dynamic table */
+		bytes = bytes_max;
+		break;
+	case h3zero_stream_type_qpack_decoder: /* not required since not using dynamic table */
+		bytes = bytes_max;
+		break;
+	case h3zero_stream_type_webtransport: /* unidir stream is used as specified in web transport */
+		bytes = h3zero_parse_control_stream_id(bytes, bytes_max, stream_state, stream_ctx, ctx, error_found);
+		break;
+	default:
+		/* Per section 6.2 of RFC 9114, unknown stream types are just ignored */
+		bytes = bytes_max;
+		break;
+	}
+	return bytes;
+}
+
+/* Parse the first bytes of a bidir or unidir stream, and determine what to do with that stream.
+*/
 uint8_t* h3zero_parse_incoming_remote_stream(
 	uint8_t* bytes, uint8_t* bytes_max,
 	h3zero_stream_ctx_t* stream_ctx,
 	h3zero_callback_ctx_t* ctx)
 {
-	h3zero_data_stream_state_t* stream_state = &stream_ctx->ps.stream_state;
-	size_t frame_type_length = 0;
+	uint64_t error_found = 0;
+
+	if (IS_BIDIR_STREAM_ID(stream_ctx->stream_id)) {
+		bytes = h3zero_parse_remote_bidir_stream(bytes, bytes_max, stream_ctx, ctx, &error_found);
+	}
+	else {
+		bytes = h3zero_parse_remote_unidir_stream(bytes, bytes_max, stream_ctx, ctx, &error_found);
+	}
+	return bytes;
+}
+
+/* Parsing of a data stream. This is implemented as a filter, with a set of states:
+* 
+* - Reading frame length: obtaining the length and type of the next frame.
+* - Reading header frame: obtaining the bytes of the header frame.
+*   When all bytes are obtained, the header is parsed and the header
+*   structure is documented. State moves back to initial, with header-read
+*   flag set. Having two frame headers before a data frame is a bug.
+* - Reading unknown frame: unknown frames can happen at any point in
+*   the stream, and should just be ignored.
+* - Reading data frame: the frame header indicated a data frame of
+*   length N. Treat the following N bytes as data.
+*/
+
+uint8_t * h3zero_parse_data_stream(uint8_t * bytes, uint8_t * bytes_max,
+	h3zero_data_stream_state_t * stream_state, size_t * available_data, uint64_t * error_found)
+{
+	*available_data = 0;
+	*error_found = 0;
+
+	if (bytes == NULL || bytes >= bytes_max) {
+		*error_found = H3ZERO_INTERNAL_ERROR;
+		return NULL;
+	}
 
 	if (!stream_state->frame_header_parsed) {
+		size_t frame_type_length;
+		size_t frame_header_length;
+
 		if (stream_state->frame_header_read < 1) {
 			stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
 		}
-		frame_type_length = VARINT_LEN_T(stream_state->frame_header, size_t);
+		frame_type_length = h3zero_varint_skip(stream_state->frame_header);
+
 		while (stream_state->frame_header_read < frame_type_length && bytes < bytes_max) {
 			stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
 		}
-		if (stream_state->frame_header_read >= frame_type_length) {
-			int is_wt_context_id_required = 0;
 
-			(void)picoquic_frames_varint_decode(stream_state->frame_header, stream_state->frame_header + frame_type_length,
-				&stream_state->current_frame_type);
+		if (stream_state->frame_header_read < frame_type_length) {
+			/* No change in state, wait for more bytes */
+			return bytes;
+		}
 
-			if (IS_BIDIR_STREAM_ID(stream_ctx->stream_id)) {
-				switch (stream_state->current_frame_type) {
-				case h3zero_frame_webtransport_stream:
-					is_wt_context_id_required = 1;
-					break;
-				default:
+		(void)h3zero_varint_decode(stream_state->frame_header, frame_type_length,
+			&stream_state->current_frame_type);
+
+		while (stream_state->frame_header_read < frame_type_length + 1 && bytes < bytes_max) {
+			stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
+		}
+
+		frame_header_length = h3zero_varint_skip(stream_state->frame_header + frame_type_length) + frame_type_length;
+
+		if (frame_header_length > sizeof(stream_state->frame_header)) {
+			*error_found = H3ZERO_INTERNAL_ERROR;
+			return NULL; /* This should never happen! */
+		}
+
+		while (stream_state->frame_header_read < frame_header_length && bytes < bytes_max) {
+			stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
+		}
+
+		if (stream_state->frame_header_read >= frame_header_length) {
+			(void)h3zero_varint_decode(stream_state->frame_header + frame_type_length, frame_header_length - frame_type_length,
+				&stream_state->current_frame_length);
+			stream_state->current_frame_read = 0;
+			stream_state->frame_header_parsed = 1;
+
+			if (stream_state->current_frame_type == h3zero_frame_data) {
+				if (!stream_state->header_found || stream_state->trailer_found || stream_state->is_web_transport) {
+					/* protocol error */
+					*error_found = H3ZERO_FRAME_UNEXPECTED;
 					bytes = NULL;
-					break;
+				}
+			}
+			else if (stream_state->current_frame_type == h3zero_frame_header) {
+				if (stream_state->header_found && (!stream_state->data_found || stream_state->trailer_found || stream_state->is_web_transport)) {
+					/* protocol error */
+					*error_found = H3ZERO_FRAME_UNEXPECTED;
+					bytes = NULL;
+				}
+				else if (stream_state->current_frame_length > 0x10000) {
+					/* error, excessive load */
+					*error_found = H3ZERO_INTERNAL_ERROR;
+					bytes = NULL;
+				}
+				else {
+					stream_state->current_frame = (uint8_t *)malloc((size_t)stream_state->current_frame_length);
+					if (stream_state->current_frame == NULL) {
+						/* error, internal error */
+						*error_found = H3ZERO_INTERNAL_ERROR;
+						bytes = NULL;
+					}
+				}
+			}
+			else if (stream_state->current_frame_type == h3zero_frame_webtransport_stream) {
+				if (stream_state->header_found) {
+					/* protocol error */
+					*error_found = H3ZERO_FRAME_UNEXPECTED;
+					bytes = NULL;
+				}
+				else {
+					stream_state->header_found = 1;
+					stream_state->is_web_transport = 1;
+					stream_state->control_stream_id = stream_state->current_frame_length;
+					stream_state->current_frame_length = 0;
+					stream_state->frame_header_parsed = 1;
+				}
+			}
+			else if (stream_state->current_frame_type == h3zero_frame_cancel_push || 
+				stream_state->current_frame_type == h3zero_frame_goaway ||
+				stream_state->current_frame_type == h3zero_frame_max_push_id) {
+				*error_found = H3ZERO_GENERAL_PROTOCOL_ERROR;
+				bytes = NULL;
+			}
+			else if (stream_state->current_frame_type == h3zero_frame_settings) {
+				*error_found = H3ZERO_FRAME_UNEXPECTED;
+				bytes = NULL;
+			}
+		}
+		return bytes;
+	}
+	else {
+		size_t available = bytes_max - bytes;
+		if (stream_state->is_web_transport) {
+			/* Bypass all processing if using web transport */
+			*available_data = (size_t) available;
+		}
+		else {
+			if (stream_state->current_frame_read + available > stream_state->current_frame_length) {
+				available = (size_t)(stream_state->current_frame_length - stream_state->current_frame_read);
+			}
+
+			if (stream_state->current_frame_type == h3zero_frame_header) {
+				memcpy(stream_state->current_frame + stream_state->current_frame_read, bytes, available);
+				stream_state->current_frame_read += available;
+				bytes += available;
+
+				if (stream_state->current_frame_read >= stream_state->current_frame_length) {
+					uint8_t* parsed;
+					h3zero_header_parts_t* parts = (stream_state->header_found) ?
+						&stream_state->trailer : &stream_state->header;
+					stream_state->trailer_found = stream_state->header_found;
+					stream_state->header_found = 1;
+					/* parse */
+					parsed = h3zero_parse_qpack_header_frame(stream_state->current_frame,
+						stream_state->current_frame + stream_state->current_frame_length, parts);
+					if (parsed == NULL || (size_t)(parsed - stream_state->current_frame) != stream_state->current_frame_length) {
+						/* protocol error */
+						*error_found = H3ZERO_FRAME_ERROR;
+						bytes = NULL;
+					}
+					/* free resource */
+					stream_state->frame_header_parsed = 0;
+					stream_state->frame_header_read = 0;
+					free(stream_state->current_frame);
+					stream_state->current_frame = NULL;
+				}
+			}
+			else if (stream_state->current_frame_type == h3zero_frame_data) {
+				*available_data = (size_t)available;
+				stream_state->current_frame_read += available;
+				if (stream_state->current_frame_read >= stream_state->current_frame_length) {
+					stream_state->frame_header_parsed = 0;
+					stream_state->frame_header_read = 0;
+					stream_state->data_found = 1;
 				}
 			}
 			else {
-				switch (stream_state->current_frame_type) {
-				case h3zero_stream_type_control: /* used to send/receive setting frame and other control frames. Ignored for now. */
-					break;
-				case h3zero_stream_type_push: /* Push type not supported in h3zero settings */
-					bytes = NULL;
-					break;
-				case h3zero_stream_type_qpack_encoder: /* not required since not using dynamic table */
-					break;
-				case h3zero_stream_type_qpack_decoder: /* not required since not using dynamic table */
-					break;
-				case h3zero_stream_type_webtransport: /* unidir stream is used as specified in web transport */
-					is_wt_context_id_required = 1;
-					break;
-				default:
-					/* Per section 6.2 of RFC 9114, unknown stream types are just ignored */
-					break;
-				}
-			}
-
-			if (bytes != NULL) {
-				if (!is_wt_context_id_required) {
-					stream_state->frame_header_parsed = 1;
-				}
-				else {
-					size_t context_id_length = 1;
-					while (stream_state->frame_header_read < frame_type_length + 1 && bytes < bytes_max) {
-						stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
-					}
-					context_id_length = VARINT_LEN_T((stream_state->frame_header + frame_type_length), size_t);
-					while (stream_state->frame_header_read < frame_type_length + context_id_length && bytes < bytes_max) {
-						stream_state->frame_header[stream_state->frame_header_read++] = *bytes++;
-					}
-					if (stream_state->frame_header_read >= frame_type_length + context_id_length) {
-						h3zero_stream_prefix_t* stream_prefix;
-
-						(void)picoquic_frames_varint_decode(stream_state->frame_header + frame_type_length,
-							stream_state->frame_header + frame_type_length + context_id_length, &stream_ctx->control_stream_id);
-						stream_prefix = h3zero_find_stream_prefix(ctx, stream_ctx->control_stream_id);
-						if (stream_prefix == NULL) {
-							bytes = NULL;
-						}
-						else {
-							stream_ctx->path_callback = stream_prefix->function_call;
-							stream_ctx->path_callback_ctx = stream_prefix->function_ctx;
-						}
-						stream_state->frame_header_parsed = 1;
-					}
+				/* Unknown frame type, should just be ignored */
+				stream_state->current_frame_read += available;
+				bytes += available;
+				if (stream_state->current_frame_read >= stream_state->current_frame_length) {
+					stream_state->frame_header_parsed = 0;
+					stream_state->frame_header_read = 0;
 				}
 			}
 		}
 	}
+
 	return bytes;
 }
 
@@ -476,23 +839,27 @@ int h3zero_process_remote_stream(picoquic_cnx_t* cnx,
 	h3zero_callback_ctx_t* ctx)
 {
 	int ret = 0;
+	uint64_t error_found = 0;
 
-	if (stream_ctx == NULL) {
-		stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1, 1);
-		picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
-	}
 	if (stream_ctx == NULL) {
 		ret = -1;
 	}
 	else {
 		uint8_t* bytes_max = bytes + length;
 
-		bytes = h3zero_parse_incoming_remote_stream(bytes, bytes_max, stream_ctx, ctx);
-		if (bytes == NULL) {
-			picoquic_log_app_message(cnx, "Cannot parse incoming stream: %"PRIu64, stream_id);
-			ret = -1;
+		if (IS_BIDIR_STREAM_ID(stream_id)) {
+			bytes = h3zero_parse_remote_bidir_stream(bytes, bytes_max, stream_ctx, ctx, &error_found);
 		}
 		else {
+			bytes = h3zero_parse_remote_unidir_stream(bytes, bytes_max, stream_ctx, ctx, &error_found);
+		}
+
+		if (bytes == NULL) {
+			picoquic_log_app_message(cnx, "Cannot parse incoming stream: %" PRIu64", error: %" PRIu64,
+				stream_id, error_found);
+			ret = picoquic_stop_sending(cnx, stream_id, error_found);
+		}
+		else if (bytes < bytes_max || fin_or_event == picoquic_callback_stream_fin) {
 			ret = h3zero_post_data_or_fin(cnx, bytes, bytes_max - bytes, fin_or_event, stream_ctx);
 		}
 	}
@@ -642,7 +1009,7 @@ int h3zero_process_request_frame(
 				/* No such connect path */
 				char log_text[256];
 				picoquic_log_app_message(cnx, "cannot find path context on stream: %"PRIu64 ", path:%s", stream_ctx->stream_id,
-					picoquic_uint8_to_str(log_text, 256, stream_ctx->ps.hq.path, stream_ctx->ps.hq.path_length));
+					picoquic_uint8_to_str(log_text, 256, stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length));
 				o_bytes = h3zero_create_not_found_header_frame(o_bytes, o_bytes_max);
 			}
 		}
@@ -723,137 +1090,6 @@ int h3zero_process_request_frame(
 	return ret;
 }
 
-int h3zero_callback_server_data(
-	picoquic_cnx_t* cnx, h3zero_stream_ctx_t * stream_ctx,
-	uint64_t stream_id, uint8_t* bytes, size_t length,
-	picoquic_call_back_event_t fin_or_event,
-	h3zero_callback_ctx_t* ctx)
-{
-	int ret = 0;
-	int process_complete = 0;
-	size_t available_data = 0;
-
-	/* Find whether this is bidir or unidir stream */
-	if (IS_BIDIR_STREAM_ID(stream_id)) {
-		/* If client bidir stream, absorb data until end, then
-		* parse the header */
-		/* TODO: add an exception for bidir streams set by Webtransport */
-		if (!IS_CLIENT_STREAM_ID(stream_id)) {
-			/* This is the client writing back on a server created stream.
-			* Call to selected callback, or ignore */
-			ret = h3zero_post_data_or_fin(cnx, bytes, length, fin_or_event, stream_ctx);
-		}
-		else {
-			/* Find or create stream context */
-			if (stream_ctx == NULL) {
-				stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1, 1);
-			}
-
-			if (stream_ctx == NULL) {
-				ret = picoquic_stop_sending(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
-
-				if (ret == 0) {
-					ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
-				}
-			}
-			else {
-				/* TODO: move this to common code with unidir, after parsing beginning of unidir? */
-				uint16_t error_found = 0;
-				uint8_t * bytes_max = bytes + length;
-				while (bytes < bytes_max) {
-					bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->ps.stream_state, &available_data, &error_found);
-					if (bytes == NULL) {
-						ret = picoquic_close(cnx, error_found);
-						break;
-					}
-					else if (available_data > 0) {
-						if (stream_ctx->ps.stream_state.is_web_transport) {
-							if (stream_ctx->path_callback == NULL) {
-								h3zero_stream_prefix_t* stream_prefix;
-								stream_prefix = h3zero_find_stream_prefix(ctx, stream_ctx->ps.stream_state.control_stream_id);
-								if (stream_prefix == NULL) {
-									ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_WEBTRANSPORT_BUFFERED_STREAM_REJECTED);
-								}
-								else {
-									stream_ctx->path_callback = stream_prefix->function_call;
-									stream_ctx->path_callback_ctx = stream_prefix->function_ctx;
-									stream_ctx->control_stream_id = stream_ctx->ps.stream_state.control_stream_id;
-									(void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
-								}
-							}
-						} else if (stream_ctx->ps.stream_state.header_found && stream_ctx->post_received == 0) {
-							int path_item = h3zero_find_path_item(stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, ctx->path_table, ctx->path_table_nb);
-							if (path_item >= 0) {
-								stream_ctx->path_callback = ctx->path_table[path_item].path_callback;
-								stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post,
-									stream_ctx, ctx->path_table[path_item].path_app_ctx);
-							}
-							(void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
-						}
-
-						/* Received data for a POST or CONNECT command. */
-						if (stream_ctx->path_callback != NULL) {
-							/* if known URL, pass the data to URL specific callback.
-							* Little oddity there. For the 'connect" method, we need to pass the data and the FIN mark.
-							* For the "post" method, the "fin" call is supposed to come from within the
-							* `h3zero_process_request_frame` call, and return the size of the post response.
-							* 
-							* The web transport callbacks may result in the stream context being deleted. That
-							* means we really should not reuse the pointer "stream_ctx" after that. But the "post"
-							* usage relies on the stack maintaining a "post_received" variable, so we need
-							* to handle that. The "process complete" flag is used to bypass the processing of
-							* the FIN bit in the following code block, because the FIN bit is already handled in this call.
-							*/
-							int is_post = stream_ctx->ps.stream_state.header.method == h3zero_method_post;
-
-							ret = stream_ctx->path_callback(cnx, bytes, available_data,
-								(fin_or_event == picoquic_callback_stream_fin && !is_post)?
-								picohttp_callback_post_fin:picohttp_callback_post_data, stream_ctx, stream_ctx->path_callback_ctx);
-							if (is_post) {
-								stream_ctx->post_received += available_data;
-							}
-							else {
-								process_complete = 1;
-							}
-						}
-						else {
-							stream_ctx->post_received += available_data;
-						}
-						bytes += available_data;
-					}
-				}
-				/* Process the header if necessary */
-				if (ret == 0 && !process_complete) {
-					if (stream_ctx->ps.stream_state.is_web_transport) {
-						if (fin_or_event == picoquic_callback_stream_fin && available_data == 0 && stream_ctx->path_callback != NULL) {
-							ret = stream_ctx->path_callback(cnx, NULL, 0, picohttp_callback_post_fin, stream_ctx, stream_ctx->path_callback_ctx);
-						}
-					} else {
-						if (fin_or_event == picoquic_callback_stream_fin || stream_ctx->ps.stream_state.header.method == h3zero_method_connect) {
-							/* Process the request header. */
-							if (stream_ctx->ps.stream_state.header_found) {
-								ret = h3zero_process_request_frame(cnx, stream_ctx, ctx);
-							}
-							else {
-								/* Unexpected end of stream before the header is received */
-								ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_FRAME_ERROR);
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-	else {
-		/* process the unidir streams. */
-		ret = h3zero_process_remote_stream(cnx, stream_id, bytes, length,
-			fin_or_event, stream_ctx, ctx);
-	}
-
-	return ret;
-}
-
-
 int h3zero_client_open_stream_file(picoquic_cnx_t* cnx, h3zero_callback_ctx_t* ctx, h3zero_stream_ctx_t* stream_ctx)
 {
 	int ret = 0;
@@ -899,109 +1135,262 @@ int h3zero_client_close_stream(picoquic_cnx_t * cnx,
 	return ret;
 }
 
-
-int h3zero_callback_client_data(picoquic_cnx_t* cnx,
+int h3zero_process_h3_server_data(picoquic_cnx_t* cnx,
 	uint64_t stream_id, uint8_t* bytes, size_t length,
-	picoquic_call_back_event_t fin_or_event, h3zero_callback_ctx_t* ctx, 
-	h3zero_stream_ctx_t* stream_ctx, uint64_t * fin_stream_id)
+	picoquic_call_back_event_t fin_or_event, h3zero_callback_ctx_t* ctx,
+	h3zero_stream_ctx_t* stream_ctx, uint64_t* fin_stream_id)
 {
 	int ret = 0;
+	int process_complete = 0;
+	size_t available_data = 0;
+	uint64_t error_found = 0;
+	uint8_t* bytes_max = bytes + length;
 
-	/* Data arrival on stream #x, maybe with fin mark */
-	if (stream_ctx == NULL) {
-		stream_ctx = h3zero_find_stream(ctx, stream_id);
-	}
-	if (IS_BIDIR_STREAM_ID(stream_id) && IS_LOCAL_STREAM_ID(stream_id, 1)) {
-		if (stream_ctx == NULL) {
-			fprintf(stdout, "unexpected data on local stream context: %" PRIu64 ".\n", stream_id);
-			ret = -1;
+	while (bytes < bytes_max) {
+		bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->ps.stream_state, &available_data, &error_found);
+		if (bytes == NULL) {
+			ret = picoquic_close(cnx, error_found);
+			break;
 		}
-		else if (stream_ctx->is_open) {
-			if (!stream_ctx->is_file_open && ctx->no_disk == 0 && stream_ctx->file_path != NULL) {
-				ret = h3zero_client_open_stream_file(cnx, ctx, stream_ctx);
-			}
-			if (ret == 0 && length > 0) {
-				uint16_t error_found = 0;
-				size_t available_data = 0;
-				uint8_t* bytes_max = bytes + length;
-				int header_required = !stream_ctx->ps.stream_state.header_found;
-				while (bytes < bytes_max) {
-					bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->ps.stream_state, &available_data, &error_found);
-					if (bytes == NULL) {
-						ret = picoquic_close(cnx, error_found);
-						if (ret != 0) {
-							picoquic_log_app_message(cnx,
-								"Could not parse incoming data from stream %" PRIu64 ", error 0x%x", stream_id, error_found);
-						}
-						break;
+		else if (available_data > 0) {
+			if (stream_ctx->ps.stream_state.is_web_transport) {
+				if (stream_ctx->path_callback == NULL) {
+					h3zero_stream_prefix_t* stream_prefix;
+					stream_prefix = h3zero_find_stream_prefix(ctx, stream_ctx->ps.stream_state.control_stream_id);
+					if (stream_prefix == NULL) {
+						ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_WEBTRANSPORT_BUFFERED_STREAM_REJECTED);
 					}
 					else {
-						if (header_required && stream_ctx->ps.stream_state.header_found && picoquic_is_client(cnx)) {
-							int is_success = (stream_ctx->ps.stream_state.header.status >= 200 &&
-								stream_ctx->ps.stream_state.header.status < 300);
-							if (stream_ctx->ps.stream_state.is_upgrade_requested) {
-								stream_ctx->is_upgraded = is_success;
-							}
-							if (stream_ctx->path_callback != NULL) {
-								stream_ctx->path_callback(cnx, NULL, 0, (is_success) ?
-									picohttp_callback_connect_accepted : picohttp_callback_connect_refused, 
-									stream_ctx, stream_ctx->path_callback_ctx);
-							}
-						}
-						if (available_data > 0) {
-							if (!stream_ctx->flow_opened) {
-								if (stream_ctx->ps.stream_state.current_frame_length < 0x100000) {
-									stream_ctx->flow_opened = 1;
-								}
-								else if (cnx->cnx_state == picoquic_state_ready) {
-									stream_ctx->flow_opened = 1;
-									ret = picoquic_open_flow_control(cnx, stream_id, stream_ctx->ps.stream_state.current_frame_length);
-								}
-							}
-							if (ret == 0 && ctx->no_disk == 0) {
-								ret = (fwrite(bytes, 1, available_data, stream_ctx->F) > 0) ? 0 : -1;
-								if (ret != 0) {
-									picoquic_log_app_message(cnx,
-										"Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
-								}
-							}
-							stream_ctx->received_length += available_data;
-							bytes += available_data;
-						}
+						stream_ctx->path_callback = stream_prefix->function_call;
+						stream_ctx->path_callback_ctx = stream_prefix->function_ctx;
+						(void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
 					}
 				}
 			}
+			else if (stream_ctx->ps.stream_state.header_found && stream_ctx->post_received == 0) {
+				int path_item = h3zero_find_path_item(stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, ctx->path_table, ctx->path_table_nb);
+				if (path_item >= 0) {
+					stream_ctx->path_callback = ctx->path_table[path_item].path_callback;
+					stream_ctx->path_callback(cnx, (uint8_t*)stream_ctx->ps.stream_state.header.path, stream_ctx->ps.stream_state.header.path_length, picohttp_callback_post,
+						stream_ctx, ctx->path_table[path_item].path_app_ctx);
+				}
+				(void)picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
+			}
 
-			if (fin_or_event == picoquic_callback_stream_fin) {
-				if (stream_ctx->path_callback != NULL) {
-					stream_ctx->path_callback(cnx, NULL, 0, picohttp_callback_post_fin, stream_ctx, stream_ctx->path_callback_ctx);
+			/* Received data for a POST or CONNECT command. */
+			if (stream_ctx->path_callback != NULL) {
+				/* if known URL, pass the data to URL specific callback.
+				* Little oddity there. For the 'connect" method, we need to pass the data and the FIN mark.
+				* For the "post" method, the "fin" call is supposed to come from within the
+				* `h3zero_process_request_frame` call, and return the size of the post response.
+				*
+				* The web transport callbacks may result in the stream context being deleted. That
+				* means we really should not reuse the pointer "stream_ctx" after that. But the "post"
+				* usage relies on the stack maintaining a "post_received" variable, so we need
+				* to handle that. The "process complete" flag is used to bypass the processing of
+				* the FIN bit in the following code block, because the FIN bit is already handled in this call.
+				*/
+				int is_post = stream_ctx->ps.stream_state.header.method == h3zero_method_post;
+
+				ret = stream_ctx->path_callback(cnx, bytes, available_data,
+					(fin_or_event == picoquic_callback_stream_fin && !is_post) ?
+					picohttp_callback_post_fin : picohttp_callback_post_data, stream_ctx, stream_ctx->path_callback_ctx);
+				if (is_post) {
+					stream_ctx->post_received += available_data;
 				}
 				else {
-					if (h3zero_client_close_stream(cnx, ctx, stream_ctx)) {
-						*fin_stream_id = stream_id;
-						if (stream_id <= 64 && !ctx->no_print) {
-							fprintf(stdout, "Stream %" PRIu64 " ended after %" PRIu64 " bytes\n",
-								stream_id, stream_ctx->received_length);
-						}
-						if (stream_ctx->received_length == 0) {
-							picoquic_log_app_message(cnx, "Stream %" PRIu64 " ended after %" PRIu64 " bytes, ret=0x%x",
-								stream_id, stream_ctx->received_length, ret);
-						}
-					}
+					process_complete = 1;
 				}
+			}
+			else {
+				stream_ctx->post_received += available_data;
+			}
+			bytes += available_data;
+		}
+	}
+	/* Process the header if necessary */
+	if (ret == 0 && !process_complete) {
+		if (stream_ctx->ps.stream_state.is_web_transport) {
+			if (fin_or_event == picoquic_callback_stream_fin && available_data == 0 && stream_ctx->path_callback != NULL) {
+				ret = stream_ctx->path_callback(cnx, NULL, 0, picohttp_callback_post_fin, stream_ctx, stream_ctx->path_callback_ctx);
 			}
 		}
 		else {
-			ret = h3zero_post_data_or_fin(cnx, bytes, length, fin_or_event, stream_ctx);
+			if (fin_or_event == picoquic_callback_stream_fin || stream_ctx->ps.stream_state.header.method == h3zero_method_connect) {
+				/* Process the request header. */
+				if (stream_ctx->ps.stream_state.header_found) {
+					ret = h3zero_process_request_frame(cnx, stream_ctx, ctx);
+				}
+				else {
+					/* Unexpected end of stream before the header is received */
+					ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_FRAME_ERROR);
+				}
+			}
 		}
 	}
-	else {
-		ret = h3zero_process_remote_stream(cnx, stream_id, bytes, length,
-			fin_or_event, stream_ctx, ctx);
+	return ret;
+}
+
+int h3zero_process_h3_client_data(picoquic_cnx_t* cnx,
+	uint64_t stream_id, uint8_t* bytes, size_t length,
+	picoquic_call_back_event_t fin_or_event, h3zero_callback_ctx_t* ctx,
+	h3zero_stream_ctx_t* stream_ctx, uint64_t* fin_stream_id)
+{
+	int ret = 0;
+	if (!stream_ctx->is_file_open && ctx->no_disk == 0 && stream_ctx->file_path != NULL) {
+		ret = h3zero_client_open_stream_file(cnx, ctx, stream_ctx);
+	}
+	if (ret == 0 && length > 0) {
+		uint64_t error_found = 0;
+		size_t available_data = 0;
+		uint8_t* bytes_max = bytes + length;
+		int header_required = !stream_ctx->ps.stream_state.header_found;
+		while (bytes < bytes_max) {
+			bytes = h3zero_parse_data_stream(bytes, bytes_max, &stream_ctx->ps.stream_state, &available_data, &error_found);
+			if (bytes == NULL) {
+				ret = picoquic_close(cnx, error_found);
+				if (ret != 0) {
+					picoquic_log_app_message(cnx,
+						"Could not parse incoming data from stream %" PRIu64 ", error 0x%x", stream_id, error_found);
+				}
+				break;
+			}
+			else {
+				if (header_required && stream_ctx->ps.stream_state.header_found && picoquic_is_client(cnx)) {
+					int is_success = (stream_ctx->ps.stream_state.header.status >= 200 &&
+						stream_ctx->ps.stream_state.header.status < 300);
+					if (stream_ctx->ps.stream_state.is_upgrade_requested) {
+						stream_ctx->is_upgraded = is_success;
+					}
+					if (stream_ctx->path_callback != NULL) {
+						stream_ctx->path_callback(cnx, NULL, 0, (is_success) ?
+							picohttp_callback_connect_accepted : picohttp_callback_connect_refused,
+							stream_ctx, stream_ctx->path_callback_ctx);
+					}
+				}
+				if (available_data > 0) {
+					if (!stream_ctx->flow_opened) {
+						if (stream_ctx->ps.stream_state.current_frame_length < 0x100000) {
+							stream_ctx->flow_opened = 1;
+						}
+						else if (cnx->cnx_state == picoquic_state_ready) {
+							stream_ctx->flow_opened = 1;
+							ret = picoquic_open_flow_control(cnx, stream_id, stream_ctx->ps.stream_state.current_frame_length);
+						}
+					}
+					if (ret == 0 && ctx->no_disk == 0) {
+						ret = (fwrite(bytes, 1, available_data, stream_ctx->F) > 0) ? 0 : -1;
+						if (ret != 0) {
+							picoquic_log_app_message(cnx,
+								"Could not write data from stream %" PRIu64 ", error 0x%x", stream_id, ret);
+						}
+					}
+					stream_ctx->received_length += available_data;
+					bytes += available_data;
+				}
+			}
+		}
+	}
+
+	if (fin_or_event == picoquic_callback_stream_fin) {
+		if (stream_ctx->path_callback != NULL) {
+			stream_ctx->path_callback(cnx, NULL, 0, picohttp_callback_post_fin, stream_ctx, stream_ctx->path_callback_ctx);
+		}
+		else {
+			if (h3zero_client_close_stream(cnx, ctx, stream_ctx)) {
+				*fin_stream_id = stream_id;
+				if (stream_id <= 64 && !ctx->no_print) {
+					fprintf(stdout, "Stream %" PRIu64 " ended after %" PRIu64 " bytes\n",
+						stream_id, stream_ctx->received_length);
+				}
+				if (stream_ctx->received_length == 0) {
+					picoquic_log_app_message(cnx, "Stream %" PRIu64 " ended after %" PRIu64 " bytes, ret=0x%x",
+						stream_id, stream_ctx->received_length, ret);
+				}
+			}
+		}
 	}
 
 	return ret;
 }
+
+int h3zero_callback_data(picoquic_cnx_t* cnx,
+	uint64_t stream_id, uint8_t* bytes, size_t length,
+	picoquic_call_back_event_t fin_or_event, h3zero_callback_ctx_t* ctx,
+	h3zero_stream_ctx_t* stream_ctx, uint64_t* fin_stream_id)
+{
+
+	int ret = 0;
+
+	/* Data arrival on stream #x, maybe with fin mark */
+	if (stream_ctx == NULL) {
+		/* If the stream is not found, we have different treatments based on direction:
+		*   - Local stream must always be created locally, thus need to be present before
+		*     data arrives.
+		*   - For remote streams, we create a context upon arrival.
+		*/
+		if (IS_LOCAL_STREAM_ID(stream_id, cnx->client_mode)) {
+			stream_ctx = h3zero_find_stream(ctx, stream_id);
+		}
+		else {
+			stream_ctx = h3zero_find_or_create_stream(cnx, stream_id, ctx, 1, 1);
+		}
+		if (stream_ctx == NULL) {
+			ret = picoquic_stop_sending(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
+
+			if (ret == 0 && IS_BIDIR_STREAM_ID(stream_id)) {
+				ret = picoquic_reset_stream(cnx, stream_id, H3ZERO_INTERNAL_ERROR);
+			}
+			ret = -1;
+		}
+		else {
+			picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx);
+		}
+	}
+	if (ret == 0) {
+		if (stream_ctx->is_upgraded) {
+			ret = h3zero_post_data_or_fin(cnx, bytes, length, fin_or_event, stream_ctx);
+		}
+		else if (IS_BIDIR_STREAM_ID(stream_id)) {
+			if (IS_CLIENT_STREAM_ID(stream_id)) {
+				/* If nothing is known about the stream, it is treated by default as an H3 stream
+				 */
+				if (stream_ctx == NULL) {
+					fprintf(stdout, "unexpected data on local stream context: %" PRIu64 ".\n", stream_id);
+					ret = -1;
+				}
+				else if (cnx->client_mode) {
+					if (stream_ctx->is_open) {
+						/* Process incoming H3 client data */
+						ret = h3zero_process_h3_client_data(cnx, stream_id, bytes, length, fin_or_event, ctx,
+							stream_ctx, fin_stream_id);
+					}
+					else {
+						/* Perform application callback */
+						ret = h3zero_post_data_or_fin(cnx, bytes, length, fin_or_event, stream_ctx);
+					}
+				}
+				else {
+					/* Process incoming H3 server data */
+					ret = h3zero_process_h3_server_data(cnx, stream_id, bytes, length, fin_or_event, ctx,
+						stream_ctx, fin_stream_id);
+				}
+			}
+			else {
+				/* Non client streams are only expected if using web transport
+				 */
+				ret = h3zero_process_remote_stream(cnx, stream_id, bytes, length,
+					fin_or_event, stream_ctx, ctx);
+			}
+		}
+		else {
+			ret = h3zero_process_remote_stream(cnx, stream_id, bytes, length,
+				fin_or_event, stream_ctx, ctx);
+		}
+	}
+	return ret;
+}
+
 
 /* Prepare to send. This is the same code as on the client side, except for the
 * delayed opening of the data file */
@@ -1313,18 +1702,8 @@ int h3zero_callback(picoquic_cnx_t* cnx,
 		case picoquic_callback_stream_data:
 		case picoquic_callback_stream_fin:
 			/* Data arrival on stream #x, maybe with fin mark */
-			if (stream_ctx != NULL && stream_ctx->is_upgraded) {
-				ret = h3zero_post_data_or_fin(cnx, bytes, length, fin_or_event, stream_ctx);
-			}
-			else {
-				if (picoquic_is_client(cnx)) {
-					ret = h3zero_callback_client_data(cnx, stream_id, bytes, length,
-						fin_or_event, ctx, stream_ctx, &fin_stream_id);
-				}
-				else {
-					ret = h3zero_callback_server_data(cnx, stream_ctx, stream_id, bytes, length, fin_or_event, ctx);
-				}
-			}
+			ret = h3zero_callback_data(cnx, stream_id, bytes, length,
+				fin_or_event, ctx, stream_ctx, &fin_stream_id);
 			break;
 		case picoquic_callback_stream_reset: /* Peer reset stream #x */
 		case picoquic_callback_stop_sending: /* Peer asks server to reset stream #x */
@@ -1335,7 +1714,7 @@ int h3zero_callback(picoquic_cnx_t* cnx,
 			if (stream_ctx != NULL) {
 				/* reset post callback. */
 				if (stream_ctx->path_callback != NULL) {
-					ret = stream_ctx->path_callback(NULL, NULL, 0, picohttp_callback_reset, stream_ctx, stream_ctx->path_callback_ctx);
+					ret = stream_ctx->path_callback(cnx, NULL, 0, picohttp_callback_reset, stream_ctx, stream_ctx->path_callback_ctx);
 				}
 
 			    /* If a file is open on a client, close and do the accounting. */
@@ -1462,6 +1841,37 @@ uint8_t* h3zero_settings_encode(uint8_t* bytes, const uint8_t* bytes_max, const 
 	return bytes;
 }
 
+const uint8_t* h3zero_settings_components_decode(const uint8_t* bytes, const uint8_t* bytes_max, h3zero_settings_t* settings)
+{
+	uint64_t component_key;
+	uint64_t component_value;
+	while (bytes != NULL &&
+		bytes < bytes_max &&
+		(bytes = picoquic_frames_varint_decode(bytes, bytes_max, &component_key)) != NULL &&
+		(bytes = picoquic_frames_varint_decode(bytes, bytes_max, &component_value)) != NULL) {
+		switch (component_key) {
+		case h3zero_setting_header_table_size:
+			settings->table_size = component_value;
+			break;
+		case h3zero_qpack_blocked_streams:
+			settings->blocked_streams = component_value;
+			break;
+		case h3zero_settings_enable_connect_protocol:
+			settings->enable_connect_protocol = (unsigned int)component_value;
+			break;
+		case h3zero_setting_h3_datagram:
+			settings->h3_datagram = (unsigned int)component_value;
+			break;
+		case h3zero_settings_webtransport_max_sessions:
+			settings->webtransport_max_sessions = component_value;
+			break;
+		default:
+			break;
+		}
+	}
+	return bytes;
+}
+
 const uint8_t* h3zero_settings_decode(const uint8_t* bytes, const uint8_t* bytes_max, h3zero_settings_t* settings)
 {
 	size_t header_length = 0;
@@ -1478,32 +1888,7 @@ const uint8_t* h3zero_settings_decode(const uint8_t* bytes, const uint8_t* bytes
 				bytes = NULL;
 			}
 			else {
-				uint64_t component_key;
-				uint64_t component_value;
-				while (bytes != NULL &&
-					bytes < settings_end &&
-					(bytes = picoquic_frames_varint_decode(bytes, settings_end, &component_key)) != NULL &&
-					(bytes = picoquic_frames_varint_decode(bytes, settings_end, &component_value)) != NULL) {
-					switch (component_key) {
-					case h3zero_setting_header_table_size:
-						settings->table_size = component_value;
-						break;
-					case h3zero_qpack_blocked_streams:
-						settings->blocked_streams = component_value;
-						break;
-					case h3zero_settings_enable_connect_protocol:
-						settings->enable_connect_protocol = (unsigned int)component_value;
-						break;
-					case h3zero_setting_h3_datagram:
-						settings->h3_datagram = (unsigned int)component_value;
-						break;
-					case h3zero_settings_webtransport_max_sessions:
-						settings->webtransport_max_sessions = component_value;
-						break;
-					default:
-						break;
-					}
-				}
+				bytes = h3zero_settings_components_decode(bytes, settings_end, settings);
 			}
 		}
 	}

--- a/picohttp/webtransport.c
+++ b/picohttp/webtransport.c
@@ -113,7 +113,8 @@ static h3zero_stream_ctx_t* picowt_create_stream_ctx(picoquic_cnx_t* cnx, int is
         cnx, stream_id, h3_ctx, 1, 1);
     if (stream_ctx != NULL) {
         /* Associate the stream with a per_stream context */
-        stream_ctx->control_stream_id = control_stream_id;
+        stream_ctx->ps.stream_state.stream_type = (is_bidir) ? h3zero_frame_webtransport_stream : h3zero_stream_type_webtransport;
+        stream_ctx->ps.stream_state.control_stream_id = control_stream_id;
         if (picoquic_set_app_stream_ctx(cnx, stream_id, stream_ctx) != 0) {
             DBG_PRINTF("Could not set context for stream %"PRIu64, stream_id);
         }

--- a/picohttp/wt_baton.c
+++ b/picohttp/wt_baton.c
@@ -358,7 +358,7 @@ int wt_baton_stream_data(picoquic_cnx_t* cnx,
             h3zero_delete_stream_prefix(cnx, baton_ctx->h3_ctx, stream_ctx->stream_id);
         }
     }
-    else if (stream_ctx->control_stream_id == UINT64_MAX) {
+    else if (stream_ctx->ps.stream_state.control_stream_id == UINT64_MAX) {
         picoquic_log_app_message(cnx, "Received FIN after baton close on stream %" PRIu64, stream_ctx->stream_id);
     }
     else if (baton_ctx->baton_state != wt_baton_state_ready &&
@@ -664,9 +664,9 @@ void wt_baton_unlink_context(picoquic_cnx_t* cnx,
             h3zero_stream_ctx_t* stream_ctx =
                 (h3zero_stream_ctx_t*)picohttp_stream_node_value(next);
 
-            if (control_stream_ctx->stream_id == stream_ctx->control_stream_id &&
+            if (control_stream_ctx->stream_id == stream_ctx->ps.stream_state.control_stream_id &&
                 control_stream_ctx->stream_id != stream_ctx->stream_id) {
-                stream_ctx->control_stream_id = UINT64_MAX;
+                stream_ctx->ps.stream_state.control_stream_id = UINT64_MAX;
                 stream_ctx->path_callback = NULL;
                 stream_ctx->path_callback_ctx = NULL;
                 picoquic_set_app_stream_ctx(cnx, stream_ctx->stream_id, NULL);
@@ -876,7 +876,7 @@ int wt_baton_ctx_init(wt_baton_ctx_t* baton_ctx, h3zero_callback_ctx_t* h3_ctx, 
         if (stream_ctx != NULL) {
             /* Register the control stream and the stream id */
             baton_ctx->control_stream_id = stream_ctx->stream_id;
-            stream_ctx->control_stream_id = stream_ctx->stream_id;
+            stream_ctx->ps.stream_state.control_stream_id = stream_ctx->stream_id;
             ret = h3zero_declare_stream_prefix(baton_ctx->h3_ctx, stream_ctx->stream_id, wt_baton_callback, baton_ctx);
         }
         else {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -738,7 +738,7 @@ int picoquic_start_client_cnx(picoquic_cnx_t* cnx);
  * to the context after making this call will cause an error, which
  * makes it unsafe to use inside a callback.
  */
-int picoquic_close(picoquic_cnx_t* cnx, uint16_t application_reason_code);
+int picoquic_close(picoquic_cnx_t* cnx, uint64_t application_reason_code);
 
 void picoquic_close_immediate(picoquic_cnx_t* cnx);
 
@@ -1186,7 +1186,7 @@ uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir);
 /* Ask the peer to stop sending on a stream. The peer is expected
  * to reset that stream when receiving the "stop sending" signal. */
 int picoquic_stop_sending(picoquic_cnx_t* cnx,
-    uint64_t stream_id, uint16_t local_stream_error);
+    uint64_t stream_id, uint64_t local_stream_error);
 
 /* Discard stream. This is equivalent to sending a stream reset
  * and a stop sending request, and also setting the app context

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -352,7 +352,7 @@ uint64_t picoquic_get_next_local_stream_id(picoquic_cnx_t* cnx, int is_unidir)
 }
 
 int picoquic_stop_sending(picoquic_cnx_t* cnx,
-    uint64_t stream_id, uint16_t local_stream_error)
+    uint64_t stream_id, uint64_t local_stream_error)
 {
     int ret = 0;
     picoquic_stream_head_t* stream = NULL;
@@ -4358,7 +4358,7 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
         p_addr_to, p_addr_from, if_index, NULL);
 }
 
-int picoquic_close(picoquic_cnx_t* cnx, uint16_t application_reason_code)
+int picoquic_close(picoquic_cnx_t* cnx, uint64_t application_reason_code)
 {
     int ret = 0;
     uint64_t current_time = picoquic_get_quic_time(cnx->quic);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1212,7 +1212,7 @@ int h3zero_stream_test_one_split(uint8_t * bytes, size_t nb_bytes,
     uint8_t data[64];
     uint8_t packet_buffer[256];
     size_t available_data;
-    uint16_t error_found;
+    uint64_t error_found;
 
     memset(&stream_state, 0, sizeof(h3zero_data_stream_state_t));
 
@@ -1640,7 +1640,7 @@ int h3zero_server_test()
 {
     return demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_callback, NULL, 
         demo_test_scenario, nb_demo_test_scenario, demo_test_stream_length,
-        0, 0, 0, 0, NULL, NULL, NULL, 0);
+        0, 0, 0, 0, NULL, ".", ".", 0);
 }
 
 int h09_server_test()
@@ -3208,7 +3208,7 @@ int h3zero_settings_decode_test(const uint8_t* bytes, size_t length, h3zero_sett
 }
 
 h3zero_settings_t default_setting_expected = {
-    0, 0, 0, 1, 1, 1
+    1, 0, 0, 0, 1, 1, 0
 };
 
 int h3zero_settings_test()

--- a/picoquictest/picoquic_lb_test.c
+++ b/picoquictest/picoquic_lb_test.c
@@ -934,15 +934,7 @@ int cid_for_lb_test_one(picoquic_quic_t* quic, int test_id, picoquic_load_balanc
     }
     else {
         /* Create a CID. */
-#if 0
-        memset(&result, 0, sizeof(picoquic_connection_id_t));
-        for (size_t i = 0; i < quic->local_cnxid_length; i++) {
-            result.id[i] = (uint8_t)(0x80 + i);
-        }
-        result.id_len = quic->local_cnxid_length;
-#else
         result = *init_cid;
-#endif
 
         if (quic->cnx_id_callback_fn) {
             quic->cnx_id_callback_fn(quic, picoquic_null_connection_id, picoquic_null_connection_id,

--- a/picoquictest/webtransport_test.c
+++ b/picoquictest/webtransport_test.c
@@ -193,6 +193,11 @@ static int picowt_baton_test_one(
             ret = -1;
         }
     }
+    /* Verify that settings were correctly received */
+    if (ret == 0 && !h3zero_cb->settings.settings_received) {
+        DBG_PRINTF("Settings not received at t: %llu", simulated_time);
+        ret = -1;
+    }
     /* verify that the execution time is as expected */
     if (ret == 0 && completion_target != 0) {
         if (simulated_time > completion_target) {

--- a/quicwind/quicwind_proc.c
+++ b/quicwind/quicwind_proc.c
@@ -31,7 +31,7 @@
 #include "picoquic_internal.h"
 #include "picosocks.h"
 #include "picoquic_utils.h"
-#include "h3zero.c"
+#include "h3zero.h"
 #include "democlient.h"
 #include "picoquic_packet_loop.h"
 
@@ -178,7 +178,7 @@ int quicwind_callback(picoquic_cnx_t* cnx,
             if (length > 0) {
                 switch (ctx->alpn) {
                 case picoquic_alpn_http_3: {
-                    uint16_t error_found = 0;
+                    uint64_t error_found = 0;
                     size_t available_data = 0;
                     uint8_t * bytes_max = bytes + length;
                     while (bytes < bytes_max) {


### PR DESCRIPTION
Add code to decode the H3 settings frame and store it in the H3 context.

This required a refactor of the H3 code, for clarity, and also to ensure that the unidirectional streams are correctly parsed. The code checks that the settings frames are properly coded, not replicated, etc. The web transport tests verify that the settings are correctly received.