### PR TITLE
Implementation of range header

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -871,6 +871,34 @@ char const * demo_client_parse_post_size(char const * text, uint64_t * post_size
     return text;
 }
 
+char const * demo_client_parse_range(char const * text, char ** range)
+{
+    if (text[0]  != '#') {
+        *range = NULL;
+    }
+    else {
+        char const* range_start = ++text;
+        size_t l_range = 0;
+        
+        while (*text != ':' && *text != ';' && *text != 0) {
+            text++;
+        }
+        l_range = text - range_start;
+        *range = malloc(l_range + 1);
+        if (*range == NULL) {
+            text = NULL;
+        } else {
+            memcpy(*range, range_start, l_range);
+            (*range)[l_range] = 0;
+
+            if (*text == ':') {
+                text++;
+            }
+        }
+    }
+
+    return text;
+}
 
 char const * demo_client_parse_stream_desc(char const * text, uint64_t default_stream, uint64_t default_previous,
     picoquic_demo_stream_desc_t * desc)
@@ -895,6 +923,10 @@ char const * demo_client_parse_stream_desc(char const * text, uint64_t default_s
         text = demo_client_parse_post_size(demo_client_parse_stream_spaces(text), &desc->post_size);
     }
 
+    if (text != NULL) {
+        text = demo_client_parse_range(demo_client_parse_stream_spaces(text), (char **)&desc->range);
+    }
+
     /* Skip the final ';' */
     if (text != NULL && *text == ';') {
         text++;
@@ -913,6 +945,10 @@ void demo_client_delete_scenario_desc(size_t nb_streams, picoquic_demo_stream_de
         if (desc[i].doc_name != NULL) {
             free((char*)desc[i].doc_name);
             *(char**)(&desc[i].doc_name) = NULL;
+        }
+        if (desc[i].range != NULL) {
+            free((char*)desc[i].range);
+            *(char**)(&desc[i].range) = NULL;
         }
     }
     free(desc);

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -226,7 +226,7 @@ int h09_demo_client_prepare_stream_open_command(
 
 static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
     picoquic_demo_callback_ctx_t* ctx,
-    uint64_t stream_id, char const* doc_name, char const* fname, uint64_t post_size, uint64_t nb_repeat)
+    uint64_t stream_id, char const* doc_name, char const* fname, char const* range, uint64_t post_size, uint64_t nb_repeat)
 {
     int ret = 0;
     uint8_t buffer[1024];
@@ -315,8 +315,10 @@ static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
 
         switch (ctx->alpn) {
         case picoquic_alpn_http_3:
-            ret = h3zero_client_create_stream_request(
-                buffer, sizeof(buffer), path, path_len, post_size, cnx->sni, &request_length);
+            ret = h3zero_client_create_stream_request_ex(
+                buffer, sizeof(buffer), path, path_len, 
+                range, (range == NULL)?0:strlen(range), post_size,
+                cnx->sni, &request_length);
             break;
         case picoquic_alpn_http_0_9:
         default:
@@ -397,6 +399,7 @@ int picoquic_demo_client_start_streams(picoquic_cnx_t* cnx,
                 ret = picoquic_demo_client_open_stream(cnx, ctx, ctx->demo_stream[i].stream_id,
                     ctx->demo_stream[i].doc_name,
                     ctx->demo_stream[i].f_name,
+                    ctx->demo_stream[i].range,
                     (size_t)ctx->demo_stream[i].post_size,
                     repeat_nb);
                 repeat_nb++;

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -906,6 +906,8 @@ char const * demo_client_parse_range(char const * text, char ** range)
 char const * demo_client_parse_stream_desc(char const * text, uint64_t default_stream, uint64_t default_previous,
     picoquic_demo_stream_desc_t * desc)
 {
+    memset(desc, 0, sizeof(picoquic_demo_stream_desc_t));
+
     text = demo_client_parse_stream_repeat(text, &desc->repeat_count);
 
     if (text != NULL) {

--- a/picohttp/democlient.h
+++ b/picohttp/democlient.h
@@ -45,6 +45,7 @@ typedef struct st_picoquic_demo_stream_desc_t {
     char const* doc_name;
     char const* f_name;
     uint64_t post_size;
+    char const* range;
 } picoquic_demo_stream_desc_t;
 
 #define PICOQUIC_DEMO_STREAM_LIST_MAX 16

--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -467,6 +467,16 @@ uint8_t * h3zero_parse_qpack_header_value(uint8_t * bytes, uint8_t * bytes_max,
                         decoded_length, &parts->path, &parts->path_length);
                 }
                 break;
+            case http_header_range:
+                if (parts->range != NULL) {
+                    /* Duplicate content type! */
+                    bytes = 0;
+                }
+                else {
+                    bytes = h3zero_parse_qpack_header_value_string(bytes, decoded,
+                        decoded_length, &parts->range, &parts->range_length);
+                }
+                break;
             case http_pseudo_header_protocol:
                 if (parts->protocol != NULL) {
                     /* Duplicate content type! */

--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -503,11 +503,12 @@ uint8_t * h3zero_parse_qpack_header_value(uint8_t * bytes, uint8_t * bytes_max,
 int h3zero_get_interesting_header_type(uint8_t * name, size_t name_length, int is_huffman)
 {
     char const  * interesting_header_name[] = {
-     ":method", ":path", ":status", "content-type", ":protocol", "origin", NULL};
+     ":method", ":path", ":status", "content-type", ":protocol", "origin", "range", NULL};
     const http_header_enum_t interesting_header[] = {
         http_pseudo_header_method, http_pseudo_header_path,
         http_pseudo_header_status, http_header_content_type,
-        http_pseudo_header_protocol, http_header_origin
+        http_pseudo_header_protocol, http_header_origin,
+        http_header_range
     };
     http_header_enum_t val = http_header_unknown;
     uint8_t deHuff[256];
@@ -862,13 +863,13 @@ uint8_t * h3zero_create_post_header_frame_ex(uint8_t * bytes, uint8_t * bytes_ma
     bytes = h3zero_qpack_code_encode(bytes, bytes_max, 0xC0, 0x3F, H3ZERO_QPACK_SCHEME_HTTPS);
     /* Path: doc_name. Use literal plus reference format */
     bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_CODE_PATH, path, path_length);
-    /*Optional: range. Use literal plus reference format */
-    if (range_length > 0) {
-        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
-    }
-    /*Authority: host. Use literal plus reference format */
+    /* Authority: host. Use literal plus reference format */
     if (host != NULL) {
         bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_AUTHORITY, (uint8_t const *)host, strlen(host));
+    }
+    /* Optional: range. Use literal plus reference format */
+    if (range_length > 0) {
+        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
     }
     /* User Agent */
     if (ua_string != NULL) {
@@ -903,13 +904,13 @@ uint8_t * h3zero_create_request_header_frame_ex(uint8_t * bytes, uint8_t * bytes
     bytes = h3zero_qpack_code_encode(bytes, bytes_max, 0xC0, 0x3F, H3ZERO_QPACK_SCHEME_HTTPS);
     /* Path: doc_name. Use literal plus reference format */
     bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_CODE_PATH, path, path_length);
-    /*Optional: range. Use literal plus reference format */
-    if (range_length > 0) {
-        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
-    }
-    /*Authority: host. Use literal plus reference format */
+    /* Authority: host. Use literal plus reference format */
     if (host != NULL) {
         bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_AUTHORITY, (uint8_t const *)host, strlen(host));
+    }
+    /* Optional: range. Use literal plus reference format */
+    if (range_length > 0) {
+        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
     }
     /* User Agent */
     if (ua_string != NULL) {

--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -837,7 +837,7 @@ uint8_t* h3zero_create_connect_header_frame(uint8_t* bytes, uint8_t* bytes_max,
 }
 
 uint8_t * h3zero_create_post_header_frame_ex(uint8_t * bytes, uint8_t * bytes_max,
-    uint8_t const * path, size_t path_length, char const * host, 
+    uint8_t const * path, size_t path_length, uint8_t const * range, size_t range_length, char const* host,
     h3zero_content_type_enum content_type, char const* ua_string)
 {
     if (bytes == NULL || bytes + 2 > bytes_max) {
@@ -852,6 +852,10 @@ uint8_t * h3zero_create_post_header_frame_ex(uint8_t * bytes, uint8_t * bytes_ma
     bytes = h3zero_qpack_code_encode(bytes, bytes_max, 0xC0, 0x3F, H3ZERO_QPACK_SCHEME_HTTPS);
     /* Path: doc_name. Use literal plus reference format */
     bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_CODE_PATH, path, path_length);
+    /*Optional: range. Use literal plus reference format */
+    if (range_length > 0) {
+        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
+    }
     /*Authority: host. Use literal plus reference format */
     if (host != NULL) {
         bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_AUTHORITY, (uint8_t const *)host, strlen(host));
@@ -869,12 +873,13 @@ uint8_t * h3zero_create_post_header_frame_ex(uint8_t * bytes, uint8_t * bytes_ma
 uint8_t* h3zero_create_post_header_frame(uint8_t* bytes, uint8_t* bytes_max,
     uint8_t const* path, size_t path_length, char const* host, h3zero_content_type_enum content_type)
 {
-    return h3zero_create_post_header_frame_ex(bytes, bytes_max, path, path_length, host,
+    return h3zero_create_post_header_frame_ex(bytes, bytes_max, path, path_length, NULL, 0, host,
         content_type, H3ZERO_USER_AGENT_STRING);
 }
 
 uint8_t * h3zero_create_request_header_frame_ex(uint8_t * bytes, uint8_t * bytes_max,
-    uint8_t const * path, size_t path_length, char const * host, char const* ua_string)
+    uint8_t const * path, size_t path_length, uint8_t const * range, size_t range_length,
+    char const * host, char const* ua_string)
 {
     if (bytes == NULL || bytes + 2 > bytes_max) {
         return NULL;
@@ -888,6 +893,10 @@ uint8_t * h3zero_create_request_header_frame_ex(uint8_t * bytes, uint8_t * bytes
     bytes = h3zero_qpack_code_encode(bytes, bytes_max, 0xC0, 0x3F, H3ZERO_QPACK_SCHEME_HTTPS);
     /* Path: doc_name. Use literal plus reference format */
     bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_CODE_PATH, path, path_length);
+    /*Optional: range. Use literal plus reference format */
+    if (range_length > 0) {
+        bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_RANGE, (uint8_t const *)range, range_length);
+    }
     /*Authority: host. Use literal plus reference format */
     if (host != NULL) {
         bytes = h3zero_qpack_literal_plus_ref_encode(bytes, bytes_max, H3ZERO_QPACK_AUTHORITY, (uint8_t const *)host, strlen(host));
@@ -903,7 +912,7 @@ uint8_t* h3zero_create_request_header_frame(uint8_t* bytes, uint8_t* bytes_max,
     uint8_t const* path, size_t path_length, char const* host)
 {
     return h3zero_create_request_header_frame_ex(bytes, bytes_max, path, path_length,
-        host, H3ZERO_USER_AGENT_STRING);
+        NULL, 0, host, H3ZERO_USER_AGENT_STRING);
 }
 
 uint8_t * h3zero_create_response_header_frame_ex(uint8_t * bytes, uint8_t * bytes_max,

--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -1058,6 +1058,11 @@ void h3zero_release_header_parts(h3zero_header_parts_t* header)
         *((uint8_t**)&header->path) = NULL;
         header->path_length = 0;
     }
+    if (header->range != NULL) {
+        free((uint8_t*)header->range);
+        *((uint8_t**)&header->range) = NULL;
+        header->range_length = 0;
+    }
     if (header->protocol != NULL) {
         free((uint8_t*)header->protocol);
         *((uint8_t**)&header->protocol) = NULL;

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -141,6 +141,7 @@ typedef enum {
 #define H3ZERO_QPACK_AUTHORITY 0
 #define H3ZERO_QPACK_SCHEME_HTTPS 23
 #define H3ZERO_QPACK_TEXT_PLAIN 53
+#define H3ZERO_QPACK_RANGE 55
 #define H3ZERO_QPACK_USER_AGENT 95
 #define H3ZERO_QPACK_ORIGIN 90
 #define H3ZERO_QPACK_SERVER 92
@@ -225,15 +226,20 @@ uint8_t * h3zero_parse_qpack_header_frame(uint8_t * bytes, uint8_t * bytes_max,
 uint8_t * h3zero_create_request_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     uint8_t const * path, size_t path_length, char const * host);
 uint8_t* h3zero_create_request_header_frame_ex(uint8_t* bytes, uint8_t* bytes_max,
-    uint8_t const* path, size_t path_length, char const* host, char const* ua_string);
+    uint8_t const* path, size_t path_length, uint8_t const* range, size_t range_length,
+    char const* host, char const* ua_string);
 uint8_t * h3zero_create_post_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     uint8_t const * path, size_t path_length, char const * host,
     h3zero_content_type_enum content_type);
+uint8_t* h3zero_create_request_header_frame_ex(uint8_t* bytes, uint8_t* bytes_max,
+    uint8_t const* path, size_t path_length, uint8_t const* range, size_t range_length,
+    char const* host, char const* ua_string);
 uint8_t* h3zero_create_connect_header_frame(uint8_t* bytes, uint8_t* bytes_max,
     uint8_t const* path, size_t path_length, char const* protocol, char const* origin,
     char const* ua_string);
 uint8_t* h3zero_create_post_header_frame_ex(uint8_t* bytes, uint8_t* bytes_max,
-    uint8_t const* path, size_t path_length, char const* host, h3zero_content_type_enum content_type, char const* ua_string);
+    uint8_t const* path, size_t path_length, uint8_t const* range, size_t range_length,
+    char const* host, h3zero_content_type_enum content_type, char const* ua_string);
 uint8_t * h3zero_create_response_header_frame(uint8_t * bytes, uint8_t * bytes_max,
     h3zero_content_type_enum doc_type);
 uint8_t* h3zero_create_error_frame(uint8_t* bytes, uint8_t* bytes_max, char const* error_code, char const* server_string);

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -184,6 +184,8 @@ typedef struct st_h3zero_header_parts_t {
     h3zero_method_enum method;
     uint8_t const * path;
     size_t path_length;
+    uint8_t const * range;
+    size_t range_length;
     int status;
     h3zero_content_type_enum content_type;
     uint8_t const * protocol;

--- a/picohttp/h3zero_client.c
+++ b/picohttp/h3zero_client.c
@@ -31,8 +31,8 @@
  * but the client implementation is barebone.
  */
 
-int h3zero_client_create_stream_request(
-    uint8_t * buffer, size_t max_bytes, uint8_t const * path, size_t path_len, uint64_t post_size, const char * host, size_t * consumed)
+int h3zero_client_create_stream_request_ex(
+    uint8_t * buffer, size_t max_bytes, uint8_t const * path, size_t path_len, const char * range, size_t range_len, uint64_t post_size, const char * host, size_t * consumed)
 {
     int ret = 0;
     uint8_t * o_bytes = buffer;
@@ -51,8 +51,8 @@ int h3zero_client_create_stream_request(
         *o_bytes++ = h3zero_frame_header;
         o_bytes += 2; /* reserve two bytes for frame length */
         if (post_size == 0) {
-            o_bytes = h3zero_create_request_header_frame(o_bytes, o_bytes_max,
-                (const uint8_t *)path, path_len, host);
+            o_bytes = h3zero_create_request_header_frame_ex(o_bytes, o_bytes_max,
+                (const uint8_t *)path, path_len, (const uint8_t *)range, range_len, host, H3ZERO_USER_AGENT_STRING);
         }
         else {
             o_bytes = h3zero_create_post_header_frame(o_bytes, o_bytes_max,
@@ -99,5 +99,10 @@ int h3zero_client_create_stream_request(
     return ret;
 }
 
+int h3zero_client_create_stream_request(
+    uint8_t* buffer, size_t max_bytes, uint8_t const* path, size_t path_len, uint64_t post_size, const char* host, size_t* consumed)
+{
+    return h3zero_client_create_stream_request_ex(buffer, max_bytes, path, path_len, NULL, 0, post_size, host, consumed);
+}
 
 

--- a/picohttp/h3zero_common.h
+++ b/picohttp/h3zero_common.h
@@ -182,6 +182,8 @@ extern "C" {
 
     /* CLIENT DEFINITIONS 
      */
+    int h3zero_client_create_stream_request_ex(
+        uint8_t* buffer, size_t max_bytes, uint8_t const* path, size_t path_len, const char* range, size_t range_len, uint64_t post_size, const char* host, size_t* consumed);
     int h3zero_client_create_stream_request(
         uint8_t * buffer, size_t max_bytes, uint8_t const * path, size_t path_len, uint64_t post_size, const char * host, size_t * consumed);
 

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -546,6 +546,8 @@ int qpack_huffman_base_test()
 #define QPACK_TEST_HEADER_INDEX_HTML_LEN 10
 #define QPACK_TEST_HEADER_PATH ':', 'p', 'a', 't', 'h'
 #define QPACK_TEST_HEADER_PATH_LEN 5
+#define QPACK_TEST_HEADER_RANGE 'r', 'a', 'n', 'g', 'e'
+#define QPACK_TEST_HEADER_RANGE_LEN 5
 #define QPACK_TEST_HEADER_STATUS ':', 's', 't', 'a', 't', 'u', 's'
 #define QPACK_TEST_HEADER_STATUS_LEN 7
 #define QPACK_TEST_HEADER_QPACK_PATH 0xFD, 0xFD, 0xFD 
@@ -554,7 +556,8 @@ int qpack_huffman_base_test()
 #define QPACK_TEST_HEADER_ALLOW_GET_POST 
 #define QPACK_TEST_ALLOWED_METHODS 'G', 'E', 'T', ',', ' ', 'P', 'O', 'S', 'T', ',', ' ', 'C', 'O', 'N', 'N', 'E', 'C', 'T'
 #define QPACK_TEST_ALLOWED_METHODS_LEN 18
-
+#define QPACK_TEST_VALUE_RANGE10 'b', 'y', 't', 'e', 's', '=', '1', '-', '1', '0'
+#define QPACK_TEST_VALUE_RANGE10_LEN 10
 static uint8_t qpack_test_get_slash[] = {
     QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0|17, 0xC0 | 1 };
 
@@ -634,7 +637,13 @@ static uint8_t qpack_status200_akamai[] = {
 
 static uint8_t qpack_test_get_slash_range[] = {
     QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0 | 17, 0xC0 | 1,
-    0x5f, 0x28, 0x0a, 'b', 'y', 't', 'e', 's', '=', '1', '-', '1', '0'
+    0x5f, 0x28, QPACK_TEST_VALUE_RANGE10_LEN, QPACK_TEST_VALUE_RANGE10
+};
+
+static uint8_t qpack_test_get_slash_range_long[] = {
+    QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0 | 17, 0xC0 | 1,
+    0x20 | QPACK_TEST_HEADER_RANGE_LEN, QPACK_TEST_HEADER_RANGE,
+    QPACK_TEST_VALUE_RANGE10_LEN, QPACK_TEST_VALUE_RANGE10
 };
 
 #define FILE_10Z '0', '0', '0', '0', '0', '0', '0', '0', '0', '0'
@@ -807,6 +816,12 @@ static qpack_test_case_t qpack_test_case[] = {
         qpack_test_range_text, sizeof(qpack_test_range_text),
         0, 0, NULL, 0}
     },
+    {
+        qpack_test_get_slash_range_long, sizeof(qpack_test_get_slash_range_long),
+        { h3zero_method_get, qpack_test_string_slash, 1,
+        qpack_test_range_text, sizeof(qpack_test_range_text),
+        0, 0, NULL, 0}
+    }
 };
 
 static size_t nb_qpack_test_case = sizeof(qpack_test_case) / sizeof(qpack_test_case_t);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -632,6 +632,11 @@ static uint8_t qpack_status200_akamai[] = {
     0x42, 0x6c, 0x28, 0xe9, 0xe3
 };
 
+static uint8_t qpack_test_get_slash_range[] = {
+    QPACK_TEST_HEADER_BLOCK_PREFIX, 0xC0 | 17, 0xC0 | 1,
+    0x5f, 0x28, 0x0a, 'b', 'y', 't', 'e', 's', '=', '1', '-', '1', '0'
+};
+
 #define FILE_10Z '0', '0', '0', '0', '0', '0', '0', '0', '0', '0'
 #define FILE_50Z FILE_10Z , FILE_10Z , FILE_10Z , FILE_10Z , FILE_10Z
 #define FILE_100Z  FILE_50Z , FILE_50Z
@@ -706,6 +711,7 @@ static uint8_t qpack_test_string_zzz[] = { 'Z', 'Z', 'Z' };
 static uint8_t qpack_test_string_1234[] = { '/', '1', '2', '3', '4' };
 static uint8_t qpack_test_string_long[] = { '/', FILE_NAME_LONG };
 static uint8_t qpack_test_string_wtp[] = { CONNECT_TEST_PROTOCOL_PATH };
+static uint8_t qpack_test_range_text[] = { 'b', 'y', 't', 'e', 's', '=', '1', '-', '1', '0' };
 
 typedef struct st_qpack_test_case_t {
     uint8_t * bytes;
@@ -716,85 +722,91 @@ typedef struct st_qpack_test_case_t {
 static qpack_test_case_t qpack_test_case[] = {
     {
         qpack_test_get_slash, sizeof(qpack_test_get_slash),
-        { h3zero_method_get, qpack_test_string_slash, 1, 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_slash_null, sizeof(qpack_test_get_slash_null),
-        { h3zero_method_get, qpack_test_string_slash, 1, 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_slash_prefix, sizeof(qpack_test_get_slash_prefix),
-        { h3zero_method_get, qpack_test_string_slash, 1, 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_index_html, sizeof(qpack_test_get_index_html),
-        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_index_html_long, sizeof(qpack_test_get_index_html_long),
-        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_status_404, sizeof(qpack_test_status_404),
-        { 0, NULL, 0, 404, 0, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0}
     },
     {
         qpack_test_status_404_code, sizeof(qpack_test_status_404_code),
-        { 0, NULL, 0, 404, 0, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0}
     },
     {
         qpack_test_status_404_long, sizeof(qpack_test_status_404_long),
-        { 0, NULL, 0, 404, 0, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0}
     },
     {
         qpack_test_response_html, sizeof(qpack_test_response_html),
-        { 0, NULL, 0, 200, h3zero_content_type_text_html, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 200, h3zero_content_type_text_html, NULL, 0}
     },
     {
         qpack_test_status_405_code, sizeof(qpack_test_status_405_code),
-        { 0, NULL, 0, 405, 0, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 405, 0, NULL, 0}
     },
     {
         qpack_test_status_405_null, sizeof(qpack_test_status_405_null),
-        { 0, NULL, 0, 405, 0, NULL, 0}
+        { 0, NULL, 0, NULL, 0, 405, 0, NULL, 0}
     },
     {
         qpack_test_get_zzz, sizeof(qpack_test_get_zzz),
-        { h3zero_method_get, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_1234, sizeof(qpack_test_get_1234),
-        { h3zero_method_get, qpack_test_string_1234, sizeof(qpack_test_string_1234), 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_1234, sizeof(qpack_test_string_1234), NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_ats, sizeof(qpack_test_get_ats),
-        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_get_ats2, sizeof(qpack_test_get_ats2),
-        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_test_post_zzz, sizeof(qpack_test_post_zzz),
-        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), 0, h3zero_content_type_text_plain, NULL, 0}
+        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0}
     },
     {
         qpack_test_post_zzz_null, sizeof(qpack_test_post_zzz_null),
-        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), 0, h3zero_content_type_text_plain, NULL, 0}
+        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0}
     },
     {
         qpack_status200_akamai, sizeof(qpack_status200_akamai),
-        { h3zero_method_none, NULL, 0, 200, h3zero_content_type_not_supported, NULL, 0}
+        { h3zero_method_none, NULL, 0, NULL, 0, 200, h3zero_content_type_not_supported, NULL, 0}
     },
     {
         qpack_get_long_file_name, sizeof(qpack_get_long_file_name),
-        { h3zero_method_get, qpack_test_string_long, sizeof(qpack_test_string_long), 0, 0, NULL, 0}
+        { h3zero_method_get, qpack_test_string_long, sizeof(qpack_test_string_long), NULL, 0, 0, 0, NULL, 0}
     },
     {
         qpack_connect_webtransport, sizeof(qpack_connect_webtransport),
-        { h3zero_method_connect, qpack_test_string_wtp, sizeof(qpack_test_string_wtp), 0, 0,
+        { h3zero_method_connect, qpack_test_string_wtp, sizeof(qpack_test_string_wtp), NULL, 0, 0, 0,
         (uint8_t *)web_transport_str, CONNECT_TEST_PROTOCOL_WTP_LEN}
-    }
+    },
+    {
+        qpack_test_get_slash_range, sizeof(qpack_test_get_slash_range),
+        { h3zero_method_get, qpack_test_string_slash, 1,
+        qpack_test_range_text, sizeof(qpack_test_range_text),
+        0, 0, NULL, 0}
+    },
 };
 
 static size_t nb_qpack_test_case = sizeof(qpack_test_case) / sizeof(qpack_test_case_t);
@@ -834,6 +846,18 @@ static int h3zero_parse_qpack_test_one(size_t i, uint8_t * data, size_t data_len
     else if (parts.path != NULL && parts.path_length > 0 &&
         memcmp(parts.path, qpack_test_case[i].parts.path, parts.path_length) != 0) {
         DBG_PRINTF("Qpack case %d parse wrong path", i);
+        ret = -1;
+    } else if (parts.range_length != qpack_test_case[i].parts.range_length) {
+        DBG_PRINTF("Qpack case %d parse wrong range length", i);
+        ret = -1;
+    }
+    else if (parts.range == NULL && qpack_test_case[i].parts.range_length > 0) {
+        DBG_PRINTF("Qpack case %d parse range not null", i);
+        ret = -1;
+    }
+    else if (parts.range_length > 0 &&
+        memcmp(parts.range, qpack_test_case[i].parts.range, parts.range_length) != 0) {
+        DBG_PRINTF("Qpack case %d parse wrong range", i);
         ret = -1;
     }
     else if (parts.status != qpack_test_case[i].parts.status) {
@@ -885,7 +909,7 @@ int h3zero_parse_qpack_test()
 int h3zero_prepare_qpack_test()
 {
     int ret = 0;
-    int qpack_compare_test[] = { 0, 2, 4, 7, 8, 13, -1 };
+    int qpack_compare_test[] = { 0, 2, 4, 7, 8, 13, 20, -1 };
     
     for (int i = 0; ret == 0 && qpack_compare_test[i] >= 0; i++) {
         uint8_t buffer[256];
@@ -897,8 +921,10 @@ int h3zero_prepare_qpack_test()
             if (qpack_test_case[j].parts.method == h3zero_method_get)
             {
                 /* Create a request header */
-                bytes = h3zero_create_request_header_frame(buffer, bytes_max,
-                    qpack_test_case[j].parts.path, qpack_test_case[j].parts.path_length, "example.com");
+                bytes = h3zero_create_request_header_frame_ex(buffer, bytes_max,
+                    qpack_test_case[j].parts.path, qpack_test_case[j].parts.path_length,
+                    qpack_test_case[j].parts.range, qpack_test_case[j].parts.range_length,
+                    "example.com", NULL);
             }
             else  if (qpack_test_case[j].parts.method == h3zero_method_post)
             {
@@ -1418,6 +1444,18 @@ int parse_demo_scenario_test_one(const char * text, picoquic_demo_stream_desc_t 
                     ret = -1;
                 }
                 else if (desc[i].post_size !=  desc_ref[i].post_size) {
+                    ret = -1;
+                }
+                else if (desc[i].range == NULL &&
+                    desc_ref[i].range != NULL) {
+                    ret = -1;
+                }
+                else if (desc[i].range != NULL &&
+                    desc_ref[i].range == NULL) {
+                    ret = -1;
+                }
+                else if (desc[i].range != NULL &&
+                    strcmp(desc[i].range, desc_ref[i].range) != 0) {
                     ret = -1;
                 }
             }
@@ -2342,6 +2380,7 @@ int h3_long_file_name_test()
         scenario_line.doc_name = doc_name_var;
         scenario_line.f_name = file_name_var;
         scenario_line.post_size = 0;
+        scenario_line.range = NULL;
 
         ret = demo_server_test(PICOHTTP_ALPN_H3_LATEST, h3zero_callback, NULL, &scenario_line, 1,
             long_file_name_stream_length, 0, 0, 400000, 0, NULL, NULL, NULL, 0);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1333,39 +1333,45 @@ int h3zero_stream_test()
  */
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc1[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0},
-    { 0, 4, 0, "test.html", "test.html", 0 },
-    { 0, 8, 0, "main.jpg", "main.jpg", 0 },
-    { 0, 12, 0, "/bla/bla/", "_bla_bla_", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, NULL},
+    { 0, 4, 0, "test.html", "test.html", 0, NULL },
+    { 0, 8, 0, "main.jpg", "main.jpg", 0, NULL },
+    { 0, 12, 0, "/bla/bla/", "_bla_bla_", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc2[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 },
-    { 0, 4, 0, "main.jpg", "main.jpg", 0 },
-    { 0, 8, 4, "test.html", "test.html", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, NULL },
+    { 0, 4, 0, "main.jpg", "main.jpg", 0, NULL },
+    { 0, 8, 4, "test.html", "test.html", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc3[] = {
-    { 1000, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0 }
+    { 1000, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/", "_", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc4[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/cgi-sink", "_cgi-sink", 1000000 },
-    { 0, 4, 0, "/", "_", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/cgi-sink", "_cgi-sink", 1000000, NULL },
+    { 0, 4, 0, "/", "_", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc5[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/32", "_32", 0 },
-    { 0, 4, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/33", "_33", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/32", "_32", 0, NULL },
+    { 0, 4, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/33", "_33", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc6[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/200000000000", "_200000000000", 0 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/200000000000", "_200000000000", 0, NULL }
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc7[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/cgi-sink", "_cgi-sink", 100000000000 }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "/cgi-sink", "_cgi-sink", 100000000000, NULL }
 };
+
+static picoquic_demo_stream_desc_t const parse_demo_scenario_desc8[] = {
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "test.html", "test.html", 0, "#bytes=80-800"},
+    { 0, 4, 0, "/cgi-sink", "_cgi-sink", 10000, "#bytes=100-1000" }
+};
+
 
 typedef struct st_demo_scenario_test_case_t {
     char const* text;
@@ -1380,7 +1386,8 @@ static const demo_scenario_test_case_t demo_scenario_test_cases[] = {
     { "/cgi-sink:1000000;4:/", parse_demo_scenario_desc4, sizeof(parse_demo_scenario_desc4) / sizeof(picoquic_demo_stream_desc_t) },
     { "-:/32;-:/33", parse_demo_scenario_desc5, sizeof(parse_demo_scenario_desc5) / sizeof(picoquic_demo_stream_desc_t) },
     { "-:/200000000000", parse_demo_scenario_desc6, sizeof(parse_demo_scenario_desc6) / sizeof(picoquic_demo_stream_desc_t) },
-    { "/cgi-sink:100000000000", parse_demo_scenario_desc7, sizeof(parse_demo_scenario_desc7) / sizeof(picoquic_demo_stream_desc_t) }
+    { "/cgi-sink:100000000000", parse_demo_scenario_desc7, sizeof(parse_demo_scenario_desc7) / sizeof(picoquic_demo_stream_desc_t) },
+    { "test.html:#bytes=80-800;/cgi-sink:10000:#bytes=100-1000;", parse_demo_scenario_desc8, sizeof(parse_demo_scenario_desc8) / sizeof(picoquic_demo_stream_desc_t) }
 };
 
 static size_t nb_demo_scenario_test_cases = sizeof(demo_scenario_test_cases) / sizeof(demo_scenario_test_case_t);

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1394,8 +1394,8 @@ static picoquic_demo_stream_desc_t const parse_demo_scenario_desc7[] = {
 };
 
 static picoquic_demo_stream_desc_t const parse_demo_scenario_desc8[] = {
-    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "test.html", "test.html", 0, "#bytes=80-800"},
-    { 0, 4, 0, "/cgi-sink", "_cgi-sink", 10000, "#bytes=100-1000" }
+    { 0, 0, PICOQUIC_DEMO_STREAM_ID_INITIAL, "test.html", "test.html", 0, "bytes=80-800"},
+    { 0, 4, 0, "/cgi-sink", "_cgi-sink", 10000, "bytes=100-1000" }
 };
 
 

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -1029,12 +1029,12 @@ int h3zero_user_agent_test_one(int test_mode, char const * ua_string, uint8_t * 
     switch (test_mode) {
     case 0:
         bytes = h3zero_create_request_header_frame_ex(buffer, bytes_max,
-            (uint8_t*)"/", 1, "example.com", ua_string);
+            (uint8_t*)"/", 1, NULL, 0, "example.com", ua_string);
         break;
     case 1:
         bytes = h3zero_create_post_header_frame_ex(buffer, bytes_max,
             (uint8_t *)h3zero_test_ua_post_path, strlen(h3zero_test_ua_post_path),
-            "example.com", h3zero_content_type_text_plain, ua_string);
+            NULL, 0, "example.com", h3zero_content_type_text_plain, ua_string);
         break;
     case 2:
         bytes = h3zero_create_not_found_header_frame_ex(buffer, bytes_max, ua_string);


### PR DESCRIPTION
Adding an option to encode a range in GET and POST requests.

This is motivated by issue #1702, but the implementation differs somewhat: the new "range" and "range_length" arguments are only added to the "extended" methods `h3zero_create_request_header_frame_ex` and `h3zero_create_post_header_frame_ex`, so as to minimize the churn in existing projects. No support in the "connect" method, because range does not make sense there. Or does it?

This implementation is insufficient. At a minimum, we need unit tests for the frame creation APIs. But it would be better to have a way to exercise the option. Maybe allow "document" arguments in the "picoquicdemo" app to include a range, as in:
~~~
picoquicdemo test.privateoctopus.com 4433 /something#1000-50000
~~~
Then, split the argument into path and range components.

But really, for a complete implementation, we should make sure that the demo server supports the range request, and only returns the requested range. At list for requests, maybe for "post" too, but we need to understand what "range" means for a post.