### PR TITLE
Fix the Handshake repeat bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.21.7
+        VERSION 1.1.21.8
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -621,7 +621,8 @@ int picoquic_queue_retire_connection_id_frame(picoquic_cnx_t * cnx, uint64_t uni
         &more_data, &is_pure_ack, cnx->is_multipath_enabled, unique_path_id, sequence);
     
     if ((consumed = bytes_next - frame_buffer) > 0) {
-        ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack);
+        ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack,
+            picoquic_packet_context_application);
     }
 
     return ret;
@@ -798,7 +799,8 @@ int picoquic_queue_new_token_frame(picoquic_cnx_t * cnx, uint8_t * token, size_t
     uint8_t* bytes = picoquic_format_new_token_frame(frame_buffer, frame_buffer + sizeof(frame_buffer), &more_data, &is_pure_ack, token, token_length);
 
     if (bytes > frame_buffer) {
-        ret = picoquic_queue_misc_frame(cnx, frame_buffer, bytes - frame_buffer, 1);
+        ret = picoquic_queue_misc_frame(cnx, frame_buffer, bytes - frame_buffer, 1,
+            picoquic_packet_context_application);
     }
 
     return ret;
@@ -4441,11 +4443,10 @@ int picoquic_check_max_streams_frame_needs_repeat(picoquic_cnx_t* cnx, const uin
 /* Common code for datagrams and misc frames
  */
 
-uint8_t * picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t * bytes_max, int * more_data, int * is_pure_ack,
+uint8_t * picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t * bytes_max,
+    int * more_data, int * is_pure_ack, picoquic_misc_frame_header_t* misc_frame,
     picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last)
 {
-    picoquic_misc_frame_header_t* misc_frame = *first;
-
     if (bytes + misc_frame->length > bytes_max) {
         *more_data = 1;
     } else {
@@ -4453,10 +4454,22 @@ uint8_t * picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t * bytes
         memcpy(bytes, frame, misc_frame->length);
         bytes += misc_frame->length;
         *is_pure_ack &= misc_frame->is_pure_ack;
-        picoquic_delete_misc_or_dg(first, last, *first);
+        picoquic_delete_misc_or_dg(first, last, misc_frame);
     }
 
     return bytes;
+}
+
+/* Check whether miscellaneous frames are ready in packet context
+ */
+picoquic_misc_frame_header_t* picoquic_find_first_misc_frame(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc)
+{
+    picoquic_misc_frame_header_t* misc_frame = cnx->first_misc_frame;
+
+    while (misc_frame != NULL && misc_frame->pc != pc) {
+        misc_frame = misc_frame->next_misc_frame;
+    }
+    return misc_frame;
 }
 
 /*
@@ -4465,7 +4478,33 @@ uint8_t * picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t * bytes
 
 uint8_t* picoquic_format_first_misc_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack)
 {
-    return picoquic_format_first_misc_or_dg_frame(bytes, bytes_max, more_data, is_pure_ack, &cnx->first_misc_frame, &cnx->last_misc_frame);
+    return picoquic_format_first_misc_or_dg_frame(bytes, bytes_max, more_data, is_pure_ack, cnx->first_misc_frame, &cnx->first_misc_frame, &cnx->last_misc_frame);
+}
+
+/*
+* Sending of miscellaneous frames in context
+*/
+
+uint8_t* picoquic_format_misc_frames_in_context(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max,
+    int* more_data, int* is_pure_ack, picoquic_packet_context_enum pc)
+{
+    picoquic_misc_frame_header_t* misc_frame;
+    /* If present, send misc frame */
+    while ((misc_frame = picoquic_find_first_misc_frame(cnx, pc)) != NULL) {
+        uint8_t* bytes_misc = bytes;
+        int frame_is_pure_ack = misc_frame->is_pure_ack;
+
+        bytes = picoquic_format_first_misc_or_dg_frame(bytes, bytes_max, more_data, is_pure_ack,
+            misc_frame, &cnx->first_misc_frame, &cnx->last_misc_frame);
+        if (bytes <= bytes_misc) {
+            break;
+        }
+        else {
+            *is_pure_ack &= frame_is_pure_ack;
+        }
+    }
+
+    return bytes;
 }
 
 /*
@@ -4727,7 +4766,7 @@ int picoquic_queue_handshake_done_frame(picoquic_cnx_t* cnx)
     uint8_t frame_buffer = picoquic_frame_type_handshake_done;
 
     return picoquic_queue_misc_or_dg_frame(cnx, &cnx->first_datagram, &cnx->last_datagram,
-            &frame_buffer, 1, 0);
+            &frame_buffer, 1, 0, picoquic_packet_context_application);
 }
 
 /* Handling of datagram frames.
@@ -4853,7 +4892,7 @@ int picoquic_queue_datagram_frame(picoquic_cnx_t * cnx, size_t length, const uin
 
         if ((consumed = bytes_next - frame_buffer) > 0) {
             ret = picoquic_queue_misc_or_dg_frame(cnx, &cnx->first_datagram, &cnx->last_datagram,
-                frame_buffer, consumed, 0);
+                frame_buffer, consumed, 0, picoquic_packet_context_application);
         }
         else {
             ret = PICOQUIC_ERROR_FRAME_BUFFER_TOO_SMALL;
@@ -4870,7 +4909,7 @@ uint8_t * picoquic_format_first_datagram_frame(picoquic_cnx_t* cnx, uint8_t* byt
     }
     else {
         bytes = picoquic_format_first_misc_or_dg_frame(bytes, bytes_max, more_data, is_pure_ack, 
-            &cnx->first_datagram, &cnx->last_datagram);
+            cnx->first_datagram, &cnx->first_datagram, &cnx->last_datagram);
     }
 
     return bytes;
@@ -5349,7 +5388,8 @@ int picoquic_queue_path_abandon_frame(picoquic_cnx_t* cnx,
     end_bytes = picoquic_format_path_abandon_frame(buffer, buffer + sizeof(buffer), &more_data,
         unique_path_id, reason, phrase);
     if (end_bytes == NULL ||
-        picoquic_queue_misc_frame(cnx, buffer, end_bytes - buffer, 0) != 0) {
+        picoquic_queue_misc_frame(cnx, buffer, end_bytes - buffer, 0,
+            picoquic_packet_context_application) != 0) {
         /* Could not format or could not queue. Internal error. */
         ret = -1;
     }
@@ -5390,7 +5430,8 @@ int picoquic_queue_path_available_or_standby_frame(
         uint8_t* bytes_next = picoquic_format_path_available_or_standby_frame(
             frame_buffer, frame_buffer + sizeof(frame_buffer), frame_type, path_id, sequence);
         size_t consumed = bytes_next - frame_buffer;
-        ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack);
+        ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack,
+            picoquic_packet_context_application);
         if (ret == 0) {
             path_x->status_sequence_sent_last = sequence;
         }
@@ -5510,7 +5551,8 @@ int picoquic_queue_max_path_id_frame(
     uint8_t* bytes_next = picoquic_format_max_path_id_frame(
         frame_buffer, frame_buffer + sizeof(frame_buffer), cnx->max_path_id_local);
     size_t consumed = bytes_next - frame_buffer;
-    ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack);
+    ret = picoquic_queue_misc_frame(cnx, frame_buffer, consumed, is_pure_ack,
+        picoquic_packet_context_application);
     return ret;
 }
 

--- a/picoquic/loss_recovery.c
+++ b/picoquic/loss_recovery.c
@@ -751,10 +751,9 @@ int picoquic_copy_before_retransmit(picoquic_packet_t * old_p,
                         * add_to_data_repeat_queue = 1;
                     }
                     else {
-                        if ((force_queue || frame_length > send_buffer_max_minus_checksum - *length) &&
-                            (old_p->ptype == picoquic_packet_0rtt_protected ||
-                                old_p->ptype == picoquic_packet_1rtt_protected)) {
-                            ret = picoquic_queue_misc_frame(cnx, &old_p->bytes[byte_index], frame_length, 0);
+                        if ((force_queue || frame_length > send_buffer_max_minus_checksum - *length)) {
+                            ret = picoquic_queue_misc_frame(cnx, &old_p->bytes[byte_index], frame_length, 0,
+                                old_p->pc);
                         }
                         else if (frame_length <= send_buffer_max_minus_checksum - *length) {
                             memcpy(&new_bytes[*length], &old_p->bytes[byte_index], frame_length);

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.21.7"
+#define PICOQUIC_VERSION "1.1.21.8"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -173,6 +173,15 @@ typedef enum {
     picoquic_state_draining,
     picoquic_state_disconnected
 } picoquic_state_enum;
+
+/* Packet contexts */
+typedef enum {
+    picoquic_packet_context_application = 0,
+    picoquic_packet_context_handshake = 1,
+    picoquic_packet_context_initial = 2,
+    picoquic_nb_packet_context = 3
+} picoquic_packet_context_enum;
+
 
 /* PMTUD 
  */
@@ -1013,7 +1022,8 @@ picoquic_stream_data_cb_fn picoquic_get_callback_function(picoquic_cnx_t * cnx);
 void * picoquic_get_callback_context(picoquic_cnx_t* cnx);
 
 /* Send extra frames */
-int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length, int is_pure_ack);
+int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length,
+    int is_pure_ack, picoquic_packet_context_enum pc);
 
 /* Queue a datagram frame for sending later.
  * The datagram length must be no more than PICOQUIC_DATAGRAM_QUEUE_MAX_LENGTH,

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -265,13 +265,6 @@ typedef enum {
     picoquic_packet_type_max
 } picoquic_packet_type_enum;
 
-typedef enum {
-    picoquic_packet_context_application = 0,
-    picoquic_packet_context_handshake = 1,
-    picoquic_packet_context_initial = 2,
-    picoquic_nb_packet_context = 3
-} picoquic_packet_context_enum;
-
 /* Packet header structure.
  * This structure is used internally when parsing or
  * formatting the header of a Quic packet.
@@ -868,6 +861,7 @@ typedef struct st_picoquic_misc_frame_header_t {
     struct st_picoquic_misc_frame_header_t* next_misc_frame;
     struct st_picoquic_misc_frame_header_t* previous_misc_frame;
     size_t length;
+    picoquic_packet_context_enum pc;
     int is_pure_ack;
 } picoquic_misc_frame_header_t;
 
@@ -1976,9 +1970,13 @@ uint8_t* picoquic_format_blocked_frames(picoquic_cnx_t* cnx, uint8_t* bytes, uin
 int picoquic_queue_retire_connection_id_frame(picoquic_cnx_t * cnx, uint64_t unique_path_id, uint64_t sequence);
 int picoquic_queue_new_token_frame(picoquic_cnx_t * cnx, uint8_t * token, size_t token_length);
 uint8_t* picoquic_format_one_blocked_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack, picoquic_stream_head_t* stream);
-uint8_t* picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last);
+uint8_t* picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack,
+    picoquic_misc_frame_header_t* misc_frame, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last);
 uint8_t* picoquic_format_first_misc_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack);
-int picoquic_queue_misc_or_dg_frame(picoquic_cnx_t* cnx, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, const uint8_t* bytes, size_t length, int is_pure_ack);
+picoquic_misc_frame_header_t* picoquic_find_first_misc_frame(picoquic_cnx_t* cnx, picoquic_packet_context_enum pc);
+uint8_t* picoquic_format_misc_frames_in_context(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max,
+    int* more_data, int* is_pure_ack, picoquic_packet_context_enum pc);
+int picoquic_queue_misc_or_dg_frame(picoquic_cnx_t* cnx, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, const uint8_t* bytes, size_t length, int is_pure_ack, picoquic_packet_context_enum pc);
 void picoquic_delete_misc_or_dg(picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, picoquic_misc_frame_header_t* frame);
 void picoquic_clear_ack_ctx(picoquic_ack_context_t* ack_ctx);
 void picoquic_reset_ack_context(picoquic_ack_context_t* ack_ctx);
@@ -2026,7 +2024,8 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
 int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mode,
     uint8_t* bytes, size_t bytes_max, size_t* consumed);
 
-picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length, int is_pure_ack);
+picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length, int is_pure_ack,
+    picoquic_packet_context_enum pc);
 
 /* Supported version upgrade.
  * Upgrades are only supported between compatible versions.

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1977,6 +1977,7 @@ picoquic_misc_frame_header_t* picoquic_find_first_misc_frame(picoquic_cnx_t* cnx
 uint8_t* picoquic_format_misc_frames_in_context(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max,
     int* more_data, int* is_pure_ack, picoquic_packet_context_enum pc);
 int picoquic_queue_misc_or_dg_frame(picoquic_cnx_t* cnx, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, const uint8_t* bytes, size_t length, int is_pure_ack, picoquic_packet_context_enum pc);
+void picoquic_purge_misc_frames_after_ready(picoquic_cnx_t* cnx);
 void picoquic_delete_misc_or_dg(picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, picoquic_misc_frame_header_t* frame);
 void picoquic_clear_ack_ctx(picoquic_ack_context_t* ack_ctx);
 void picoquic_reset_ack_context(picoquic_ack_context_t* ack_ctx);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -4306,7 +4306,8 @@ void * picoquic_get_callback_context(picoquic_cnx_t * cnx)
     return cnx->callback_ctx;
 }
 
-picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length, int is_pure_ack)
+picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, size_t length, int is_pure_ack,
+    picoquic_packet_context_enum pc)
 {
     size_t l_alloc = sizeof(picoquic_misc_frame_header_t) + length;
 
@@ -4319,6 +4320,7 @@ picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, s
             memset(head, 0, sizeof(picoquic_misc_frame_header_t));
             head->length = length;
             head->is_pure_ack = is_pure_ack;
+            head->pc = pc;
             memcpy(((uint8_t *)head) + sizeof(picoquic_misc_frame_header_t), bytes, length);
         }
         return head;
@@ -4326,10 +4328,11 @@ picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, s
 }
 
 int picoquic_queue_misc_or_dg_frame(picoquic_cnx_t * cnx, picoquic_misc_frame_header_t** first, 
-    picoquic_misc_frame_header_t** last, const uint8_t* bytes, size_t length, int is_pure_ack)
+    picoquic_misc_frame_header_t** last, const uint8_t* bytes, size_t length, int is_pure_ack,
+    picoquic_packet_context_enum pc)
 {
     int ret = 0;
-    picoquic_misc_frame_header_t* misc_frame = picoquic_create_misc_frame(bytes, length, is_pure_ack);
+    picoquic_misc_frame_header_t* misc_frame = picoquic_create_misc_frame(bytes, length, is_pure_ack, pc);
 
     if (misc_frame == NULL) {
         ret = PICOQUIC_ERROR_MEMORY;
@@ -4350,9 +4353,10 @@ int picoquic_queue_misc_or_dg_frame(picoquic_cnx_t * cnx, picoquic_misc_frame_he
     return ret;
 }
 
-int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length, int is_pure_ack)
+int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t length,
+    int is_pure_ack, picoquic_packet_context_enum pc)
 {
-    return picoquic_queue_misc_or_dg_frame(cnx, &cnx->first_misc_frame, &cnx->last_misc_frame, bytes, length, is_pure_ack);
+    return picoquic_queue_misc_or_dg_frame(cnx, &cnx->first_misc_frame, &cnx->last_misc_frame, bytes, length, is_pure_ack, pc);
 }
 
 void picoquic_delete_misc_or_dg(picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, picoquic_misc_frame_header_t* frame)

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -4359,6 +4359,20 @@ int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t 
     return picoquic_queue_misc_or_dg_frame(cnx, &cnx->first_misc_frame, &cnx->last_misc_frame, bytes, length, is_pure_ack, pc);
 }
 
+void picoquic_purge_misc_frames_after_ready(picoquic_cnx_t* cnx)
+{
+    picoquic_misc_frame_header_t* misc_frame = cnx->first_misc_frame;
+
+    while (misc_frame != NULL) {
+        picoquic_misc_frame_header_t* next_frame = misc_frame->next_misc_frame;
+
+        if (misc_frame->pc != picoquic_packet_context_application) {
+            picoquic_delete_misc_or_dg(&cnx->first_misc_frame, &cnx->last_misc_frame, misc_frame);
+        }
+        misc_frame = next_frame;
+    }
+}
+
 void picoquic_delete_misc_or_dg(picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last, picoquic_misc_frame_header_t* frame)
 {
     if (frame->next_misc_frame) {

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2721,6 +2721,9 @@ void picoquic_ready_state_transition(picoquic_cnx_t* cnx, uint64_t current_time)
     picoquic_crypto_context_free(&cnx->crypto_context[picoquic_epoch_0rtt]);
     picoquic_crypto_context_free(&cnx->crypto_context[picoquic_epoch_handshake]);
 
+    /* Remove the frames queued in initial and handshake contexts */
+    picoquic_purge_misc_frames_after_ready(cnx);
+
     /* Trim the memory buffers allocated during handshake */
     picoquic_tlscontext_trim_after_handshake(cnx);
 

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -304,7 +304,8 @@ int picoquic_open_flow_control(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t
                 uint8_t* bytes_next = picoquic_format_max_stream_data_frame(cnx, stream, buffer + consumed, bytes_max, &more_data, &is_pure_ack, max_required);
                 bytes_next = picoquic_format_max_data_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack, expected_data_size);
                 if ((length = bytes_next - buffer) > 0) {
-                    ret = picoquic_queue_misc_frame(cnx, buffer, length, is_pure_ack);
+                    ret = picoquic_queue_misc_frame(cnx, buffer, length, is_pure_ack,
+                        picoquic_packet_context_application);
                 }
             }
         }
@@ -1613,13 +1614,8 @@ int picoquic_prepare_packet_0rtt(picoquic_cnx_t* cnx, picoquic_path_t * path_x, 
         length = 0;
     } else {
         /* If present, send misc frame */
-        while (cnx->first_misc_frame != NULL) {
-            uint8_t* bytes_misc = bytes_next;
-            bytes_next = picoquic_format_first_misc_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
-            if (bytes_next == bytes_misc) {
-                break;
-            }
-        }
+        bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+            &more_data, &is_pure_ack, picoquic_packet_context_application);
 
         /* We assume that if BDP data is associated with the zero RTT ticket, it can be sent */
         /* Encode the bdp frame */
@@ -1707,6 +1703,7 @@ size_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_
         uint8_t* bytes_max = bytes + send_buffer_max - checksum_overhead;
         uint8_t* bytes_next;
         size_t this_header_length = 0;
+        int is_pure_ack = 0;
 
         send_buffer_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : send_buffer_max;
         length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, next_wake_time, packet, send_buffer_max, &this_header_length);
@@ -1730,12 +1727,16 @@ size_t picoquic_prepare_packet_old_context(picoquic_cnx_t* cnx, picoquic_packet_
         }
 
         if (length > 0) {
+            bytes_next = bytes + length;
+            /* If present, send misc frame */
+            bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                &more_data, &is_pure_ack, picoquic_packet_context_application);
             if (packet->ptype != picoquic_packet_0rtt_protected) {
                 /* Check whether it makes sense to add an ACK at the end of the retransmission */
-                bytes_next = picoquic_format_ack_frame(cnx, bytes + length, bytes_max, &more_data,
+                bytes_next = picoquic_format_ack_frame(cnx, bytes_next, bytes_max, &more_data,
                     current_time, pc, 0);
-                length = bytes_next - bytes;
             }
+            length = bytes_next - bytes;
             packet->length = length;
             /* document the send time & overhead */
             packet->send_time = current_time;
@@ -1988,7 +1989,7 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
 
         if (ret == 0 && retransmit_possible &&
             (length = picoquic_retransmit_needed(cnx, pc, path_x, current_time, next_wake_time, packet, send_buffer_max, &header_length)) > 0) {
-            /* Check whether it makes sens to add an ACK at the end of the retransmission */
+            /* Check whether it makes sense to add an ACK at the end of the retransmission */
             if (epoch != picoquic_epoch_0rtt && length > header_length) {
                 bytes_next = picoquic_format_ack_frame(cnx, bytes + length, bytes_max, &more_data, current_time, pc, 0);
                 length = bytes_next - bytes;
@@ -2038,14 +2039,9 @@ int picoquic_prepare_packet_client_init(picoquic_cnx_t* cnx, picoquic_path_t * p
                         bytes_next = picoquic_format_ack_frame(cnx, bytes_next, bytes_max, &more_data, current_time, pc, 0);
                     }
 
-                    /* If present, send misc frame -- but only if packet is 1RTT */
-                    while (pc == picoquic_packet_context_application && cnx->first_misc_frame != NULL) {
-                        uint8_t* bytes_misc = bytes_next;
-                        bytes_next = picoquic_format_first_misc_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
-                        if (bytes_next == bytes_misc) {
-                            break;
-                        }
-                    }
+                    /* If present, send misc frame -- but only if for the current packet context */
+                    bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                        &more_data, &is_pure_ack, pc);
                     length = bytes_next - bytes;
 
                     if (ret == 0 && path_x->cwin > path_x->bytes_in_transit && cnx->quic->cwin_max > path_x->bytes_in_transit) {
@@ -2267,10 +2263,14 @@ int picoquic_prepare_packet_server_init(picoquic_cnx_t* cnx, picoquic_path_t * p
         packet->pc = pc;
         bytes_next = bytes + length;
 
-        if ((tls_ready != 0 && path_x->cwin > path_x->bytes_in_transit && cnx->quic->cwin_max > path_x->bytes_in_transit) 
+        if (((tls_ready || picoquic_find_first_misc_frame(cnx, pc) != NULL)
+            && path_x->cwin > path_x->bytes_in_transit && cnx->quic->cwin_max > path_x->bytes_in_transit) 
             || cnx->ack_ctx[pc].act[0].ack_needed) {
             bytes_next = picoquic_format_ack_frame(cnx, bytes_next, bytes_max, &more_data, current_time, pc, 0);
-            /* Encode the crypto frame */
+            /* Encode misc frames if present */
+            bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                &more_data, &is_pure_ack, pc);
+            /* Encode the crypto frame if present */
             bytes_next = picoquic_format_crypto_hs_frame(&cnx->tls_stream[epoch],
                 bytes_next, bytes_max, &more_data, &is_pure_ack);
             length = bytes_next - bytes;
@@ -3216,19 +3216,19 @@ int picoquic_prepare_packet_almost_ready(picoquic_cnx_t* cnx, picoquic_path_t* p
                             bytes_next, bytes_max, &more_data, &is_pure_ack);
                     }
 
-                    length = bytes_next - bytes;
-                    if (pc == picoquic_packet_context_application) {
+                    if (pc != picoquic_packet_context_application) {
+                        bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                            &more_data, &is_pure_ack, pc);
+                        length = bytes_next - bytes;
+                    }
+                    else {
+                        length = bytes_next - bytes;
                         if (length > header_length || pmtu_discovery_needed != picoquic_pmtu_discovery_required ||
                             send_buffer_max <= path_x->send_mtu) {
                             /* No need or no way to do pmtu discovery */
                             /* If present, send misc frame */
-                            while (cnx->first_misc_frame != NULL) {
-                                uint8_t* bytes_misc = bytes_next;
-                                bytes_next = picoquic_format_first_misc_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
-                                if (bytes_next == bytes_misc) {
-                                    break;
-                                }
-                            }
+                            bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                                &more_data, &is_pure_ack, pc);
 
                             /* If there are not enough published CID, create and advertise */
                             if (ret == 0) {
@@ -3514,22 +3514,18 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                 if (ret == 0 && cnx->max_stream_data_needed) {
                     bytes_next = picoquic_format_required_max_stream_data_frames(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
                 }
-
-                /* If present, send misc frame */
-                while (cnx->first_misc_frame != NULL) {
-                    uint8_t* bytes_misc = bytes_next;
-                    /* Funky code alert:
-                     * if misc frames are present the function `picoquic_retransmit_needed` is bypassed.
-                     * if "more data" was not set, the code would not reset the wait time, and the
-                     * program could stall.
-                     * TODO: rework the way packets are repeated so this is not necessary.
-                     */
-                    more_data = 1; 
-                    bytes_next = picoquic_format_first_misc_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack);
-                    if (bytes_next <= bytes_misc) {
-                        break;
-                    }
+                /* Funky code alert:
+                * if misc frames are present the function `picoquic_retransmit_needed` is bypassed.
+                * if "more data" was not set, the code would not reset the wait time, and the
+                * program could stall.
+                * TODO: rework the way packets are repeated so this is not necessary.
+                */
+                if (cnx->first_misc_frame != NULL) {
+                    more_data = 1;
                 }
+                /* If present, send misc frame */
+                bytes_next = picoquic_format_misc_frames_in_context(cnx, bytes_next, bytes_max,
+                    &more_data, &is_pure_ack, pc);
 
                 /* Compute the length before entering the CC block */
                 length = bytes_next - bytes;

--- a/picoquictest/datagram_tests.c
+++ b/picoquictest/datagram_tests.c
@@ -357,8 +357,10 @@ int datagram_test_one(uint8_t test_id, test_datagram_send_recv_ctx_t *dg_ctx, ui
             if (all_sent_time == 0) {
                 /* Queue a Ping frame to trigger acks */
                 uint8_t ping_frame[] = { picoquic_frame_type_ping };
-                picoquic_queue_misc_frame(test_ctx->cnx_client, ping_frame, sizeof(ping_frame), 0);
-                picoquic_queue_misc_frame(test_ctx->cnx_server, ping_frame, sizeof(ping_frame), 0);
+                picoquic_queue_misc_frame(test_ctx->cnx_client, ping_frame, sizeof(ping_frame), 0,
+                    picoquic_packet_context_application);
+                picoquic_queue_misc_frame(test_ctx->cnx_server, ping_frame, sizeof(ping_frame), 0,
+                    picoquic_packet_context_application);
                 loss_mask = 0;
                 all_sent_time = simulated_time;
             }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -6053,7 +6053,8 @@ int client_error_test_modal(int mode)
         if (mode == 0) {
             /* Queue a data frame on stream 4, which was already closed */
             uint8_t stream_error_frame[] = { 0x17, 0x04, 0x41, 0x01, 0x08, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
-            picoquic_queue_misc_frame(test_ctx->cnx_client, stream_error_frame, sizeof(stream_error_frame), 0);
+            picoquic_queue_misc_frame(test_ctx->cnx_client, stream_error_frame, sizeof(stream_error_frame), 0,
+                picoquic_packet_context_application);
         }
         else if (mode == 1) {
             /* Test injection of a wrong NEW CONNECTION ID */
@@ -6070,12 +6071,14 @@ int client_error_test_modal(int mode)
             /* deliberate error: repeat the reset secret defined for path[0] */
             memcpy(x, test_ctx->cnx_server->path[0]->p_remote_cnxid->reset_secret, PICOQUIC_RESET_SECRET_SIZE);
             x += PICOQUIC_RESET_SECRET_SIZE;
-            picoquic_queue_misc_frame(test_ctx->cnx_client, new_cnxid_error, x - new_cnxid_error, 0);
+            picoquic_queue_misc_frame(test_ctx->cnx_client, new_cnxid_error, x - new_cnxid_error, 0,
+                picoquic_packet_context_application);
         }
         else if (mode == 2) {
             /* Queue a stop sending on stream 2, which is unidir */
             uint8_t stop_sending_error_frame[] = { (uint8_t)picoquic_frame_type_stop_sending, 2, 0 };
-            picoquic_queue_misc_frame(test_ctx->cnx_client, stop_sending_error_frame, sizeof(stop_sending_error_frame), 0);
+            picoquic_queue_misc_frame(test_ctx->cnx_client, stop_sending_error_frame, sizeof(stop_sending_error_frame), 0,
+                picoquic_packet_context_application);
         }
         else {
             DBG_PRINTF("Error mode %d is not defined yet", mode);
@@ -12959,7 +12962,8 @@ int immediate_ack_test()
         int all_acked = 0;
         uint8_t immediate_ack_frame[2] = { 0x40, picoquic_frame_type_immediate_ack };
         /* Queue misc frame with "Immediate ACK" set */
-        picoquic_queue_misc_frame(test_ctx->cnx_client, immediate_ack_frame, 2, 0);
+        picoquic_queue_misc_frame(test_ctx->cnx_client, immediate_ack_frame, 2, 0,
+            picoquic_packet_context_application);
         /* Do couple of rounds until the frame is received;
          * Check that it is received my verifying that the "immediate ACK" 
          * is set in the ACK context at the server. Check the time.


### PR DESCRIPTION
This PR redefines the queue of "miscellaneous" frames to also include initial and handshake frames, in addition to application frames. Each frame is tagged with the packet context in which it should be sent. This is used to avoid the error "Cannot copy frame for retransmit" listed in bug #1722.