### PR TITLE
Tuning the handling of suspensions

### DIFF
--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -74,14 +74,10 @@ static const picoquic_test_def_t test_table[] = {
     { "h3_long_file_name", h3_long_file_name_test },
     { "h3_multi_file", h3_multi_file_test },
     { "h3_multi_file_loss", h3_multi_file_loss_test },
-#if 1
     { "h3_multi_file_preemptive", h3_multi_file_preemptive_test },
-#endif
     { "h09_multi_file", h09_multi_file_test },
     { "h09_multi_file_loss", h09_multi_file_loss_test },
-#if 1
     { "h09_multi_file_preemptive", h09_multi_file_preemptive_test },
-#endif
     { "h3zero_settings", h3zero_settings_test },
     { "http_stress", http_stress_test },
     { "http_corrupt", http_corrupt_test},

--- a/picoquic/bbr.c
+++ b/picoquic/bbr.c
@@ -1046,7 +1046,6 @@ void picoquic_bbr_notify_congestion(
         /* filter repeated loss events */
         return;
     }
-#if 1
     if (is_timeout || path_x->cwin < PICOQUIC_CWIN_MINIMUM) {
         if (!bbr_state->is_suspended) {
             bbr_state->is_suspended = 1;
@@ -1056,16 +1055,6 @@ void picoquic_bbr_notify_congestion(
     } else {
         path_x->cwin = path_x->cwin / 2;
     }
-#else
-    path_x->cwin = path_x->cwin / 2;
-    if (is_timeout || path_x->cwin < PICOQUIC_CWIN_MINIMUM) {
-        if (!bbr_state->is_suspended) {
-            bbr_state->is_suspended = 1;
-            bbr_state->cwin_before_suspension = path_x->cwin;
-        }
-        path_x->cwin = PICOQUIC_CWIN_MINIMUM;
-    }
-#endif
     bbr_state->loss_interval_start = current_time;
     bbr_state->last_loss_was_timeout = is_timeout;
     bbr_state->congestion_sequence = picoquic_cc_get_sequence_number(cnx, path_x);


### PR DESCRIPTION
There is probably an interaction between congestion control and packet scheduling. After a suspension, the first ACK that arrive are those queued inside the network, before the suspension. They trigger the first "spurious ACK" notification. But at that point there are lots of unacked packets, some of which have been marked lost. They will be marked as Acked when the next ACK arrive, maybe 1 RTT after the end of the suspension. But since they have been marked lost, their content is ready to be resent. When the CC is lifted immediately, the content of the lost packets is immediately resent -- it takes priority over new content. But this is useless, because that content was already received. Sending useless content does not improve performance. It might actually delay sending new content a little bit, which will degrade performance.

Apparently, the best compromise is to set the "suspension probably over" flag upon spurious repeat, but to only open the CWND when the acks are received. Messing with the sending algorithm for repeated data has no effect, so better avoid it. With the current code, the "wifi bbr many" test completes in 3.9978 sec, with the proposed fix, 3.9955 sec -- saving 2.3 ms, which is not much of course. The other tests show a "saving" of 1 microsecond (wifi bbr  test) or 4 us (wifi hard test) -- probably just noise.