### PR TITLE
Add API to provide IP addresses of paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.21.8
+        VERSION 1.1.21.9
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4536,7 +4536,10 @@ const uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, const u
     } else {
         /*
          * Queue a response frame as response to path challenge.
-         * TODO: ensure it goes out on the same path as the incoming challenge.
+         * If the path already exists, we verify that the IP addresses match expectation:
+         * - source IP and port shall match the address and port with which the path was created.
+         * - destination IP shall match the local address.
+         * - destination port shall match the local port if that local port is not zero.
          */
         uint64_t challenge_response;
 
@@ -4545,7 +4548,10 @@ const uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, const u
         bytes += challenge_length;
         if (path_x != NULL &&
             (addr_from == NULL || picoquic_compare_addr(addr_from, (struct sockaddr *)&path_x->peer_addr) == 0) &&
-            (addr_to == NULL || picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0)) {
+            (addr_to == NULL || 
+                (picoquic_get_addr_port((struct sockaddr*)&path_x->local_addr) == 0 &&
+                    picoquic_compare_ip_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0) ||
+                picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0)){
             path_x->challenge_response = challenge_response;
             path_x->response_required = 1;
         }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4546,12 +4546,12 @@ const uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, const u
         bytes++;
         challenge_response = PICOPARSE_64(bytes);
         bytes += challenge_length;
-        if (path_x != NULL &&
+        if (path_x != NULL && (cnx->is_multipath_enabled ||
             (addr_from == NULL || picoquic_compare_addr(addr_from, (struct sockaddr *)&path_x->peer_addr) == 0) &&
             (addr_to == NULL || 
                 (picoquic_get_addr_port((struct sockaddr*)&path_x->local_addr) == 0 &&
                     picoquic_compare_ip_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0) ||
-                picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0)){
+                picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0))){
             path_x->challenge_response = challenge_response;
             path_x->response_required = 1;
         }

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.21.8"
+#define PICOQUIC_VERSION "1.1.21.9"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -894,6 +894,12 @@ int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id,
 int picoquic_refresh_path_connection_id(picoquic_cnx_t* cnx, uint64_t unique_path_id);
 int picoquic_set_stream_path_affinity(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t unique_path_id);
 int picoquic_set_path_status(picoquic_cnx_t* cnx, uint64_t unique_path_id, picoquic_path_status_enum status);
+/* The get path addr API provides the IP addresses used by a specific path.
+* The "local" argument determines whether the APi returns the local address
+* (local == 1) or the address of the peer (local == 2).
+*/
+int picoquic_get_path_addr(picoquic_cnx_t* cnx, uint64_t unique_path_id, int local, struct sockaddr_storage* addr);
+
 /*
 * The calls to picoquic_get_path_quality takes as argument a structure
 * of type `picoquic_path_quality_t`.

--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -96,6 +96,10 @@ int picoquic_print_connection_id_hexa(char* buf, size_t buf_len, const picoquic_
 uint8_t picoquic_create_packet_header_cnxid_lengths(uint8_t dest_len, uint8_t srce_len);
 
 int picoquic_compare_addr(const struct sockaddr* expected, const struct sockaddr* actual);
+int picoquic_compare_ip_addr(const struct sockaddr* expected, const struct sockaddr* actual);
+uint16_t picoquic_get_addr_port(const struct sockaddr* addr);
+void picoquic_set_addr_port(const struct sockaddr* addr, uint16_t port);
+
 int picoquic_addr_length(const struct sockaddr* addr);
 void picoquic_store_addr(struct sockaddr_storage * stored_addr, const struct sockaddr * addr);
 void picoquic_get_ip_addr(struct sockaddr * addr, uint8_t ** ip_addr, uint8_t * ip_addr_len);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2464,6 +2464,18 @@ int picoquic_set_path_status(picoquic_cnx_t* cnx, uint64_t unique_path_id, picoq
     return ret;
 }
 
+int picoquic_get_path_addr(picoquic_cnx_t* cnx, uint64_t unique_path_id, int local, struct sockaddr_storage* addr)
+{
+    int ret = 0;
+    int path_id = picoquic_get_path_id_from_unique(cnx, unique_path_id);
+    if (path_id >= 0) {
+        picoquic_store_addr(addr, (struct sockaddr*)
+            ((local) ? &cnx->path[path_id]->local_addr : &cnx->path[path_id]->peer_addr));
+    }
+
+    return ret;
+}
+
 /* Reset the path MTU, for example if too many packet losses are detected */
 void picoquic_reset_path_mtu(picoquic_path_t* path_x)
 {

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -465,6 +465,48 @@ int picoquic_compare_addr(const struct sockaddr * expected, const struct sockadd
     return ret;
 }
 
+
+int picoquic_compare_ip_addr(const struct sockaddr* expected, const struct sockaddr* actual)
+{
+    int ret = -1;
+
+    if (expected->sa_family == actual->sa_family) {
+        if (expected->sa_family == AF_INET6) {
+            struct sockaddr_in6* ex = (struct sockaddr_in6*)expected;
+            struct sockaddr_in6* ac = (struct sockaddr_in6*)actual;
+
+            ret = memcmp(&ex->sin6_addr, &ac->sin6_addr, 16);
+        }
+        else {
+            struct sockaddr_in* ex = (struct sockaddr_in*)expected;
+            struct sockaddr_in* ac = (struct sockaddr_in*)actual;
+#ifdef _WINDOWS
+            ret = (ex->sin_addr.S_un.S_addr == ac->sin_addr.S_un.S_addr) ? 0 : -1;
+#else
+            ret = (ex->sin_addr.s_addr == ac->sin_addr.s_addr) ? 0 : -1;
+#endif
+        }
+    }
+    return ret;
+}
+
+uint16_t picoquic_get_addr_port(const struct sockaddr* addr)
+{
+    uint16_t port = (addr->sa_family == AF_INET6) ? ((struct sockaddr_in6*)addr)->sin6_port : ((struct sockaddr_in*)addr)->sin_port;
+
+    return port;
+}
+
+void picoquic_set_addr_port(const struct sockaddr* addr, uint16_t port)
+{
+    if (addr->sa_family == AF_INET6) {
+        ((struct sockaddr_in6*)addr)->sin6_port = port;
+    }
+    else {
+        ((struct sockaddr_in*)addr)->sin_port = port;
+    }
+}
+
 int picoquic_addr_length(const struct sockaddr* addr)
 {
     int len = 0;

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -598,6 +598,7 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                                 picoquic_log_app_message(cb_ctx->cnx_client, "Cannot add new path, wrong address family, %d vs. %d\n", 
                                     cb_ctx->client_alt_address[i].ss_family, path0_addr.ss_family);
                             } else {
+#if 0
                                 /* The configuration code sets the port number in "client_alt_address" to zero,
                                 * but it should be set to the actual value because of the "matching address"
                                 * test when processing path challenges. The actual value is the same as
@@ -610,6 +611,7 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                                     ((struct sockaddr_in*)&cb_ctx->client_alt_address[i])->sin_port =
                                         ((struct sockaddr_in*)&path0_addr)->sin_port;
                                 }
+#endif
                                 if ((ret = picoquic_probe_new_path_ex(cb_ctx->cnx_client, (struct sockaddr*)&cb_ctx->server_address,
                                     (struct sockaddr*)&cb_ctx->client_alt_address[i], cb_ctx->client_alt_if[i], picoquic_get_quic_time(quic), 0)) != 0) {
                                     picoquic_log_app_message(cb_ctx->cnx_client, "Probe new path failed with exit code %d", ret);

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -579,8 +579,14 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                     if (remote_cid_ready) {
                         struct sockaddr_in6 addr_zero6 = { 0 };
                         struct sockaddr_in addr_zero4 = { 0 };
+                        struct sockaddr_storage path0_addr = { 0 };
                         addr_zero6.sin6_family = AF_INET6;
                         addr_zero4.sin_family = AF_INET;
+
+                        if (picoquic_get_path_addr(cb_ctx->cnx_client, 0, 1, &path0_addr) != 0) {
+                            /* This should never happen, as path[0] is always defined before the first migration. */
+                            picoquic_log_app_message(cb_ctx->cnx_client, "Cannot use multipath. Cannot get address of path 0");
+                        }
 
                         for (int i = 0; i < cb_ctx->nb_alt_paths; i++) {
                             if (picoquic_compare_addr((struct sockaddr*)&addr_zero6, (struct sockaddr*)&cb_ctx->client_alt_address[i]) == 0 ||
@@ -588,9 +594,9 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                                 simulate_multipath = 1;
                                 picoquic_log_app_message(cb_ctx->cnx_client, "%s\n", "Will try to simulate new path");
                             }
-                            else if (cb_ctx->client_alt_address[i].ss_family != cb_ctx->cnx_client->path[0]->local_addr.ss_family) {
+                            else if (cb_ctx->client_alt_address[i].ss_family != path0_addr.ss_family) {
                                 picoquic_log_app_message(cb_ctx->cnx_client, "Cannot add new path, wrong address family, %d vs. %d\n", 
-                                    cb_ctx->client_alt_address[i].ss_family, cb_ctx->cnx_client->path[0]->local_addr.ss_family);
+                                    cb_ctx->client_alt_address[i].ss_family, path0_addr.ss_family);
                             } else {
                                 /* The configuration code sets the port number in "client_alt_address" to zero,
                                 * but it should be set to the actual value because of the "matching address"
@@ -598,11 +604,11 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                                 * used in the default path. */
                                 if (cb_ctx->client_alt_address[i].ss_family == AF_INET6) {
                                     ((struct sockaddr_in6*)&cb_ctx->client_alt_address[i])->sin6_port =
-                                        ((struct sockaddr_in6*)&cb_ctx->cnx_client->path[0]->local_addr)->sin6_port;
+                                        ((struct sockaddr_in6*)&path0_addr)->sin6_port;
                                 }
                                 else {
                                     ((struct sockaddr_in*)&cb_ctx->client_alt_address[i])->sin_port =
-                                        ((struct sockaddr_in*)&cb_ctx->cnx_client->path[0]->local_addr)->sin_port;
+                                        ((struct sockaddr_in*)&path0_addr)->sin_port;
                                 }
                                 if ((ret = picoquic_probe_new_path_ex(cb_ctx->cnx_client, (struct sockaddr*)&cb_ctx->server_address,
                                     (struct sockaddr*)&cb_ctx->client_alt_address[i], cb_ctx->client_alt_if[i], picoquic_get_quic_time(quic), 0)) != 0) {
@@ -612,8 +618,9 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                                     picoquic_log_app_message(cb_ctx->cnx_client, "New path added, total path available %d", cb_ctx->cnx_client->nb_paths);
                                 }
                             }
-                            cb_ctx->multipath_probe_done = 1;
                         }
+
+                        cb_ctx->multipath_probe_done = 1;
 
                         if (simulate_multipath) {
                             ret = simulate_migration(cb_ctx);


### PR DESCRIPTION
Add the public API `picoquic_get_path_addr` to retrieve the IP address and port number currently used by a path.

Relax the test of local addresses in the processing of incoming challenge.