### PR TITLE
Add seed bandwidth to picquic_ns

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2105,6 +2105,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(cc_ns_satellite)
+        {
+            int ret = cc_ns_satellite_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(cc_ns_media)
         {
             int ret = cc_ns_media_test();

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -118,6 +118,7 @@ static const picoquic_test_def_t test_table[] = {
     { "cc_ns_wifi_fade", cc_ns_wifi_fade_test },
     { "cc_ns_wifi_suspension", cc_ns_wifi_suspension_test },
     { "cc_ns_varylink", cc_ns_varylink_test },
+    { "cc_ns_satellite", cc_ns_satellite_test },
     { "cc_ns_media", cc_ns_media_test }
 };
 

--- a/picoquictest/cc_compete_test.c
+++ b/picoquictest/cc_compete_test.c
@@ -359,3 +359,31 @@ int cc_ns_varylink_test()
 
     return picoquic_ns(&spec, NULL);
 }
+
+/* Check using seed bandwidth and seed RTT for a satellite test.
+* Without setting the seed parameters, this test completes in
+* 7.25 seconds. If the seed is properly set, it completes in
+* 6.25 seconds. Stting the target completion time to 6.5 seconds
+* verifies that seeding works as expected.
+ */
+static char const* cc_compete_satellite_scenario = "=b1:*1:397:20000000;";
+
+int cc_ns_satellite_test()
+{
+    picoquic_ns_spec_t spec = { 0 };
+    picoquic_connection_id_t icid = { { 0xcc, 0x5a, 0xbb, 0, 0, 0, 0, 0}, 8 };
+    spec.main_cc_algo = picoquic_bbr_algorithm;
+    spec.nb_connections = 1;
+    spec.main_start_time = 0;
+    spec.main_scenario_text = cc_compete_satellite_scenario;
+    spec.data_rate_in_gbps = 0.05;
+    spec.latency = 300000;
+    spec.main_target_time = 6500000;
+    spec.queue_delay_max = 600000;
+    spec.icid = icid;
+    spec.qlog_dir = ".";
+    spec.seed_cwin = 3750000;
+    spec.seed_rtt = 600010;
+
+    return picoquic_ns(&spec, NULL);
+}

--- a/picoquictest/picoquic_ns.c
+++ b/picoquictest/picoquic_ns.c
@@ -105,6 +105,8 @@ typedef struct st_picoquic_ns_client_t {
     char const* cc_option_string;
     quicperf_ctx_t* quicperf_ctx;
     picoquic_connection_id_t icid;
+    uint64_t seed_cwin;
+    uint64_t seed_rtt;
 } picoquic_ns_client_t;
 
 typedef struct st_picoquic_ns_ctx_t {
@@ -144,7 +146,17 @@ int picoquic_ns_server_callback(picoquic_cnx_t* cnx,
             if (cc_ctx->client_ctx[i] != NULL && cc_ctx->client_ctx[i]->cnx != NULL &&
                 picoquic_compare_connection_id(&cnx->path[0]->first_tuple->p_remote_cnxid->cnx_id,
                     &cc_ctx->client_ctx[i]->cnx->path[0]->first_tuple->p_local_cnxid->cnx_id) == 0) {
-                picoquic_set_congestion_algorithm_ex(cnx, cc_ctx->client_ctx[i]->cc_algo, cc_ctx->client_ctx[i]->cc_option_string);
+                picoquic_set_congestion_algorithm_ex(cnx, cc_ctx->client_ctx[i]->cc_algo,
+                    cc_ctx->client_ctx[i]->cc_option_string);
+                if (cc_ctx->client_ctx[i]->seed_cwin > 0 &&
+                    cc_ctx->client_ctx[i]->seed_rtt > 0) {
+                    uint8_t* ip_addr;
+                    uint8_t ip_addr_len;
+                    picoquic_get_ip_addr((struct sockaddr*)&cc_ctx->addr[1], &ip_addr, &ip_addr_len);
+                    picoquic_seed_bandwidth(cnx, cc_ctx->client_ctx[i]->seed_rtt,
+                        cc_ctx->client_ctx[i]->seed_cwin, ip_addr, ip_addr_len);
+                }
+                
                 ret = 0;
             }
         }
@@ -199,6 +211,8 @@ int picoquic_ns_create_client_ctx(picoquic_ns_ctx_t* cc_ctx, picoquic_ns_spec_t*
             client_ctx->start_time = spec->main_start_time;
             client_ctx->cc_algo = spec->main_cc_algo;
             client_ctx->cc_option_string = spec->main_cc_options;
+            client_ctx->seed_cwin = spec->seed_cwin;
+            client_ctx->seed_rtt = spec->seed_rtt;
             scenario_text = spec->main_scenario_text;
         }
         else {
@@ -540,7 +554,7 @@ picoquic_ns_ctx_t* picoquic_ns_create_ctx(picoquic_ns_spec_t* spec, FILE* err_fd
             cc_ctx->packet_ecn_default = PICOQUIC_ECN_ECT_1;
         }
         /* Create the client contexts */
-        if (spec->nb_connections > PICOQUIC_NS_MAX_CLIENTS) {
+        if (spec->nb_connections > PICOQUIC_NS_MAX_CLIENTS || spec->nb_connections == 0) {
             ret = -1;
         }
         else {

--- a/picoquictest/picoquic_ns.h
+++ b/picoquictest/picoquic_ns.h
@@ -68,6 +68,8 @@ typedef struct st_picoquic_ns_spec_t {
     char const* main_cc_options;
     picoquic_congestion_algorithm_t const* background_cc_algo;
     char const* background_cc_options;
+    uint64_t seed_cwin; /* seed bandwidth, server side. */
+    uint64_t seed_rtt; /* seed rtt, server side. */
     int nb_connections;
     double data_rate_in_gbps; /* datarate, server to clients, defaults to 10 mbps */
     double data_rate_up_in_gbps; /* datarate, server to clients, defaults to data rate */

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -285,6 +285,7 @@ int cc_ns_low_and_up_test();
 int cc_ns_wifi_fade_test();
 int cc_ns_wifi_suspension_test();
 int cc_ns_varylink_test();
+int cc_ns_satellite_test();
 int cc_ns_media_test();
 int satellite_basic_test();
 int satellite_seeded_test();


### PR DESCRIPTION
Add "seed_cwin" and "seed_rtt" attributes to picoquic_ns specificatons. Add code to apply these attributes to the server connection. Add test to verify that this works as expected.