### PR TITLE
Add immediate path delete test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.21.6
+        VERSION 1.1.21.7
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2471,6 +2471,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(multipath_ab1) {
+            int ret = multipath_ab1_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(multipath_sat_plus) {
             int ret = multipath_sat_plus_test();
 

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2043,7 +2043,7 @@ int picoquic_find_incoming_unique_path(picoquic_cnx_t* cnx, picoquic_packet_head
          */
         if (cnx->nb_paths < PICOQUIC_NB_PATH_TARGET &&
             (cnx->quic->is_port_blocking_disabled || !picoquic_check_addr_blocked(addr_from)) &&
-            picoquic_create_path(cnx, current_time, addr_to, addr_from) > 0) {
+            picoquic_create_path(cnx, current_time, addr_to, addr_from, ph->l_cid->path_id) > 0) {
             /* if we do create a new path, it should have the right path_id. We cannot
             * assume that paths will be created in the full order, so that means we may
             * have to create "empty" paths in invalid state. Or, more simply,
@@ -2178,7 +2178,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header* ph,
 
         if (cnx->nb_paths < PICOQUIC_NB_PATH_TARGET &&
             (cnx->quic->is_port_blocking_disabled || !picoquic_check_addr_blocked(addr_from)) &&
-            picoquic_create_path(cnx, current_time, addr_to, addr_from) > 0) {
+            picoquic_create_path(cnx, current_time, addr_to, addr_from, UINT64_MAX) > 0) {
             /* The peer is probing for a new path, or there was a path rebinding */
             path_id = cnx->nb_paths - 1;
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.21.6"
+#define PICOQUIC_VERSION "1.1.21.7"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -858,7 +858,8 @@ int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_
 void picoquic_enable_path_callbacks(picoquic_cnx_t* cnx, int are_enabled);
 void picoquic_enable_path_callbacks_default(picoquic_quic_t* quic, int are_enabled);
 int picoquic_set_app_path_ctx(picoquic_cnx_t* cnx, uint64_t unique_path_id, void * app_path_ctx);
-int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id, uint64_t reason, char const* phrase);
+int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id, 
+    uint64_t reason, char const* phrase, uint64_t current_time);
 int picoquic_refresh_path_connection_id(picoquic_cnx_t* cnx, uint64_t unique_path_id);
 int picoquic_set_stream_path_affinity(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t unique_path_id);
 int picoquic_set_path_status(picoquic_cnx_t* cnx, uint64_t unique_path_id, picoquic_path_status_enum status);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1472,9 +1472,35 @@ void picoquic_create_local_cnx_id(picoquic_quic_t* quic, picoquic_connection_id_
     }
 }
 
-/* Path management -- returns the index of the path that was created. */
+uint64_t picoquic_find_avalaible_unique_path_id(picoquic_cnx_t* cnx, uint64_t requested_id)
+{
+    uint64_t unique_path_id = requested_id;
 
-int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, const struct sockaddr* local_addr, const struct sockaddr* peer_addr)
+    if (requested_id == UINT64_MAX) {
+        if (!cnx->is_multipath_enabled) {
+            unique_path_id = cnx->unique_path_id_next;
+            cnx->unique_path_id_next++;
+        }
+        else {
+            /* Look at available stashes. exlcude stash if id=0, as this is the
+             * always used.
+             */
+            picoquic_remote_cnxid_stash_t* stash = cnx->first_remote_cnxid_stash;
+
+            while (stash != NULL && (stash->is_in_use || stash->unique_path_id == 0)){
+                stash = stash->next_stash;
+            }
+            if (stash != NULL) {
+                unique_path_id = stash->unique_path_id;
+            }
+        }
+    }
+    return unique_path_id;
+}
+
+/* Path management -- returns the index of the path that was created. */
+int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, const struct sockaddr* local_addr,
+    const struct sockaddr* peer_addr, uint64_t requested_id)
 {
     int ret = -1;
 
@@ -1501,14 +1527,15 @@ int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, const struct 
 
     if (cnx->nb_paths < cnx->nb_path_alloc)
     {
-        picoquic_path_t * path_x = (picoquic_path_t *)malloc(sizeof(picoquic_path_t));
+        uint64_t unique_path_id = picoquic_find_avalaible_unique_path_id(cnx, requested_id);
+        picoquic_path_t * path_x = (unique_path_id == UINT64_MAX)?NULL:
+            (picoquic_path_t *)malloc(sizeof(picoquic_path_t));
 
         if (path_x != NULL)
         {
             memset(path_x, 0, sizeof(picoquic_path_t));
             /* Register the sequence number */
-            path_x->unique_path_id = cnx->unique_path_id_next;
-            cnx->unique_path_id_next++;
+            path_x->unique_path_id = unique_path_id;
             path_x->cnx = cnx;
 
             /* Set the addresses */
@@ -1837,16 +1864,8 @@ void picoquic_demote_path(picoquic_cnx_t* cnx, int path_index, uint64_t current_
                     cnx->path[path_index]->unique_path_id, reason);
             }
             else if (!cnx->path[path_index]->path_abandon_sent) {
-                uint8_t buffer[512];
-                uint8_t* end_bytes;
-                int more_data = 0;
                 uint64_t path_id = cnx->path[path_index]->unique_path_id;
-                end_bytes = picoquic_format_path_abandon_frame(buffer, buffer + sizeof(buffer), &more_data,
-                    path_id, reason, phrase);
-                if (end_bytes != NULL && picoquic_queue_misc_frame(cnx, buffer, end_bytes - buffer, 0) == 0) {
-                    /* At this point, all the connection ID associated with the path
-                     * by the peer should be automatically removed, because otherwise there is a
-                     * risk of processing a stateless reset */
+                if (picoquic_queue_path_abandon_frame(cnx, path_id, reason, phrase) == 0){
                     picoquic_remote_cnxid_stash_t* remote_cnxid_stash = 
                         picoquic_find_or_create_remote_cnxid_stash(cnx, 
                             cnx->path[path_index]->unique_path_id, 0);
@@ -2085,16 +2104,21 @@ void picoquic_notify_destination_unreachable_by_cnxid(picoquic_quic_t * quic, pi
 
 
 /* Assign CID to path */
-int picoquic_assign_peer_cnxid_to_path(picoquic_cnx_t* cnx, int path_id)
+int picoquic_assign_peer_cnxid_to_path(picoquic_cnx_t* cnx, int path_index)
 {
     int ret = -1;
-    uint64_t unique_path_id = (cnx->is_multipath_enabled) ? cnx->path[path_id]->unique_path_id : 0;
-    picoquic_remote_cnxid_t* available_cnxid = picoquic_obtain_stashed_cnxid(cnx, unique_path_id);
+    uint64_t unique_path_id = (cnx->is_multipath_enabled) ? cnx->path[path_index]->unique_path_id : 0;
+    picoquic_remote_cnxid_stash_t* stash = picoquic_find_or_create_remote_cnxid_stash(cnx, unique_path_id, 0);
+    
+    if (stash != NULL) {
+        picoquic_remote_cnxid_t* available_cnxid = picoquic_get_cnxid_from_stash(stash);
 
-    if (available_cnxid != NULL) {
-        cnx->path[path_id]->p_remote_cnxid = available_cnxid;
-        available_cnxid->nb_path_references++;
-        ret = 0;
+        if (available_cnxid != NULL) {
+            cnx->path[path_index]->p_remote_cnxid = available_cnxid;
+            available_cnxid->nb_path_references++;
+            stash->is_in_use = 1;
+            ret = 0;
+        }
     }
 
     return ret;
@@ -2130,7 +2154,7 @@ int picoquic_probe_new_path_ex(picoquic_cnx_t* cnx, const struct sockaddr* addr_
         /* Too many paths created already */
         ret = -1;
     }
-    else if (picoquic_create_path(cnx, current_time, addr_local, addr_peer) > 0) {
+    else if (picoquic_create_path(cnx, current_time, addr_local, addr_peer, UINT64_MAX) > 0) {
         path_id = cnx->nb_paths - 1;
         ret = picoquic_assign_peer_cnxid_to_path(cnx, path_id);
 
@@ -2194,22 +2218,70 @@ int picoquic_probe_new_path(picoquic_cnx_t* cnx, const struct sockaddr* addr_pee
     return picoquic_probe_new_path_ex(cnx, addr_peer, addr_local, 0, current_time, 0);
 }
 
-/* TODO: the "unique_path_id" should really be a unique ID, managed by the stack.
- */
-int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id, uint64_t reason, char const * phrase)
+int picoquic_demote_local_cnxid_list(picoquic_cnx_t* cnx, uint64_t unique_path_id,
+    uint64_t reason, char const* phrase, uint64_t current_time)
 {
     int ret = 0;
-    int path_index = picoquic_get_path_id_from_unique(cnx, unique_path_id);
+    picoquic_local_cnxid_list_t* local_cnxid_list =
+        picoquic_find_or_create_local_cnxid_list(cnx, unique_path_id, 0);
 
-    if (path_index < 0 || path_index >= cnx->nb_paths || cnx->nb_paths == 1 || !cnx->is_multipath_enabled){
+    if (local_cnxid_list != NULL &&
+        !local_cnxid_list->is_demoted) {
+        if ((ret = picoquic_queue_path_abandon_frame(cnx, unique_path_id, reason, phrase)) == 0) {
+            picoquic_remote_cnxid_stash_t* remote_cnxid_stash =
+                picoquic_find_or_create_remote_cnxid_stash(cnx, unique_path_id, 0);
+            if (remote_cnxid_stash != NULL) {
+                picoquic_delete_remote_cnxid_stash(cnx, remote_cnxid_stash);
+            }
+            local_cnxid_list->is_demoted = 1;
+        }
+        else {
+            DBG_PRINTF("Cannot abandon path %" PRIu64, unique_path_id);
+        }
+    }
+    return ret;
+}
+
+
+int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id, 
+    uint64_t reason, char const * phrase, uint64_t current_time)
+{
+    int ret = 0;
+
+    if (!cnx->is_multipath_enabled) {
         ret = -1;
     }
-    else if (!cnx->path[path_index]->path_is_demoted) {
-        /* if demotion is not already in progress, demote the path,
-         * and if the path can be properly identified, post a path abandon frame.
-         */
+    else if (unique_path_id > cnx->max_path_id_remote ||
+        unique_path_id > cnx->max_path_id_local) {
+        /* that path has not been created yet */
+        ret = -1;
+    }
+    else {
+        /* Check whether there is a path by that ID */
+        int path_index = picoquic_get_path_id_from_unique(cnx, unique_path_id);
 
-        picoquic_demote_path(cnx, path_index, picoquic_get_quic_time(cnx->quic), 0, NULL);
+        if (path_index >= 0) {
+            /* Check whether this is the last path */
+            if (cnx->nb_paths <= 1) {
+                /* That would mean deleting the last path. Don't do that */
+                ret = -1;
+            }
+            else if (!cnx->path[path_index]->path_is_demoted) {
+                /* if demotion is not already in progress, demote the path,
+                * and if the path can be properly identified, post a path abandon frame.
+                */
+                picoquic_demote_path(cnx, path_index, current_time, reason, phrase);
+            }
+        }
+        else {
+            /* The path ID is not in use yet, but local cid have been allocated.
+             * We need to send an abandon if not sent yet, mark the local CID
+             * as demoted, and delete the stash. The stash has to remain deleted
+             * even if we receive new CID for that path.
+             */
+            ret = picoquic_demote_local_cnxid_list(cnx, unique_path_id,
+                reason, phrase, current_time);
+        }
     }
 
     return ret;
@@ -3646,7 +3718,7 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
         picoquic_queue_data_repeat_init(cnx);
 
         /* Initialize the connection ID stash */
-        ret = picoquic_create_path(cnx, start_time, NULL, addr_to);
+        ret = picoquic_create_path(cnx, start_time, NULL, addr_to, 0);
         if (ret == 0) {
             /* Should return 0, since this is the first path */
             ret = picoquic_init_cnxid_stash(cnx);

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -439,6 +439,7 @@ static const picoquic_test_def_t test_table[] = {
     { "multipath_drop_first", multipath_drop_first_test },
     { "multipath_drop_second", multipath_drop_second_test },
     { "multipath_fail", multipath_fail_test },
+    { "multipath_ab1", multipath_ab1_test },
     { "multipath_sat_plus", multipath_sat_plus_test },
     { "multipath_renew", multipath_renew_test },
     { "multipath_rotation", multipath_rotation_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -432,6 +432,7 @@ int monopath_0rtt_loss_test();
 int multipath_aead_test();
 int multipath_basic_test();
 int multipath_fail_test();
+int multipath_ab1_test();
 int multipath_drop_first_test();
 int multipath_drop_second_test();
 int multipath_sat_plus_test();


### PR DESCRIPTION
Add a multipath test of "path" deletion before the path is actually created. This tests cases when a party wants to just remove a set of connection identifiers allocated to a path. It forces clarity in handling of "unique path identifiers" and lists of allocated or received connection identifiers.