### PR TITLE
Tighten reset loop prevention

### DIFF
--- a/picoquic/port_blocking.c
+++ b/picoquic/port_blocking.c
@@ -123,6 +123,7 @@ const uint16_t picoquic_blocked_port_list[] = {
         53,     /* DNS */
         19,     /* Chargen */
         17,     /* Quote of the Day */
+        7,      /* Echo */
         0,      /* Unusable */
 };
 


### PR DESCRIPTION
Looking at a report from a [nasty loop between Google QUIC servers and an UDP ECHO service](https://bughunters.google.com/blog/5960150648750080/preventing-cross-service-udp-loops-in-quic) incited two changes in the code:

1) Add the ECHO service (UDP port 7) to the list of ports that are protected against reflection attacks.
2) Update the code of the stateless reset generation to make it obvious that the stateless reset will always be at least one byte shorter that the incoming packet.

The other precautions in the code are unchanged, in particular the rate limiting of packet resets, by default enforcing a delay of at least 100ms between consecutive stateless reset packets.