### PR TITLE
Always trace picohhtp_t tests

### DIFF
--- a/.github/workflows/ci-asan-ubsan.yml
+++ b/.github/workflows/ci-asan-ubsan.yml
@@ -52,7 +52,8 @@ jobs:
             else
                 echo "No leaks detected in picoquic_ct"
             fi
-            ./picohttp_ct -n -r 1>http_ct.txt 2>sanity.txt || QUICHTTPRESULT=$? 
+            #./picohttp_ct -n -r 1>http_ct.txt 2>sanity.txt || QUICHTTPRESULT=$? 
+            ./picohttp_ct -n -r 2>sanity.txt || QUICHTTPRESULT=$? 
             echo "running picohttp_ct returns <$QUICHTTPRESULT> "
             cat sanity.txt
             if [ ! -z ${QUICHTTPRESULT} ]; then

--- a/.github/workflows/ci-tests-no-fusion.yml
+++ b/.github/workflows/ci-tests-no-fusion.yml
@@ -39,6 +39,7 @@ jobs:
             make test && QUICRESULT=$?
             cd ..
             if [[ ${QUICRESULT} == 0 ]]; then exit 0; fi;
+            cat /home/runner/work/picoquic/picoquic/build/Testing/Temporary/LastTest.log
             exit 1
             
       #TODO: reset the test once openssl issue is understood.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Release
 */*.ilk
 *.b
 /picoquic/qlogger.c
+/picohttp_t/h3-m-www

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -268,6 +268,7 @@ int main(int argc, char** argv)
             if (optind >= argc) {
                 for (size_t i = 0; i < nb_tests; i++) {
                     if (test_status[i] == test_not_run) {
+                        fprintf(stdout, "Test number %d: %s\n", (int)i, test_table[i].test_name);
                         nb_test_tried++;
                         if (do_one_test(i, stdout) != 0) {
                             test_status[i] = test_failed;
@@ -293,6 +294,7 @@ int main(int argc, char** argv)
                     }
                     else {
                         nb_test_tried++;
+                        fprintf(stdout, "Test number %d: %s\n", (int)test_number, test_table[test_number].test_name);
                         if (do_one_test(test_number, stdout) != 0) {
                             test_status[test_number] = test_failed;
                             nb_test_failed++;

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -268,7 +268,6 @@ int main(int argc, char** argv)
             if (optind >= argc) {
                 for (size_t i = 0; i < nb_tests; i++) {
                     if (test_status[i] == test_not_run) {
-                        fprintf(stdout, "Test number %d: %s\n", (int)i, test_table[i].test_name);
                         nb_test_tried++;
                         if (do_one_test(i, stdout) != 0) {
                             test_status[i] = test_failed;
@@ -294,7 +293,6 @@ int main(int argc, char** argv)
                     }
                     else {
                         nb_test_tried++;
-                        fprintf(stdout, "Test number %d: %s\n", (int)test_number, test_table[test_number].test_name);
                         if (do_one_test(test_number, stdout) != 0) {
                             test_status[test_number] = test_failed;
                             nb_test_failed++;

--- a/picoquictest/webtransport_test.c
+++ b/picoquictest/webtransport_test.c
@@ -124,6 +124,7 @@ static int picowt_baton_test_one(
             ret = 1;
         }
         else {
+            h3zero_cb->no_print = 1;
             picoquic_set_callback(test_ctx->cnx_client, h3zero_callback, h3zero_cb);
             /* Initialize the callback context. First, create a bidir stream */
             wt_baton_ctx_init(&baton_ctx, h3zero_cb, NULL, NULL);


### PR DESCRIPTION
The tests in `httptest_ct -n` sometimes fail to complete. Printing out the progress to isolate the test causing the issue.