### PR TITLE
Make addition of CC algorithms modular

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ set(PICOQUIC_LIBRARY_FILES
     picoquic/port_blocking.c
     picoquic/prague.c
     picoquic/quicctx.c
+    picoquic/register_all_cc_algorithms.c
     picoquic/sacks.c
     picoquic/sender.c
     picoquic/sim_link.c
@@ -126,6 +127,12 @@ set(PICOQUIC_CORE_HEADERS
      picoquic/picoquic_binlog.h
      picoquic/picoquic_config.h
      picoquic/picoquic_lb.h
+     picoquic/picoquic_newreno.h
+     picoquic/picoquic_cubic.h
+     picoquic/picquic_bbr.h
+     picoquic/picquic_bbr1.h
+     picoquic/picquic_fastcc.h
+     picoquic/picquic_prague.h
      picoquic/siphash.h)
 
 set(LOGLIB_LIBRARY_FILES

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -34,6 +34,7 @@
 #include "picoquic_unified_log.h"
 #include "tls_api.h"
 #include "picoquic_config.h"
+#include "picoquic_bbr.h"
 
 typedef struct st_option_param_t {
     char const * param;
@@ -64,7 +65,7 @@ static option_table_line_t option_table[] = {
     { picoquic_option_DisablePortBlocking, 'X', "disable_block", 0, "", "Disable the check for blocked ports"},
     { picoquic_option_SOLUTION_DIR, 'S', "solution_dir", 1, "folder", "Set the path to the source files to find the default files" },
     { picoquic_option_CC_ALGO, 'G', "cc_algo", 1, "cc_algorithm",
-    "Use the specified congestion control algorithm: reno, cubic, bbr or fast. Defaults to bbr." },
+    "Use the specified congestion control algorithm. Defaults to bbr. Supported values are:" },
     { picoquic_option_SPINBIT, 'P', "spinbit", 1, "number", "Set the default spinbit policy" },
     { picoquic_option_LOSSBIT, 'O', "lossbit", 1, "number", "Set the default lossbit policy" },
     { picoquic_option_MULTIPATH, 'M', "multipath", 0, "", "Enable QUIC multipath extension" },
@@ -482,6 +483,22 @@ void picoquic_config_usage_file(FILE* F)
             putc(' ', F);
         }
         fprintf(F, " %s\n", option_table[i].option_help);
+        if (option_table[i].option_num == picoquic_option_CC_ALGO){
+            if (picoquic_congestion_control_algorithms != NULL &&
+                picoquic_nb_congestion_control_algorithms > 0) {
+                /* Add a line with supported values. */
+                for (size_t j = 0; j < 18; j++) {
+                    putc(' ', F);
+                }
+                for (size_t k = 0; k < picoquic_nb_congestion_control_algorithms; k++) {
+                    if (k != 0) {
+                        fprintf(F, ", ");
+                    }
+                    fprintf(F, "%s", picoquic_congestion_control_algorithms[k]->congestion_algorithm_id);
+                }
+                fprintf(F, ".\n");
+            }
+        }
     }
 }
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1565,6 +1565,8 @@ typedef struct st_picoquic_congestion_algorithm_t {
     picoquic_congestion_algorithm_observe alg_observe;
 } picoquic_congestion_algorithm_t;
 
+#if 1
+#else
 extern picoquic_congestion_algorithm_t* picoquic_newreno_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_cubic_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_dcubic_algorithm;
@@ -1572,10 +1574,19 @@ extern picoquic_congestion_algorithm_t* picoquic_fastcc_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_bbr_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_prague_algorithm;
 extern picoquic_congestion_algorithm_t* picoquic_bbr1_algorithm;
+#endif
 
 #define PICOQUIC_DEFAULT_CONGESTION_ALGORITHM picoquic_newreno_algorithm;
 
-picoquic_congestion_algorithm_t const* picoquic_get_congestion_algorithm(char const* alg_name);
+
+extern picoquic_congestion_algorithm_t const** picoquic_congestion_control_algorithms;
+extern size_t picoquic_nb_congestion_control_algorithms;
+/* Register a custom table of congestion control algorithms */
+void picoquic_register_congestion_control_algorithms(picoquic_congestion_algorithm_t const** alg, size_t nb_algorithms);
+/* Register a full list of congestion control algorithms */
+void picoquic_register_all_congestion_control_algorithms();
+
+picoquic_congestion_algorithm_t const* picoquic_get_congestion_algorithm(char const* alg_id);
 
 void picoquic_set_default_congestion_algorithm(picoquic_quic_t* quic, picoquic_congestion_algorithm_t const* algo);
 

--- a/picoquic/picoquic.vcxproj
+++ b/picoquic/picoquic.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="quicctx.c" />
     <ClCompile Include="packet.c" />
     <ClCompile Include="picohash.c" />
+    <ClCompile Include="register_all_cc_algorithms.c" />
     <ClCompile Include="sacks.c" />
     <ClCompile Include="sender.c" />
     <ClCompile Include="bbr.c" />

--- a/picoquic/picoquic.vcxproj.filters
+++ b/picoquic/picoquic.vcxproj.filters
@@ -141,6 +141,9 @@
     <ClCompile Include="siphash.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="register_all_cc_algorithms.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="picoquic.h">

--- a/picoquic/picoquic_bbr.h
+++ b/picoquic/picoquic_bbr.h
@@ -1,0 +1,36 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_BBR_H
+#define PICOQUIC_BBR_H
+
+#include "picoquic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern picoquic_congestion_algorithm_t* picoquic_bbr_algorithm;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/picoquic/picoquic_bbr1.h
+++ b/picoquic/picoquic_bbr1.h
@@ -1,0 +1,29 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_BBR1_H
+#define PICOQUIC_BBR1_H
+
+#include "picoquic.h"
+
+extern picoquic_congestion_algorithm_t* picoquic_bbr1_algorithm;
+
+#endif

--- a/picoquic/picoquic_cubic.h
+++ b/picoquic/picoquic_cubic.h
@@ -1,0 +1,37 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_CUBIC_H
+#define PICOQUIC_CUBIC_H
+
+#include "picoquic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern picoquic_congestion_algorithm_t* picoquic_cubic_algorithm;
+extern picoquic_congestion_algorithm_t* picoquic_dcubic_algorithm;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/picoquic/picoquic_fastcc.h
+++ b/picoquic/picoquic_fastcc.h
@@ -1,0 +1,30 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2017, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_FASTCC_H
+#define PICOQUIC_FASTCC_H
+
+#include "picoquic.h"
+
+
+extern picoquic_congestion_algorithm_t* picoquic_fastcc_algorithm;
+
+#endif

--- a/picoquic/picoquic_newreno.h
+++ b/picoquic/picoquic_newreno.h
@@ -1,0 +1,36 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_NEWRENO_H
+#define PICOQUIC_NEWRENO_H
+
+#include "picoquic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern picoquic_congestion_algorithm_t* picoquic_newreno_algorithm;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/picoquic/picoquic_prague.h
+++ b/picoquic/picoquic_prague.h
@@ -1,0 +1,36 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_PRAGUE_H
+#define PICOQUIC_PRAGUE_H
+
+#include "picoquic.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern picoquic_congestion_algorithm_t* picoquic_prague_algorithm;
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/picoquic/register_all_cc_algorithms.c
+++ b/picoquic/register_all_cc_algorithms.c
@@ -1,0 +1,49 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2025, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "picoquic.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
+
+
+/* Register a complete list of congestion control algorithms, which
+* can then be used by calls to picoquic_get_congestion_algorithm()
+* and picoquic_create_and_configure(). 
+ */
+
+picoquic_congestion_algorithm_t const* getter_test_cc_algo_list[7] = {
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL
+};
+
+void picoquic_register_all_congestion_control_algorithms()
+{
+    getter_test_cc_algo_list[0] = picoquic_newreno_algorithm;
+    getter_test_cc_algo_list[1] = picoquic_cubic_algorithm;
+    getter_test_cc_algo_list[2] = picoquic_dcubic_algorithm;
+    getter_test_cc_algo_list[3] = picoquic_fastcc_algorithm;
+    getter_test_cc_algo_list[4] = picoquic_bbr_algorithm;
+    getter_test_cc_algo_list[5] = picoquic_prague_algorithm;
+    getter_test_cc_algo_list[6] = picoquic_bbr1_algorithm;
+    picoquic_register_congestion_control_algorithms(getter_test_cc_algo_list, 7);
+}

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -1317,6 +1317,7 @@ int main(int argc, char** argv)
     WSADATA wsaData = { 0 };
     (void)WSA_START(MAKEWORD(2, 2), &wsaData);
 #endif
+    picoquic_register_all_congestion_control_algorithms();
     picoquic_config_init(&config);
     memcpy(option_string, "A:u:f:1", 7);
     ret = picoquic_config_option_letters(option_string + 7, sizeof(option_string) - 7, NULL);

--- a/picoquictest/ack_frequency_test.c
+++ b/picoquictest/ack_frequency_test.c
@@ -29,6 +29,12 @@
 #include "logreader.h"
 #include "qlog.h"
 
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+
 /* Verify that the ack frequency is correctly set.
  */
 

--- a/picoquictest/app_limited.c
+++ b/picoquictest/app_limited.c
@@ -29,6 +29,11 @@
 #include "picoquic_binlog.h"
 #include "logreader.h"
 #include "qlog.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
 
 /* Add a series of tests to study the behavior of rate limited
 * clients, such as those sending at a sustained rate lower

--- a/picoquictest/cc_compete_test.c
+++ b/picoquictest/cc_compete_test.c
@@ -24,6 +24,12 @@
 #include <string.h>
 #include <stdint.h>
 #include "picoquic_ns.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
 
 /* Congestion compete test.
 * These tests measure what happens when multiple connections fight for the same

--- a/picoquictest/config_usage_ref.txt
+++ b/picoquictest/config_usage_ref.txt
@@ -11,7 +11,8 @@ Picoquic options:
   -s <32 hex chars> Reset seed
   -X              Disable the check for blocked ports
   -S folder       Set the path to the source files to find the default files
-  -G cc_algorithm Use the specified congestion control algorithm: reno, cubic, bbr or fast. Defaults to bbr.
+  -G cc_algorithm Use the specified congestion control algorithm. Defaults to bbr. Supported values are:
+                  newreno, cubic, bbr.
   -P number       Set the default spinbit policy
   -O number       Set the default lossbit policy
   -M              Enable QUIC multipath extension

--- a/picoquictest/congestion_test.c
+++ b/picoquictest/congestion_test.c
@@ -30,6 +30,13 @@
 #include "picoquic_logger.h"
 #include "qlog.h"
 
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
+
 static test_api_stream_desc_t test_scenario_congestion[] = {
     { 4, 0, 257, 1000000 },
     { 8, 4, 257, 1000000 },

--- a/picoquictest/cpu_limited.c
+++ b/picoquictest/cpu_limited.c
@@ -30,6 +30,14 @@
 #include "logreader.h"
 #include "qlog.h"
 
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
+
+
 /* Add a series of tests to study the behavior of cpu-limited clients.
 * This requires simulating clients that have cpu limitations, such
 * as only being able to proceed a set number of messages per second.

--- a/picoquictest/datagram_tests.c
+++ b/picoquictest/datagram_tests.c
@@ -42,7 +42,7 @@
 #include "picoquic_logger.h"
 #include "performance_log.h"
 #include "picoquictest.h"
-
+#include "picoquic_bbr.h"
 /*
  * Test whether datagrams are sent and received properly
  */

--- a/picoquictest/delay_tolerant_test.c
+++ b/picoquictest/delay_tolerant_test.c
@@ -37,6 +37,7 @@
 #include "picoquic_logger.h"
 #include "performance_log.h"
 #include "picoquictest.h"
+#include "picoquic_newreno.h"
 
 
 /* Delay tolerant networking tests.

--- a/picoquictest/getter_test.c
+++ b/picoquictest/getter_test.c
@@ -26,6 +26,12 @@
 #include "picoquic_utils.h"
 #include "picoquictest_internal.h"
 #include "picoquic.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
 
 /* Verify that the getter/setter functions work as expected 
  */
@@ -229,10 +235,13 @@ int getter_test()
             ret = -1;
         }
     }
-
+    /* set the algorithm list to the completevalue before the alogorithm set/get test
+    * Hopefully, nobody is going to call their algorithm "wuovipfwds".
+     */
+    picoquic_register_all_congestion_control_algorithms();
     if (ret == 0) {
         char const* alg_name[] = {
-            "reno", "cubic", "dcubic", "fast", "bbr", "prague", "bbr1", "abracadabra", NULL
+            "reno", "cubic", "dcubic", "fast", "bbr", "prague", "bbr1", "wuovipfwds", NULL
         };
         picoquic_congestion_algorithm_t const* alg[] = {
             picoquic_newreno_algorithm, picoquic_cubic_algorithm, picoquic_dcubic_algorithm,

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -44,7 +44,7 @@
 #endif
 #include "autoqlog.h"
 #include "picoquic_binlog.h"
-#include "picoquic_utils.h"
+#include "picoquic_bbr.h"
 
 /*
  * Test of the prefixed integer encoding

--- a/picoquictest/high_latency_test.c
+++ b/picoquictest/high_latency_test.c
@@ -37,7 +37,9 @@
 #include "picoquic_logger.h"
 #include "performance_log.h"
 #include "picoquictest.h"
-
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
 
 /* Very high latency test. This requires relaxing the handshake timer, so that it covers
  * at least one rtt.

--- a/picoquictest/l4s_test.c
+++ b/picoquictest/l4s_test.c
@@ -30,6 +30,10 @@
 #include "picoquic_binlog.h"
 #include "logreader.h"
 #include "qlog.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_prague.h"
 
 static test_api_stream_desc_t test_scenario_l4s[] = {
     { 4, 0, 257, 1000000 },

--- a/picoquictest/mediatest.c
+++ b/picoquictest/mediatest.c
@@ -27,6 +27,8 @@
 #include "picoquic_utils.h"
 #include "picoquictest_internal.h"
 #include "picoquic_binlog.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
 
 /* Media tests: simulate media transmission, include cases in which
 * the media bandwidth is much lower than the available bandwidth on

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -28,6 +28,7 @@
 #include "picoquic_binlog.h"
 #include "logreader.h"
 #include "qlog.h"
+#include "picoquic_bbr.h"
 
 /* Add the additional links for multipath scenario */
 static int multipath_test_add_links(picoquic_test_tls_api_ctx_t* test_ctx, int mtu_drop)

--- a/picoquictest/netperf_test.c
+++ b/picoquictest/netperf_test.c
@@ -29,6 +29,7 @@
 #include "picoquic_internal.h"
 #include "tls_api.h"
 #include "picoquictest_internal.h"
+#include "picoquic_bbr.h"
 #ifdef _WINDOWS
 #include "wincompat.h"
 #else

--- a/picoquictest/pacing_test.c
+++ b/picoquictest/pacing_test.c
@@ -29,6 +29,12 @@
 #include "picoquic_binlog.h"
 #include "picoquic_logger.h"
 #include "qlog.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
 
 /* Test of the pacing functions.
 */

--- a/picoquictest/satellite_test.c
+++ b/picoquictest/satellite_test.c
@@ -37,6 +37,10 @@
 #include "picoquic_logger.h"
 #include "performance_log.h"
 #include "picoquictest.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
+#include "picoquic_prague.h"
 
 
 /* This is similar to the long rtt test, but operating at a higher speed.

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -38,6 +38,11 @@
 #include "picoquic_logger.h"
 #include "performance_log.h"
 #include "picoquictest.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_fastcc.h"
+#include "picoquic_prague.h"
 
 static const uint8_t test_ticket_encrypt_key[32] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,

--- a/picoquictest/warptest.c
+++ b/picoquictest/warptest.c
@@ -27,6 +27,7 @@
 #include "picoquic_utils.h"
 #include "picoquictest_internal.h"
 #include "autoqlog.h"
+#include "picoquic_bbr.h"
 
 /* Warp tests:
 * These tests are very similar to the "media tests", with one twist.

--- a/picoquictest/wifitest.c
+++ b/picoquictest/wifitest.c
@@ -28,6 +28,10 @@
 #include "picoquictest_internal.h"
 #include "autoqlog.h"
 #include "picoquic_binlog.h"
+#include "picoquic_newreno.h"
+#include "picoquic_cubic.h"
+#include "picoquic_bbr.h"
+#include "picoquic_bbr1.h"
 
 /* Wifi test: explore the behavior of QUIC over Wi-Fi links.
 * 

--- a/quicwind/quicwind_proc.c
+++ b/quicwind/quicwind_proc.c
@@ -19,6 +19,7 @@
 #include "democlient.h"
 #include "quicwind.h"
 #include "autoqlog.h"
+#include "picoquic_cubic.h"
 
 #ifndef SOCKET_TYPE
 #define SOCKET_TYPE SOCKET

--- a/sample/sample_background.c
+++ b/sample/sample_background.c
@@ -47,6 +47,7 @@
 #include <autoqlog.h>
 #include <picoquic_packet_loop.h>
 #include "picoquic_sample.h"
+#include "picoquic_bbr.h"
 
  /* Background thread management:
   * 

--- a/sample/sample_client.c
+++ b/sample/sample_client.c
@@ -47,6 +47,7 @@
 #include <autoqlog.h>
 #include <picoquic_packet_loop.h>
 #include "picoquic_sample.h"
+#include "picoquic_bbr.h"
 
  /* Client context and callback management:
   *

--- a/sample/sample_server.c
+++ b/sample/sample_server.c
@@ -47,6 +47,7 @@
 #include <autoqlog.h>
 #include "picoquic_sample.h"
 #include "picoquic_packet_loop.h"
+#include "picoquic_bbr.h"
 
 /* Server context and callback management:
  *


### PR DESCRIPTION
We like to use picoquic to investigate congestion control and test multiple algorithms. However, we do not want to load the code of multiple algorithms in every executable program that uses picoquic. For example, some developers are looking at Arduino class devices, and want to make the code as small as possible.

The general approach is to use dynamic linking. If an object file does not include any function required by the program, it will not be linked into the executable. But to achieve that, the program shall not have any reference to the function, including no calls in a rarely used branch, and no addition to the function pointer in a list of "external" objects. We apply this logic to congestion control algorithms as follow:

* remove the list of congestion algorithm pointers in `picoquic.h`
* declare a separate header file for each congestion control algorithm, to be included in the programs using that algorithm
* add a dynamic table of congestion control algorithm, either initialized by a program to the small set that it uses or  initialized by a "register all algorithms" function for programs like `picoquicdemo` that want to surface all available options
* modify the "config" functions to use the table of algorithms registered by the program.
 