### PR TITLE
Reenter startup after big BW increase

### DIFF
--- a/picoquic/bbr.c
+++ b/picoquic/bbr.c
@@ -303,6 +303,7 @@ typedef struct st_bbr_per_ack_state_t {
 /* Forward definition of key functions */
 static int IsInAProbeBWState(picoquic_bbr_state_t* bbr_state);
 static int BBRIsProbingBW(picoquic_bbr_state_t* bbr_state);
+static void BBREnterProbeBW(picoquic_bbr_state_t* bbr_state, picoquic_path_t* path_x, uint64_t current_time);
 static void BBREnterDrain(picoquic_bbr_state_t* bbr_state, picoquic_path_t* path_x, uint64_t current_time);
 #if 0
 static void BBRHandleRestartFromIdle(picoquic_bbr_state_t* bbr_state, picoquic_path_t* path_x, uint64_t current_time);
@@ -1283,7 +1284,7 @@ static void BBRExitProbeRTT(picoquic_bbr_state_t* bbr_state, picoquic_path_t * p
     BBRResetLowerBounds(bbr_state);
     path_x->rtt_min = bbr_state->min_rtt;
     if (bbr_state->filled_pipe) {
-        BBRStartProbeBW(bbr_state, path_x, current_time);
+        BBREnterProbeBW(bbr_state, path_x, current_time);
         BBRStartProbeBW_CRUISE(bbr_state);
     }
     else {

--- a/picoquic/bbr.c
+++ b/picoquic/bbr.c
@@ -210,6 +210,7 @@ typedef struct st_picoquic_bbr_state_t {
     unsigned int probe_probe_bw_quickly : 1;
     uint32_t rounds_since_bw_probe;
     uint64_t bw_probe_wait;
+    uint64_t bw_probe_ceiling; /* If bandwidth grows more than ceiling in probe_bw states, redo startup */
     uint64_t cycle_stamp;
     uint32_t bw_probe_up_cnt;
     uint32_t bw_probe_up_rounds;
@@ -1282,7 +1283,7 @@ static void BBRExitProbeRTT(picoquic_bbr_state_t* bbr_state, picoquic_path_t * p
     BBRResetLowerBounds(bbr_state);
     path_x->rtt_min = bbr_state->min_rtt;
     if (bbr_state->filled_pipe) {
-        BBRStartProbeBW_DOWN(bbr_state, path_x, current_time);
+        BBRStartProbeBW(bbr_state, path_x, current_time);
         BBRStartProbeBW_CRUISE(bbr_state);
     }
     else {
@@ -1708,12 +1709,17 @@ static void BBRUpdateProbeBWCyclePhase(picoquic_bbr_state_t* bbr_state, picoquic
 
     default:
         /* In non probe BW states, do nothing. */
-        break;
+        return;
+    }
+    /* Only in probe BW states, if BW > ceiling, enter startup */
+    if (bbr_state->bw > bbr_state->bw_probe_ceiling) {
+        BBRReEnterStartup(bbr_state, path_x, current_time);
     }
 }
 
 static void BBREnterProbeBW(picoquic_bbr_state_t* bbr_state, picoquic_path_t* path_x, uint64_t current_time)
 {
+    bbr_state->bw_probe_ceiling = bbr_state->bw + bbr_state->bw / 2;
     BBRStartProbeBW_DOWN(bbr_state, path_x, current_time);
 }
 /* End of probe BW specific algorithms */


### PR DESCRIPTION
In the "probe BW" states, probing for bandwidth is cautious and slow. This is generally a good idea, but it results in long delays of low bandwidth operation when recovering from a big slow down in capacity. To speed this up, we trigger a reentry of the "startup" state if the measured bandwidth increased by more than 50% during "probeBW".