### PR TITLE
compiler warnings

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4562,10 +4562,10 @@ const uint8_t* picoquic_decode_path_challenge_frame(picoquic_cnx_t* cnx, const u
         bytes += challenge_length;
         if (path_x != NULL && (cnx->is_multipath_enabled ||
             (addr_from == NULL || 
-                (picoquic_compare_addr(addr_from, (struct sockaddr *)&path_x->peer_addr) == 0 &&
+                ((picoquic_compare_addr(addr_from, (struct sockaddr *)&path_x->peer_addr) == 0 &&
             (addr_to == NULL || 
                 (picoquic_get_addr_port((struct sockaddr*)&path_x->local_addr) == 0 &&
-                    picoquic_compare_ip_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0)) ||
+                    picoquic_compare_ip_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0))) ||
                 picoquic_compare_addr(addr_to, (struct sockaddr *)&path_x->local_addr) == 0)))){
             path_x->challenge_response = challenge_response;
             path_x->response_required = 1;


### PR DESCRIPTION
https://github.com/private-octopus/picoquic/actions/runs/10436424505/job/28901475179

1) fix

I think a few parantheses were forgotten here when solving the RTT problem. Ends in a compiler warning. Please check again whether I have set the brackets correctly.

2) fix

And another warning, **which I haven't fixed yet**, where I unfortunately don't know whether it is intended or not. 
The `bytes` pointer is modified
https://github.com/private-octopus/picoquic/blob/e78af222dab8eb1816d1b505da20dffe557aa3e1/picoquic/frames.c#L1299
and used afterwards,
https://github.com/private-octopus/picoquic/blob/e78af222dab8eb1816d1b505da20dffe557aa3e1/picoquic/frames.c#L1300
which leads to unsequenced modification. Maybe we can move the `elseif` part into the `else` part and introduce a new variable for `bytes + consumed`. But I want to make sure that I have understood this code correctly.


