### PR TITLE
Add simulation of extreme Wi-Fi jitter.

### DIFF
--- a/picoquic/picoquic_utils.h
+++ b/picoquic/picoquic_utils.h
@@ -245,6 +245,9 @@ uint64_t picoquic_test_random(uint64_t* random_context);
 void picoquic_test_random_bytes(uint64_t* random_context, uint8_t* bytes, size_t bytes_max);
 uint64_t picoquic_test_uniform_random(uint64_t* random_context, uint64_t rnd_max);
 double picoquic_test_gauss_random(uint64_t* random_context); /* random gaussian of variance 1.0, average 0 */
+/* picoquic_test_poisson_random: Poisson distribution lambda 
+* parameter exp_minus_lambda_2_30 = (uint64_t)(exp(-lambda)*0x40000000) */
+uint64_t picoquic_test_poisson_random(uint64_t* random_context, uint64_t exp_minus_lambda_2_30); 
 
 /* Convert text carried in uint8_t arrays to text string
  * suitable for logs */
@@ -269,6 +272,11 @@ typedef struct st_picoquictest_sim_packet_t {
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picoquictest_sim_packet_t;
 
+typedef enum {
+    jitter_gauss = 0,
+    jitter_wifi
+} picoquic_jitter_mode;
+
 typedef struct st_picoquictest_sim_link_t {
     uint64_t next_send_time;
     uint64_t queue_time;
@@ -279,6 +287,7 @@ typedef struct st_picoquictest_sim_link_t {
     uint64_t packets_dropped;
     uint64_t packets_sent;
     uint64_t jitter;
+    picoquic_jitter_mode jitter_mode;
     uint64_t jitter_seed;
     size_t path_mtu;
     picoquictest_sim_packet_t* first_packet;

--- a/picoquictest/picoquic_ns.c
+++ b/picoquictest/picoquic_ns.c
@@ -345,9 +345,15 @@ int picoquic_ns_create_link_spec(picoquic_ns_ctx_t* cc_ctx, picoquic_ns_spec_t* 
         case link_scenario_wifi_fade:
             if ((ret = picoquic_ns_create_default_link_spec(cc_ctx, spec, 3)) == 0) {
                 cc_ctx->vary_link_spec[0].duration = 1000000;
+                cc_ctx->vary_link_spec[0].jitter = 999;
+                cc_ctx->vary_link_spec[0].is_wifi_jitter = 1;
                 cc_ctx->vary_link_spec[1].duration = 2000000;
-                cc_ctx->vary_link_spec[1].data_rate_in_gbps_down *= 0.1;
-                cc_ctx->vary_link_spec[1].data_rate_in_gbps_up *= 0.1;
+                cc_ctx->vary_link_spec[1].data_rate_in_gbps_down *= 0.9;
+                cc_ctx->vary_link_spec[1].data_rate_in_gbps_up *= 0.9;
+                cc_ctx->vary_link_spec[1].is_wifi_jitter = 1;
+                cc_ctx->vary_link_spec[1].jitter = 12000;
+                cc_ctx->vary_link_spec[2].jitter = 999;
+                cc_ctx->vary_link_spec[2].is_wifi_jitter = 1;
                 cc_ctx->vary_link_spec[2].duration = UINT64_MAX;
             }
             break;
@@ -720,6 +726,7 @@ void picoquic_ns_simlink_reset(picoquictest_sim_link_t* link, double data_rate_i
     link->picosec_per_byte = (uint64_t)pico_d;
     link->microsec_latency = vary_link_spec->latency;
     link->jitter = vary_link_spec->jitter;
+    link->jitter_mode = (vary_link_spec->is_wifi_jitter) ? jitter_wifi : jitter_gauss;
     link->queue_delay_max = vary_link_spec->queue_delay_max;
     link->l4s_max = vary_link_spec->l4s_max;
     link->is_suspended = (data_rate_in_gps <= 0);

--- a/picoquictest/picoquic_ns.h
+++ b/picoquictest/picoquic_ns.h
@@ -56,6 +56,7 @@ typedef struct st_picoquic_ns_link_spec_t {
     uint64_t l4s_max; /* if specified, specify the max buffer queuing for the link, in microseconds */
     uint64_t nb_loss_in_burst; /* if specified, loose that many packet in burst of errors every interval */
     uint64_t packets_between_losses; /* packets to send between two losses */
+    int is_wifi_jitter; /* 0 = guaussian jitter (default), 1 = wifi jitter emulation. */
 } picoquic_ns_link_spec_t;
 
 typedef struct st_picoquic_ns_spec_t {
@@ -75,6 +76,7 @@ typedef struct st_picoquic_ns_spec_t {
     double data_rate_up_in_gbps; /* datarate, server to clients, defaults to data rate */
     uint64_t latency; /* one way latency, microseconds, both directions */
     uint64_t jitter; /* delay jitter, microseconds, both directions */
+    int is_wifi_jitter; /* 0 = guaussian jitter (default), 1 = wifi jitter emulation. */
     uint64_t queue_delay_max; /* if specified, specify the max buffer queuing for the link, in microseconds */
     uint64_t l4s_max; /* if specified, specify the max buffer queuing for the link, in microseconds */
     picoquic_connection_id_t icid; /* if specified, set the ICID of connections. Last byte will be overwriten by connection number */


### PR DESCRIPTION
Wi-Fi jitter can go up to 200ms in some extreme scenarios. The PR adds support of these scenarios in the simulation "picoquic_ns".