### PR TITLE
Make FindPTLS cmake aware of MBEDTLS flag

### DIFF
--- a/cmake/FindPTLS.cmake
+++ b/cmake/FindPTLS.cmake
@@ -2,16 +2,30 @@
 
 if (PICOQUIC_FETCH_PTLS)
     set(PTLS_CORE_LIBRARY picotls-core)
-    set(PTLS_OPENSSL_LIBRARY picotls-openssl)
     set(PTLS_MINICRYPTO_LIBRARY picotls-minicrypto)
-    if(WITH_FUSION)
-        set(PTLS_FUSION_LIBRARY picotls-fusion)
-        set(PTLS_WITH_FUSION_DEFAULT ON)
-        set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+
+    if(WITH_MBEDTLS)
+        find_package_handle_standard_args(PTLS REQUIRED_VARS
+            PTLS_CORE_LIBRARY
+            PTLS_MINICRYPTO_LIBRARY
+            PTLS_INCLUDE_DIR)
+
+        if(PTLS_FOUND)
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+            set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+            set(PTLS_WITH_FUSION_DEFAULT OFF)
+        endif()
     else()
-        set(PTLS_WITH_FUSION_DEFAULT OFF)
-        set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY}  ${PTLS_MINICRYPTO_LIBRARY})
-        unset(PTLS_FUSION_LIBRARY)
+        set(PTLS_OPENSSL_LIBRARY picotls-openssl)
+        if(WITH_FUSION)
+            set(PTLS_FUSION_LIBRARY picotls-fusion)
+            set(PTLS_WITH_FUSION_DEFAULT ON)
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+        else()
+            set(PTLS_WITH_FUSION_DEFAULT OFF)
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY}  ${PTLS_MINICRYPTO_LIBRARY})
+            unset(PTLS_FUSION_LIBRARY)
+        endif()
     endif()
     set(PTLS_INCLUDE_DIRS ${picotls_SOURCE_DIR}/include)
 else(PICOQUIC_FETCH_PTLS)
@@ -25,39 +39,55 @@ else(PICOQUIC_FETCH_PTLS)
     set(PTLS_HINTS ${PTLS_PREFIX}/lib ${CMAKE_BINARY_DIR}/../picotls ../picotls)
 
     find_library(PTLS_CORE_LIBRARY picotls-core HINTS ${PTLS_HINTS})
-    find_library(PTLS_OPENSSL_LIBRARY picotls-openssl HINTS ${PTLS_HINTS})
-    find_library(PTLS_FUSION_LIBRARY picotls-fusion HINTS ${PTLS_HINTS})
     find_library(PTLS_MINICRYPTO_LIBRARY picotls-minicrypto HINTS ${PTLS_HINTS})
 
-    if(NOT PTLS_FUSION_LIBRARY)
-        include(FindPackageHandleStandardArgs)
-        # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
-        # if all listed variables are TRUE
+    if(WITH_MBEDTLS)
         find_package_handle_standard_args(PTLS REQUIRED_VARS
             PTLS_CORE_LIBRARY
-            PTLS_OPENSSL_LIBRARY
             PTLS_MINICRYPTO_LIBRARY
             PTLS_INCLUDE_DIR)
+
         if(PTLS_FOUND)
-            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
             set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
             set(PTLS_WITH_FUSION_DEFAULT OFF)
         endif()
     else()
-        include(FindPackageHandleStandardArgs)
-        # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
-        # if all listed variables are TRUE
-        find_package_handle_standard_args(PTLS REQUIRED_VARS
-            PTLS_CORE_LIBRARY
-            PTLS_OPENSSL_LIBRARY
-            PTLS_FUSION_LIBRARY
-            PTLS_MINICRYPTO_LIBRARY
-            PTLS_INCLUDE_DIR)
+        find_library(PTLS_OPENSSL_LIBRARY picotls-openssl HINTS ${PTLS_HINTS})
+        find_library(PTLS_FUSION_LIBRARY picotls-fusion HINTS ${PTLS_HINTS})
 
-        if(PTLS_FOUND)
-            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
-            set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
-            set(PTLS_WITH_FUSION_DEFAULT ON)
+        if(NOT PTLS_FUSION_LIBRARY)
+            include(FindPackageHandleStandardArgs)
+            # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+            # if all listed variables are TRUE
+
+            find_package_handle_standard_args(PTLS REQUIRED_VARS
+                PTLS_CORE_LIBRARY
+                PTLS_OPENSSL_LIBRARY
+                PTLS_MINICRYPTO_LIBRARY
+                PTLS_INCLUDE_DIR)
+
+            if(PTLS_FOUND)
+                set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+                set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+                set(PTLS_WITH_FUSION_DEFAULT OFF)
+            endif()
+        else()
+            include(FindPackageHandleStandardArgs)
+            # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+            # if all listed variables are TRUE
+            find_package_handle_standard_args(PTLS REQUIRED_VARS
+                PTLS_CORE_LIBRARY
+                PTLS_OPENSSL_LIBRARY
+                PTLS_FUSION_LIBRARY
+                PTLS_MINICRYPTO_LIBRARY
+                PTLS_INCLUDE_DIR)
+
+            if(PTLS_FOUND)
+                set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+                set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+                set(PTLS_WITH_FUSION_DEFAULT ON)
+            endif()
         endif()
     endif()
 endif(PICOQUIC_FETCH_PTLS)


### PR DESCRIPTION
When building picoquic with mbedtls, we only need "picotls-core" and "picotls-minicrypto" by default.
Make the FindPTLS cmake file aware of the WITH_MBEDTLS flag and include only the required libraries.
