### PR TITLE
Probe up if app exits app-limited

### DIFF
--- a/picoquic/bbr.c
+++ b/picoquic/bbr.c
@@ -129,6 +129,8 @@ typedef enum {
 #define BBRProbeBwUpPacingGain 1.25
 #define BBRProbeBwUpCwndGain 2.25
 
+#define BBRAppLimitedRoundsThreshold 3
+
 #define BBRMinRttMarginPercent 5 /* Margin factor of 20% for avoiding firing RTT Probe too often */
 #define BBRLongRttThreshold 250000
 
@@ -232,8 +234,12 @@ typedef struct st_picoquic_bbr_state_t {
     uint64_t recovery_delivered;
 
     /* Management of lost feedback */
-    unsigned int is_handling_lost_feedback;
+    unsigned int is_handling_lost_feedback : 1;
     uint64_t cwin_before_lost_feedback;
+
+    /* Management of App limited and transition */
+    int app_limited_round_count;
+    int app_limited_this_round;
 
     /* Management of ECN marks */
     uint64_t ecn_ect1_last_round;
@@ -1572,6 +1578,51 @@ static int BBRCheckPathSaturated(picoquic_bbr_state_t* bbr_state, picoquic_path_
 }
 #endif
 
+
+/* Additional code for managing transition out of "app limited"
+* If the application remained in "app limited" state for a long time, the
+* interaction between application adaptation and bandwidth measurement may
+* cause the measured bottleneck rate to drift down. If the application
+* starts pushing more data, we will see a transition "out of app limited".
+* In this case, we should accelerate the transition to "ProbeBW UP", and
+* let the rate quickly adapt to the new requirements of the application
+* and the current state of the network.
+*
+* The potential downside is that an application alternating between
+* high activity and silence might probe for bandwidth more quickly
+* than an application that steadily sends data. This may or may not be an
+* issue if "steady" and "bumpy" share the same bottleneck -- the bumpy
+* application will probe more often, but the steady application will
+* defend its sending rate more effectively.
+*
+* We defined an "app limited state" as "being app limited for more
+* than BBRAppLimitedRoundsThreshold" rounds. The code maintains the
+* "limited rounds" counter, incremented when a round concludes
+* in app limited state, and reset when the congestion limit is
+* reached. If reset happens in a Probe BW Cruise state, we force
+* and immediate transition to Refill.
+*/
+static int BBRCheckAppLimitedEnded(picoquic_bbr_state_t* bbr_state, bbr_per_ack_state_t* rs)
+{
+    int app_limited_ended = 0;
+    if (bbr_state->round_start) {
+        if (bbr_state->app_limited_this_round) {
+            bbr_state->app_limited_round_count++;
+        }
+        else
+        {
+            app_limited_ended =
+                (bbr_state->app_limited_round_count > BBRAppLimitedRoundsThreshold);
+            bbr_state->app_limited_round_count = 0;
+        }
+        bbr_state->app_limited_this_round = 0;
+    }
+    else {
+        bbr_state->app_limited_this_round |= rs->is_app_limited;
+    }
+    return app_limited_ended;
+}
+
 static int BBRIsRenoCoexistenceProbeTime(picoquic_bbr_state_t* bbr_state, picoquic_path_t * path_x)
 {
     uint64_t reno_rounds = (BBRTargetInflight(bbr_state, path_x)/path_x->send_mtu);
@@ -1584,10 +1635,11 @@ static int BBRHasElapsedInPhase(picoquic_bbr_state_t* bbr_state, uint64_t interv
     return current_time > bbr_state->cycle_stamp + interval;
 }
 
-static int BBRCheckTimeToProbeBW(picoquic_bbr_state_t* bbr_state, picoquic_path_t * path_x, uint64_t current_time)
+static int BBRCheckTimeToProbeBW(picoquic_bbr_state_t* bbr_state, picoquic_path_t * path_x, bbr_per_ack_state_t* rs, uint64_t current_time)
 {
     if (BBRHasElapsedInPhase(bbr_state, bbr_state->bw_probe_wait, current_time) ||
-        BBRIsRenoCoexistenceProbeTime(bbr_state, path_x)) {
+        BBRIsRenoCoexistenceProbeTime(bbr_state, path_x) ||
+        BBRCheckAppLimitedEnded(bbr_state, rs)) {
         BBRStartProbeBW_REFILL(bbr_state, path_x);
         return 1;
     }
@@ -1613,6 +1665,9 @@ static void BBRStartProbeBW_DOWN(picoquic_bbr_state_t* bbr_state, picoquic_path_
     BBRStartRound(bbr_state, path_x);
     bbr_state->state = picoquic_bbr_alg_probe_bw_down;
     bbr_state->nb_rtt_excess = 0;
+    bbr_state->app_limited_round_count = 0;
+    bbr_state->app_limited_this_round = 0;
+
     path_x->is_cca_probing_up = 0;
 }
 
@@ -1660,7 +1715,7 @@ static void BBRUpdateProbeBWCyclePhase(picoquic_bbr_state_t* bbr_state, picoquic
 
     switch (bbr_state->state) {
     case picoquic_bbr_alg_probe_bw_down:
-        if (BBRCheckTimeToProbeBW(bbr_state, path_x, current_time))
+        if (BBRCheckTimeToProbeBW(bbr_state, path_x, rs, current_time))
             return; /* already decided state transition */
 #ifdef RTTJitterBufferProbe
         if (BBRCheckPathSaturated(bbr_state, path_x, rs, current_time)) {
@@ -1693,7 +1748,7 @@ static void BBRUpdateProbeBWCyclePhase(picoquic_bbr_state_t* bbr_state, picoquic
             return;
         }
 #endif
-        if (BBRCheckTimeToProbeBW(bbr_state, path_x, current_time))
+        if (BBRCheckTimeToProbeBW(bbr_state, path_x, rs, current_time))
             return; /* already decided state transition */
         break;
 


### PR DESCRIPTION
We suspect that if an application remains a long time in "app limited" mode, BBR will "drift down" and the pacing rate will become less and less. The PR forces a transition to "probe BW up"  if the application exist app limited status.