### PR TITLE
Fix build on Android

### DIFF
--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -1043,7 +1043,11 @@ void picoquic_delete_thread(picoquic_thread_t * thread)
     *thread = NULL;
 #else
     if (pthread_join(*thread, NULL) != 0) {
+# ifdef ANDROID
+        pthread_kill(*thread, SIGTERM);
+# else
         (void)pthread_cancel(*thread);
+# endif
     }
 #endif
 }


### PR DESCRIPTION
Android's NDK doesn't support `pthread_cancel`: use `pthread_kill` instead (only when building for Android)