### PR TITLE
Fix series of test warnings.

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -336,12 +336,15 @@ static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
         }
 
         if (!ctx->no_print) {
+            char text[128];
             if (ret != 0) {
                 fprintf(stdout, "Cannot send %s command for stream(%" PRIu64 "): %s\n",
-                    (post_size == 0) ? "GET" : "POST", stream_ctx->stream_id, path);
+                    (post_size == 0) ? "GET" : "POST", stream_ctx->stream_id,
+                    );
             }
             else if (nb_repeat == 0) {
-                fprintf(stdout, "Opening stream %d to %s %s\n", (int)stream_ctx->stream_id, (post_size == 0) ? "GET" : "POST", path);
+                fprintf(stdout, "Opening stream %d to %s %s\n", (int)stream_ctx->stream_id, (post_size == 0) ? "GET" : "POST", 
+                    picoquic_uint8_to_str(text, sizeof(text), path, path_len));
             }
         }
     }

--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -339,8 +339,8 @@ static int picoquic_demo_client_open_stream(picoquic_cnx_t* cnx,
             char text[128];
             if (ret != 0) {
                 fprintf(stdout, "Cannot send %s command for stream(%" PRIu64 "): %s\n",
-                    (post_size == 0) ? "GET" : "POST", stream_ctx->stream_id,
-                    );
+                    (post_size == 0) ? "GET" : "POST", stream_ctx->stream_id, 
+                    picoquic_uint8_to_str(text, sizeof(text), path, path_len));
             }
             else if (nb_repeat == 0) {
                 fprintf(stdout, "Opening stream %d to %s %s\n", (int)stream_ctx->stream_id, (post_size == 0) ? "GET" : "POST", 

--- a/picohttp/quicperf.c
+++ b/picohttp/quicperf.c
@@ -1245,12 +1245,12 @@ size_t quicperf_prepare_time_stamp(quicperf_stream_ctx_t* stream_ctx, uint8_t * 
     size_t byte_index = 0;
     if (stream_ctx->frame_bytes_sent < 8) {
         uint8_t time_stamp[8];
-        (void)picoquic_frames_uint64_encode(buffer, buffer + 8, stream_ctx->frame_start_stamp);
-
-        while (stream_ctx->frame_bytes_sent < 8 && byte_index < available) {
-            buffer[byte_index] = time_stamp[stream_ctx->frame_bytes_sent];
-            stream_ctx->frame_bytes_sent++;
-            byte_index++;
+        if (picoquic_frames_uint64_encode(buffer, buffer + 8, stream_ctx->frame_start_stamp) != NULL) {
+            while (stream_ctx->frame_bytes_sent < 8 && byte_index < available) {
+                buffer[byte_index] = time_stamp[stream_ctx->frame_bytes_sent];
+                stream_ctx->frame_bytes_sent++;
+                byte_index++;
+            }
         }
     }
     return byte_index;

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -1594,36 +1594,37 @@ int frames_format_test()
             ret = -1;
         }
     }
-
-    stream->reset_requested = 1; 
-    FRAME_FORMAT_TEST_ONCE(picoquic_format_stream_reset_frame, 2, cnx, stream, bytes, bytes_max, &more_data, &is_pure_ack);
-    stream->reset_requested = 0;
-    FRAME_FORMAT_TEST(picoquic_format_new_connection_id_frame, cnx, local_cnxid_list, bytes, bytes_max, &more_data, &is_pure_ack, l_cid);
-    FRAME_FORMAT_TEST(picoquic_format_retire_connection_id_frame, bytes, bytes_max, &more_data, &is_pure_ack, 1, 0, 17);
-    FRAME_FORMAT_TEST(picoquic_format_new_token_frame, bytes, bytes_max, &more_data, &is_pure_ack, data, 2);
-    stream->stop_sending_requested = 1;
-    FRAME_FORMAT_TEST_ONCE(picoquic_format_stop_sending_frame, 2, stream, bytes, bytes_max, &more_data, &is_pure_ack);
-    stream->stop_sending_requested = 0;
-    stream->stop_sending_sent = 0;
-    FRAME_FORMAT_TEST_ONCE(picoquic_format_data_blocked_frame, 1, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
-    FRAME_FORMAT_TEST(picoquic_format_stream_data_blocked_frame, bytes, bytes_max, &more_data, &is_pure_ack, stream);
-    stream->stream_data_blocked_sent = 0;
-    FRAME_FORMAT_TEST_ONCE(picoquic_format_stream_blocked_frame, 1, cnx, bytes, bytes_max, &more_data, &is_pure_ack, stream);
-    cnx->stream_blocked_bidir_sent = 0;
-    FRAME_FORMAT_TEST(picoquic_format_connection_close_frame, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
-    FRAME_FORMAT_TEST(picoquic_format_application_close_frame, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
-    FRAME_FORMAT_TEST(picoquic_format_max_stream_data_frame, cnx, stream, bytes, bytes_max, &more_data, &is_pure_ack, 100000000);
-    FRAME_FORMAT_TEST(picoquic_format_path_challenge_frame, bytes, bytes_max, &more_data, &is_pure_ack, 0xaabbccddeeff0011ull);
-    FRAME_FORMAT_TEST(picoquic_format_path_response_frame, bytes, bytes_max, &more_data, &is_pure_ack, 0xaabbccddeeff0011ull);
-    FRAME_FORMAT_TEST(picoquic_format_datagram_frame, bytes, bytes_max, &more_data, &is_pure_ack, 2, data);
-    FRAME_FORMAT_TEST_ONCE(picoquic_format_ack_frequency_frame, 2, cnx, bytes, bytes_max, &more_data);
-    FRAME_FORMAT_TEST(picoquic_format_immediate_ack_frame, bytes, bytes_max, &more_data);
-    FRAME_FORMAT_TEST(picoquic_format_time_stamp_frame, cnx, buffer, bytes_max, &more_data, simulated_time);
-    FRAME_FORMAT_TEST(picoquic_format_path_abandon_frame, bytes, bytes_max, &more_data, 1, 3);
-    FRAME_FORMAT_TEST(picoquic_format_path_available_or_standby_frame, bytes, bytes_max, picoquic_frame_type_path_available, 1, 17, &more_data);
-    FRAME_FORMAT_TEST(picoquic_format_max_path_id_frame, bytes, bytes_max, 123, &more_data);
-    FRAME_FORMAT_TEST(picoquic_format_path_blocked_frame, bytes, bytes_max, 123, &more_data);
-    FRAME_FORMAT_TEST(picoquic_format_observed_address_frame, bytes, bytes_max, picoquic_frame_type_observed_address_v4, 13, addr_bytes, 4433, &more_data);
+    if (ret == 0) {
+        stream->reset_requested = 1;
+        FRAME_FORMAT_TEST_ONCE(picoquic_format_stream_reset_frame, 2, cnx, stream, bytes, bytes_max, &more_data, &is_pure_ack);
+        stream->reset_requested = 0;
+        FRAME_FORMAT_TEST(picoquic_format_new_connection_id_frame, cnx, local_cnxid_list, bytes, bytes_max, &more_data, &is_pure_ack, l_cid);
+        FRAME_FORMAT_TEST(picoquic_format_retire_connection_id_frame, bytes, bytes_max, &more_data, &is_pure_ack, 1, 0, 17);
+        FRAME_FORMAT_TEST(picoquic_format_new_token_frame, bytes, bytes_max, &more_data, &is_pure_ack, data, 2);
+        stream->stop_sending_requested = 1;
+        FRAME_FORMAT_TEST_ONCE(picoquic_format_stop_sending_frame, 2, stream, bytes, bytes_max, &more_data, &is_pure_ack);
+        stream->stop_sending_requested = 0;
+        stream->stop_sending_sent = 0;
+        FRAME_FORMAT_TEST_ONCE(picoquic_format_data_blocked_frame, 1, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
+        FRAME_FORMAT_TEST(picoquic_format_stream_data_blocked_frame, bytes, bytes_max, &more_data, &is_pure_ack, stream);
+        stream->stream_data_blocked_sent = 0;
+        FRAME_FORMAT_TEST_ONCE(picoquic_format_stream_blocked_frame, 1, cnx, bytes, bytes_max, &more_data, &is_pure_ack, stream);
+        cnx->stream_blocked_bidir_sent = 0;
+        FRAME_FORMAT_TEST(picoquic_format_connection_close_frame, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
+        FRAME_FORMAT_TEST(picoquic_format_application_close_frame, cnx, bytes, bytes_max, &more_data, &is_pure_ack);
+        FRAME_FORMAT_TEST(picoquic_format_max_stream_data_frame, cnx, stream, bytes, bytes_max, &more_data, &is_pure_ack, 100000000);
+        FRAME_FORMAT_TEST(picoquic_format_path_challenge_frame, bytes, bytes_max, &more_data, &is_pure_ack, 0xaabbccddeeff0011ull);
+        FRAME_FORMAT_TEST(picoquic_format_path_response_frame, bytes, bytes_max, &more_data, &is_pure_ack, 0xaabbccddeeff0011ull);
+        FRAME_FORMAT_TEST(picoquic_format_datagram_frame, bytes, bytes_max, &more_data, &is_pure_ack, 2, data);
+        FRAME_FORMAT_TEST_ONCE(picoquic_format_ack_frequency_frame, 2, cnx, bytes, bytes_max, &more_data);
+        FRAME_FORMAT_TEST(picoquic_format_immediate_ack_frame, bytes, bytes_max, &more_data);
+        FRAME_FORMAT_TEST(picoquic_format_time_stamp_frame, cnx, buffer, bytes_max, &more_data, simulated_time);
+        FRAME_FORMAT_TEST(picoquic_format_path_abandon_frame, bytes, bytes_max, &more_data, 1, 3);
+        FRAME_FORMAT_TEST(picoquic_format_path_available_or_standby_frame, bytes, bytes_max, picoquic_frame_type_path_available, 1, 17, &more_data);
+        FRAME_FORMAT_TEST(picoquic_format_max_path_id_frame, bytes, bytes_max, 123, &more_data);
+        FRAME_FORMAT_TEST(picoquic_format_path_blocked_frame, bytes, bytes_max, 123, &more_data);
+        FRAME_FORMAT_TEST(picoquic_format_observed_address_frame, bytes, bytes_max, picoquic_frame_type_observed_address_v4, 13, addr_bytes, 4433, &more_data);
+    }
 
     if (qclient != NULL) {
         picoquic_free(qclient);


### PR DESCRIPTION
Make sure that even in error scenarios the test never uses non-initialized variables.