### PR TITLE
Option to control SSLKEYLOG

### DIFF
--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -95,79 +95,13 @@ static option_table_line_t option_table[] = {
     { picoquic_option_No_GSO, '0', "no_gso", 0, "", "Do not use UDP GSO or equivalent" },
     { picoquic_option_BDP_frame, 'j', "bdp", 1, "number", "use bdp extension frame(1) or don\'t (0). Default=0" },
     { picoquic_option_CWIN_MAX, 'W', "cwin_max", 1, "bytes", "Max value for CWIN. Default=UINT64_MAX"},
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    { picoquic_option_SSLKEYLOG, '8', "sslkeylog", 0, "", "Enable SSLKEYLOG" },
+#endif
     { picoquic_option_HELP, 'h', "help", 0, "", "This help message" }
 };
 
 static size_t option_table_size = sizeof(option_table) / sizeof(option_table_line_t);
-
-#if 0
-/* Not in use and not tests. Reevaluate if we use files of parameters */
-static int skip_spaces(const char* line, int offset)
-{
-    int c;
-
-    while ((c = line[offset]) != 0) {
-        if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
-            offset++;
-        }
-        else {
-            break;
-        }
-    }
-    return offset;
-}
-
-static int skip_name(const char* line, int offset)
-{
-    int c;
-
-    while ((c = line[offset]) != 0) {
-        if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == ':' || c == '#') {
-            break;
-        }
-        else {
-            offset++;
-        }
-    }
-    return offset;
-}
-
-static int parse_line_params(const char* line, int offset, option_param_t* params, int params_max, int* nb_params)
-{
-    int nb_found = 0;
-
-    offset = skip_spaces(line, offset);
-    if (line[offset] == ':') {
-        while (nb_found < params_max) {
-            int offset_start;
-            offset_start = skip_spaces(line, offset);
-            offset = skip_name(line, offset);
-            if (offset == offset_start) {
-                /* Nothing there. */
-                break;
-            }
-            else {
-                params[nb_found].param = line + offset_start;
-                params[nb_found].length = offset - offset_start;
-                nb_found++;
-            }
-        }
-    }
-    *nb_params = nb_found;
-    return offset;
-}
-
-static int compare_option_name(const char * line, int offset, size_t length, char const* option_name)
-{
-    int ret = -1;
-    
-    if (length == strlen(option_name)) {
-        ret = strncmp(option_name, line + offset, length);
-    }
-
-    return ret;
-}
-#endif
 
 static uint32_t config_parse_target_version(char const* v_arg)
 {
@@ -345,6 +279,11 @@ static int config_set_option(option_table_line_t* option_desc, option_param_t* p
     case picoquic_option_DisablePortBlocking:
         config->disable_port_blocking = 1;
         break;
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    case picoquic_option_SSLKEYLOG:
+        config->enable_sslkeylog = 1;
+        break;
+#endif
     case picoquic_option_SOLUTION_DIR:
         ret = config_set_string_param(&config->solution_dir, params, nb_params, 0);
         break;
@@ -814,6 +753,10 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
         picoquic_set_preemptive_repeat_policy(quic, config->do_preemptive_repeat);
 
         picoquic_disable_port_blocking(quic, config->disable_port_blocking);
+
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+        picoquic_enable_sslkeylog(quic, config->enable_sslkeylog);
+#endif
 
         if (config->initial_random >= 0 && config->initial_random <= 2) {
             picoquic_set_random_initial(quic, config->initial_random);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -421,6 +421,28 @@ void picoquic_set_log_level(picoquic_quic_t* quic, int log_level);
  */
 void picoquic_use_unique_log_names(picoquic_quic_t* quic, int use_unique_log_names);
 
+/* The SSLKEYLOG function defines a way to publish the encryption keys
+* used by QUIC. If that feature is enabled, the code read the environment
+* variable SSLKEYLOG to find the path of the file where to log the encryption
+* file. If the environment variable is not present, no file is set.
+* 
+* This is a very dangerous feature, that can be abused to break encryption.
+* Using an environment variable may be a fine way to specify on which file
+* copies of keys have to be written, but it is a terrible way to specify
+* whether these keys should be. Environment variables can be installed by
+* scripts, etc., and there are many ways of doing that without user awareness.
+* 
+* This feature is enabled by setting the "SSLKEYLOG" option (option -8 if
+* using the "config" module in the application), or by calling
+* the "picoquic_enable_sslkeylog" API. This setting is "off" by default.
+* The SSLKEYLOG feature will be disabled, whatever the
+* setting, on builds of picoquic that are compiled with the macro
+* "PICOQUIC_WITHOUT_SSLKEYLOG" defined (e.g., set CFLAGS=-DPICOQUIC_WITHOUT_SSLKEYLOG).
+*/
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+void picoquic_enable_sslkeylog(picoquic_quic_t* quic, int enable_sslkeylog);
+int picoquic_is_sslkeylog_enabled(picoquic_quic_t* quic);
+#endif
 /* 
  * picoquic_set_random_initial:
  * randomization of initial PN numbers, i.e.. the number assigned to

--- a/picoquic/picoquic_config.h
+++ b/picoquic/picoquic_config.h
@@ -72,6 +72,7 @@ typedef enum {
     picoquic_option_No_GSO,
     picoquic_option_BDP_frame,
     picoquic_option_CWIN_MAX,
+    picoquic_option_SSLKEYLOG,
     picoquic_option_HELP
 }  picoquic_option_enum_t;
 
@@ -106,6 +107,9 @@ typedef struct st_picoquic_quic_config_t {
     unsigned int do_preemptive_repeat : 1;
     unsigned int do_not_use_gso : 1;
     unsigned int disable_port_blocking : 1;
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    unsigned int enable_sslkeylog : 1;
+#endif
     /* Server only */
     char const* www_dir;
     uint8_t reset_seed[16];

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -654,6 +654,7 @@ typedef struct st_picoquic_quic_t {
     unsigned int is_cert_store_not_empty : 1;
     unsigned int use_long_log : 1;
     unsigned int should_close_log : 1;
+    unsigned int enable_sslkeylog : 1; /* Enable the SSLKEYLOG feature */
     unsigned int use_unique_log_names : 1; /* Add 64 bit random number to log names for uniqueness */
     unsigned int dont_coalesce_init : 1; /* test option to turn of packet coalescing on server */
     unsigned int one_way_grease_quic_bit : 1; /* Grease of QUIC bit, but do not announce support */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -4191,6 +4191,18 @@ void picoquic_use_unique_log_names(picoquic_quic_t* quic, int use_unique_log_nam
     quic->use_unique_log_names = use_unique_log_names;
 }
 
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+void picoquic_enable_sslkeylog(picoquic_quic_t* quic, int enable_sslkeylog)
+{
+    quic->enable_sslkeylog = (enable_sslkeylog != 0);
+}
+
+int picoquic_is_sslkeylog_enabled(picoquic_quic_t* quic)
+{
+    return quic->enable_sslkeylog;
+}
+#endif
+
 void picoquic_set_random_initial(picoquic_quic_t* quic, int random_initial)
 {
     /* If set, triggers randomization of initial PN numbers. */

--- a/picoquictest/config_test.c
+++ b/picoquictest/config_test.c
@@ -27,8 +27,11 @@
 #include "picoquic_config.h"
 #include "picoquictest_internal.h"
 
+#ifdef PICOQUIC_WITHOUT_SSLKEYLOG
 static char* ref_option_text = "c:k:p:v:o:w:x:rR:s:XS:G:P:O:Me:C:i:l:Lb:q:m:n:a:t:zI:d:DQT:N:B:F:VU:0j:W:h";
-
+#else
+static char* ref_option_text = "c:k:p:v:o:w:x:rR:s:XS:G:P:O:Me:C:i:l:Lb:q:m:n:a:t:zI:d:DQT:N:B:F:VU:0j:W:8h";
+#endif
 int config_option_letters_test()
 {
     char option_text[256];
@@ -76,6 +79,9 @@ static picoquic_quic_config_t param1 = {
     1, /* unsigned int do_preemptive_repeat : 1; */
     1, /* unsigned int do_not_use_gso : 1 */
     0, /* disable port blocking */
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    0,
+#endif
     /* Server only */
     "/data/www/", /* char const* www_dir; */
     { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
@@ -158,6 +164,9 @@ static picoquic_quic_config_t param2 = {
     0, /* unsigned int do_preemptive_repeat : 1; */
     0, /* unsigned int do_not_use_gso : 1 */
     1, /* disable port blocking */
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    1,
+#endif
     /* Server only */
     NULL, /* char const* www_dir; */
     { 0 }, /* Reset seed */
@@ -193,6 +202,9 @@ static const char* config_argv2[] = {
     "-D",
     "-Q",
     "-X",
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    "-8",
+#endif
     "-I", "5",
     "-T", "/data/tickets.bin",
     "-N", "/data/tokens.bin",
@@ -238,7 +250,10 @@ static config_error_test_t config_errors[] = {
     { 2, { "-I", "255" }},
     { 2, { "-U", "XY000002" }},
     { 2, { "-W", "cwin" }},
-    { 2, { "-d", "idle" }}
+    { 2, { "-d", "idle" }},
+#ifdef PICOQUIC_WITHOUT_SSLKEYLOG
+    { 1, {"-8"}},
+#endif
 };
 
 static size_t nb_config_errors = sizeof(config_errors) / sizeof(config_error_test_t);
@@ -340,6 +355,10 @@ int config_test_compare(const picoquic_quic_config_t* expected, const picoquic_q
     ret |= config_test_compare_int("bdp", expected->bdp_frame_option, actual->bdp_frame_option);
     ret |= config_test_compare_int("idle_timeout", expected->idle_timeout, actual->idle_timeout);
     ret |= config_test_compare_uint64("cwin_max", expected->cwin_max, actual->cwin_max);
+#ifndef PICOQUIC_WITHOUT_SSLKEYLOG
+    ret |= config_test_compare_int("sslkeylog", expected->enable_sslkeylog, actual->enable_sslkeylog);
+#endif
+    
     return ret;
 }
 

--- a/picoquictest/config_usage_ref.txt
+++ b/picoquictest/config_usage_ref.txt
@@ -40,4 +40,5 @@ Picoquic options:
   -0              Do not use UDP GSO or equivalent
   -j number       use bdp extension frame(1) or don't (0). Default=0
   -W bytes        Max value for CWIN. Default=UINT64_MAX
+  -8              Enable SSLKEYLOG
   -h              This help message


### PR DESCRIPTION
Discussions on the TLS mailing lists pointed out the dangers of the SSLKEYLOG feature: if some script could manages to publish an environment variable that is accessible from a client account, and then all encrypted communication could be decrypted. The PR adds a control option that will have to be set explicitly to enable the disclosure of encryption keys. It also adds a compile option to completely prevent that disclosure.