### PR TITLE
Tighten initial packet screening

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -612,6 +612,7 @@ typedef struct st_picoquic_quic_t {
     uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE];
     uint8_t retry_seed[PICOQUIC_RETRY_SECRET_SIZE];
     uint64_t* p_simulated_time;
+    uint8_t hash_seed[8];
     char const* ticket_file_name;
     char const* token_file_name;
     picoquic_stored_ticket_t * p_first_ticket;

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -307,10 +307,17 @@ static int picoquic_net_id_compare(const void* key1, const void* key2)
 
 static uint64_t picoquic_net_icid_hash(const void* key)
 {
+    /* The ICID is controlled by the peer. We mix a random seed in the
+     * hash to avoid possible shenanigans. */
     const picoquic_cnx_t* cnx = (const picoquic_cnx_t*)key;
+    picoquic_connection_id_t cid = cnx->initial_cnxid;
+
+    for (int i = 0; i < 8; i++) {
+        cid.id[i] ^= cnx->quic->hash_seed[i];
+    }
 
     return picohash_hash_mix(picoquic_hash_addr((struct sockaddr*) & cnx->registered_icid_addr), 
-        picoquic_connection_id_hash(&cnx->initial_cnxid));
+        picoquic_connection_id_hash(&cid));
 }
 
 static int picoquic_net_icid_compare(const void* key1, const void* key2)
@@ -716,6 +723,7 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
                         memcpy(quic->reset_seed, reset_seed, sizeof(quic->reset_seed));
 
                     picoquic_crypto_random(quic, quic->retry_seed, sizeof(quic->retry_seed));
+                    picoquic_crypto_random(quic, quic->hash_seed, sizeof(quic->hash_seed));
 
                     /* If there is no root certificate context specified, use a null certifier. */
                     /* Load tickets */
@@ -4755,6 +4763,7 @@ picoquic_cnx_t* picoquic_cnx_by_icid(picoquic_quic_t* quic, picoquic_connection_
 
     picoquic_store_addr(&dummy_cnx.registered_icid_addr, addr);
     dummy_cnx.initial_cnxid = *icid;
+    dummy_cnx.quic = quic;
 
     item = picohash_retrieve(quic->table_cnx_by_icid, &dummy_cnx);
 


### PR DESCRIPTION
Make sure that malformed initial packets are dropped before memory is allocated. Also, tighten hashing of initial CID.