### PR TITLE
Measure select delay

### DIFF
--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -79,6 +79,11 @@
 #include <netinet/in.h>
 #include <sys/select.h>
 
+#ifndef __APPLE__
+/* On Linux systems, add macro to define the GNU extension for pthread_setname_np */
+#define _GNU_SOURCE
+#endif
+
 #include <pthread.h>
 
 #ifndef SOCKET_TYPE

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -798,6 +798,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
         * ever sending responses or ACKs. We moderate that by counting the number
         * of loops in "immediate" mode, and ignoring the "loop
         * immediate" condition if that number reaches a limit */
+        current_time = picoquic_current_time();
         if (!loop_immediate) {
             nb_loop_immediate = 1;
             delta_t = picoquic_get_next_wake_delay(quic, current_time, delay_max);


### PR DESCRIPTION
In theory, calling "select()" (or the equivalent on Windows) with a wait time of zero returns immediately. However, this is a system call. In high CPU usage condition, the OS may decide to take the opportunity and schedule a different process. In that case, the wait might be much longer. Measuring that time might allow us to detect such high CPU conditions.