### PR TITLE
Add custom thread creation

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -160,6 +160,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(sockloop_thread_name)
+        {
+            int ret = sockloop_thread_name_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(splay)
         {
             int ret = splay_test();

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ test_script:
  # using alternative because of error `vstest.console.exe .\UnitTest1.dll`
  # - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
  # Alternative to UnitTest1 (running the same tests):
- - ps: .\picoquic_t -n -r -x fuzz_initial
+ - ps: .\picoquic_t.exe -n -x fuzz_initial
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,9 +35,10 @@ test_script:
  - ps: cd "$Env:Configuration"
  - ps: pwd
  - ps: dir
- - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
+ # using alternative because of error `vstest.console.exe .\UnitTest1.dll`
+ # - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
  # Alternative to UnitTest1 (running the same tests):
- # - ps: .\picoquic_t -n -r -x fuzz_initial
+ - ps: .\picoquic_t -n -r -x fuzz_initial
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,8 @@ test_script:
  # using alternative because of error `vstest.console.exe .\UnitTest1.dll`
  # - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
  # Alternative to UnitTest1 (running the same tests):
- - ps: .\picoquic_t.exe -n -x fuzz_initial
+ - ps: echo "Trying picoquic_t"
+ - ps: .\picoquic_t.exe -x fuzz_initial
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ test_script:
  - ps: if ($Env:Platform -eq "x64") { cd x64 }
  - ps: cd "$Env:Configuration"
  - ps: pwd
- - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll 
+ - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll RunConfiguration.DisableAppDomain=true
  # Alternative to UnitTest1 (running the same tests):
  # - ps: .\picoquic_t -n -r -x fuzz_initial
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,7 @@ test_script:
  # using alternative because of error `vstest.console.exe .\UnitTest1.dll`
  # - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
  # Alternative to UnitTest1 (running the same tests):
- - ps: echo "Trying picoquic_t"
- - ps: .\picoquic_t.exe -x fuzz_initial
+ # - ps: .\picoquic_t.exe -x fuzz_initial
 
 deploy: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,8 @@ test_script:
  - ps: if ($Env:Platform -eq "x64") { cd x64 }
  - ps: cd "$Env:Configuration"
  - ps: pwd
- - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll RunConfiguration.DisableAppDomain=true
+ - ps: dir
+ - ps: vstest.console /logger:Appveyor "/testcasefilter:(Name!=config_quic)&(Name!=config_option)&(Name!=qlog_trace)&(Name!=qlog_trace_auto)&(Name!=qlog_trace_ecn)&(Name!=qlog_trace_only)&(Name!=simple_multipath_qlog)&(Name!=multipath_qlog)&(Name!=threading)" UnitTest1.dll
  # Alternative to UnitTest1 (running the same tests):
  # - ps: .\picoquic_t -n -r -x fuzz_initial
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -58,6 +58,7 @@ static const picoquic_test_def_t test_table[] = {
     { "sockloop_migration", sockloop_migration_test },
     { "sockloop_nat", sockloop_nat_test },
     { "sockloop_thread", sockloop_thread_test },
+    { "sockloop_thread_name", sockloop_thread_name_test },
     { "splay", splay_test },
     { "cnxcreation", cnxcreation_test },
     { "parseheader", parseheadertest },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -175,6 +175,7 @@ int sockloop_ipv4_test();
 int sockloop_migration_test();
 int sockloop_nat_test();
 int sockloop_thread_test();
+int sockloop_thread_name_test();
 int splay_test();
 int TlsStreamFrameTest();
 int draft17_vector_test();


### PR DESCRIPTION
This PR adds two important features to the network thread support:

1) Support of thread creation in application frameworks that require framework specific APIs instead of using the platform APIs in Windows or the pthread APIs in Unix systems.

2) Support of thread naming, which is difficult to implement in some OSes for which the naming API must be used from inside the named thread (Apple, mostly).

See the definition of `picoquic_start_custom_network_thread` in the new `picoquic_packet_loop.h`.