### PR TITLE
Add API to set BBR quantum ratio

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1453,6 +1453,16 @@ void picoquic_set_congestion_algorithm(picoquic_cnx_t* cnx, picoquic_congestion_
  */
 void picoquic_set_default_wifi_shadow_rtt(picoquic_quic_t* quic, uint64_t wifi_shadow_rtt);
 
+/* The experimental API `picoquic_set_default_bbr_quantum_ratio`
+* allows application to change the "quantum ratio" parameter of the BBR
+* algorithm. The default value is 0.001 (1/1000th of the pacing rate
+* in bytes per second). Larger values like 0.01 would increase the
+* size of the "leaky bucket" used by the pacing algorithms. Whether
+* that's a good idea or not is debatable, probably depends on the
+* application.
+ */
+void picoquic_set_default_bbr_quantum_ratio(picoquic_quic_t* quic, double quantum_ratio);
+
 /* Bandwidth update and congestion control parameters value.
  * Congestion control in picoquic is characterized by three values:
  * - pacing rate, expressed in bytes per second (for example, 10Mbps would be noted as 1250000)

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -666,6 +666,7 @@ typedef struct st_picoquic_quic_t {
 
     picoquic_congestion_algorithm_t const* default_congestion_alg;
     uint64_t wifi_shadow_rtt;
+    double bbr_quantum_ratio;
 
     struct st_picoquic_cnx_t* cnx_list;
     struct st_picoquic_cnx_t* cnx_last;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -4525,6 +4525,11 @@ void picoquic_set_default_wifi_shadow_rtt(picoquic_quic_t* quic, uint64_t wifi_s
     quic->wifi_shadow_rtt = wifi_shadow_rtt;
 }
 
+void picoquic_set_default_bbr_quantum_ratio(picoquic_quic_t* quic, double quantum_ratio)
+{
+    quic->bbr_quantum_ratio = quantum_ratio;
+}
+
 void picoquic_subscribe_pacing_rate_updates(picoquic_cnx_t* cnx, uint64_t decrease_threshold, uint64_t increase_threshold)
 {
     cnx->pacing_decrease_threshold = decrease_threshold;


### PR DESCRIPTION
This PR adds an experimental API to change the "quantum ratio" of BBR from the default 0.001 (1/1000th of the pacing rate in bytes per second) to a larger value. The API is:
~~~
void picoquic_set_default_bbr_quantum_ratio(picoquic_quic_t* quic, double quantum_ratio);
~~~
It should be called before a connection is created. Calling the API does not affect existing connections.