### PR TITLE
compiler warnings

### DIFF
--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -658,7 +658,7 @@ int client_loop_cb(picoquic_quic_t* quic, picoquic_packet_loop_cb_enum cb_mode,
                 if (cb_ctx->multipath_initiated == 0) {
                     int is_already_allowed = 0;
                     cb_ctx->multipath_initiated = 1;
-                    if (ret = picoquic_subscribe_new_path_allowed(cb_ctx->cnx_client, &is_already_allowed) == 0) {
+                    if ((ret = picoquic_subscribe_new_path_allowed(cb_ctx->cnx_client, &is_already_allowed)) == 0) {
                         if (is_already_allowed) {
                             ret = client_create_additional_path(cb_ctx->cnx_client, cb_ctx);
                         }

--- a/picoquictest/picoquic_ns.c
+++ b/picoquictest/picoquic_ns.c
@@ -644,7 +644,7 @@ void picoquic_ns_simlink_reset(picoquictest_sim_link_t* link, double data_rate_i
         link->last_packet = previous_packet;
     }
     /* Requeue the other packets:
-    /* reset the queue time to current_time, i.e., after packets in transit are delivered.*/
+     * reset the queue time to current_time, i.e., after packets in transit are delivered.*/
     link->queue_time = current_time;
     /* reset the leaky bucket, so it starts working from the current time. */
     link->bucket_arrival_last = current_time;


### PR DESCRIPTION
just a quick fix 

```
[126/230] Building C object CMakeFiles/picoquic-test.dir/picoquictest/picoquic_ns.c.o
/Users/matthias/CLionProjects/picoquic/picoquictest/picoquic_ns.c:647:5: warning: '/*' within block comment [-Wcomment]
  647 |     /* reset the queue time to current_time, i.e., after packets in transit are delivered.*/
      |     ^
1 warning generated.
[143/230] Building C object CMakeFiles/picoquicdemo.dir/picoquicfirst/picoquicdemo.c.o
/Users/matthias/CLionProjects/picoquic/picoquicfirst/picoquicdemo.c:661:29: warning: using the result of an assignment as a condition without parentheses [-Wparentheses]
  661 |                     if (ret = picoquic_subscribe_new_path_allowed(cb_ctx->cnx_client, &is_already_allowed) == 0) {
      |                         ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/matthias/CLionProjects/picoquic/picoquicfirst/picoquicdemo.c:661:29: note: place parentheses around the assignment to silence this warning
  661 |                     if (ret = picoquic_subscribe_new_path_allowed(cb_ctx->cnx_client, &is_already_allowed) == 0) {
      |                             ^                                                                                  
      |                         (                                                                                      )
/Users/matthias/CLionProjects/picoquic/picoquicfirst/picoquicdemo.c:661:29: note: use '==' to turn this assignment into an equality comparison
  661 |                     if (ret = picoquic_subscribe_new_path_allowed(cb_ctx->cnx_client, &is_already_allowed) == 0) {
      |                             ^
      |                             ==
1 warning generated.
```