### PR TITLE
Use path allowed API for testing multipath

### DIFF
--- a/picohttp/democlient.c
+++ b/picohttp/democlient.c
@@ -633,6 +633,9 @@ int picoquic_demo_client_callback(picoquic_cnx_t* cnx,
 
         break;
     }
+    case picoquic_callback_next_path_allowed:
+        /* This event should be handled according to the application's requirements */
+        break;
     default:
         /* unexpected */
         break;

--- a/picohttp/democlient.h
+++ b/picohttp/democlient.h
@@ -88,6 +88,10 @@ typedef struct st_picoquic_demo_client_callback_ctx_t {
     int no_print;
     int connection_ready;
     int connection_closed;
+
+    /* Context extension for handling asynchronous creation of paths */
+    void (*handle_path_allowed)(picoquic_cnx_t* cnx, void* ctx);
+    void* path_allowed_context;
 } picoquic_demo_callback_ctx_t;
 
 picoquic_alpn_enum picoquic_parse_alpn(char const * alpn);

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -498,10 +498,13 @@ const uint8_t* picoquic_decode_new_connection_id_frame(picoquic_cnx_t* cnx, cons
         else {
             uint64_t transport_error = picoquic_add_remote_cnxid_to_stash(cnx, remote_cnxid_stash, retire_before,
                 sequence, cid_length, cnxid_bytes, secret_bytes, NULL);
-            if (transport_error == 0 && remote_cnxid_stash->retire_cnxid_before < retire_before) {
-                /* retire the now deprecated CIDs */
-                remote_cnxid_stash->retire_cnxid_before = retire_before;
-                transport_error = picoquic_remove_not_before_cid(cnx, unique_path_id, retire_before, current_time);
+            if (transport_error == 0) {
+                picoquic_test_and_signal_new_path_allowed(cnx);
+                if (remote_cnxid_stash->retire_cnxid_before < retire_before) {
+                    /* retire the now deprecated CIDs */
+                    remote_cnxid_stash->retire_cnxid_before = retire_before;
+                    transport_error = picoquic_remove_not_before_cid(cnx, unique_path_id, retire_before, current_time);
+                }
             }
             if (transport_error != 0) {
                 picoquic_connection_error(cnx, transport_error,

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1313,6 +1313,8 @@ typedef struct st_picoquic_cnx_t {
     unsigned int is_forced_probe_up_required : 1; /* application wants "probe up" if CC requests it */
     unsigned int is_address_discovery_provider : 1; /* send the address discovery extension */
     unsigned int is_address_discovery_receiver : 1; /* receive the address discovery extension */
+    unsigned int is_subscribed_to_path_allowed : 1; /* application wants to be advised if it is now possible to create a path */
+    unsigned int is_notified_that_path_is_allowed : 1; /* application wants to be advised if it is now possible to create a path */
     
     /* PMTUD policy */
     picoquic_pmtud_policy_enum pmtud_policy;
@@ -2043,6 +2045,8 @@ const uint8_t* picoquic_skip_path_abandon_frame(const uint8_t* bytes, const uint
 const uint8_t* picoquic_skip_path_available_or_standby_frame(const uint8_t* bytes, const uint8_t* bytes_max);
 int picoquic_queue_path_available_or_standby_frame(
     picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_path_status_enum status);
+/* Internal only API, notify that next path is now allowed. */
+void picoquic_test_and_signal_new_path_allowed(picoquic_cnx_t* cnx);
 
 int picoquic_decode_closing_frames(picoquic_cnx_t* cnx, uint8_t* bytes, size_t bytes_max, int* closing_received);
 


### PR DESCRIPTION
Improve the implementation of `picoquic_probe_new_path_ex` to incorporate tests and return detailed error codes.

Add API `picoquic_subscribe_new_path_allowed` to either return immediately if `picoquic_probe_new_path_ex` is expected to succeed, or program the stack to execute a callback `picoquic_callback_next_path_allowed` when the next call to  `picoquic_probe_new_path_ex` is expected to succeed.

Use these two API in `picoquicdemo` to provide an example.

This should address issue #1835 