### PR TITLE
Allow OpenSSL verifier to be called with NULL SNI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ if(PICOQUIC_FETCH_PTLS)
     include(FetchContent)
     FetchContent_Declare(picotls
         GIT_REPOSITORY      https://github.com/h2o/picotls.git
-        GIT_TAG             af66fc4aa8853b0725fcb2c18a702e8f1c656cf1)
+        GIT_TAG             5a4461d8a3948d9d26bf861e7d90cb80d8093515)
     FetchContent_MakeAvailable(picotls)
 endif()
 

--- a/ci/build_picotls.ps1
+++ b/ci/build_picotls.ps1
@@ -1,5 +1,5 @@
 # Build at a known-good commit
-$COMMIT_ID=" af66fc4aa8853b0725fcb2c18a702e8f1c656cf1"
+$COMMIT_ID=" 5a4461d8a3948d9d26bf861e7d90cb80d8093515"
 
 # Match expectations of picotlsvs project.
 mkdir $dir\include\

--- a/ci/build_picotls.sh
+++ b/ci/build_picotls.sh
@@ -2,7 +2,7 @@
 #build last picotls master (for Travis)
 
 # Build at a known-good commit
-COMMIT_ID= af66fc4aa8853b0725fcb2c18a702e8f1c656cf1
+COMMIT_ID= 5a4461d8a3948d9d26bf861e7d90cb80d8093515
 
 cd ..
 # git clone --branch master --single-branch --shallow-submodules --recurse-submodules --no-tags https://github.com/h2o/picotls

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3786,11 +3786,9 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
 
             cnx->cnx_state = picoquic_state_client_init;
 
-            if (!quic->is_cert_store_not_empty || sni == NULL) {
-                /* This is a hack. The open SSL certifier crashes if no name is specified,
-                 * and always fails if no certificate is stored, so we just use a NULL verifier */
-                picoquic_log_app_message(cnx, "%s -- certificate will not be verified.\n",
-                    (sni == NULL) ? "No server name specified" : "No root crt list specified");
+            if (!quic->is_cert_store_not_empty) {
+                /* The open SSL certifier always fails if no certificate is stored, so we just use a NULL verifier */
+                picoquic_log_app_message(cnx, "No root crt list specified -- certificate will not be verified.\n");
 
                 picoquic_set_null_verifier(quic);
             }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -2175,9 +2175,6 @@ static int tls_api_test_with_loss(uint64_t* loss_mask, uint32_t proposed_version
     {
         DBG_PRINTF("Could not create the QUIC test contexts for V=%x\n", proposed_version);
     }
-    else if (sni == NULL) {
-        picoquic_set_null_verifier(test_ctx->qclient);
-    }
 
     if (ret == 0) {
         ret = tls_api_connection_loop(test_ctx, loss_mask, 0, &simulated_time);


### PR DESCRIPTION
Removed NULL SNI check in picoquic_create_cnx

Following this recent Picotls change https://github.com/h2o/picotls/pull/520 the verifier now skips the client side SNI check if it is NULL.

This change resolves #1184 