### PR TITLE
Testing removal of bypass rate protection

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1600,13 +1600,17 @@ void picoquic_set_congestion_algorithm_ex(picoquic_cnx_t* cnx, picoquic_congesti
 * will bypass congestion control.
 * 
 * This experimental feature will not be activated in a multipath
-* environment, i.e., if more that 1 path is activated.
+* environment, i.e., if more that 1 path is activated.*/
+#if 1
+#else
+* 
 * 
 * To protect against potential abuse, the code includes a rate limiter,
 * ensuring that if congestion control is blocking transmission, 
 * the "bypass" will not result in more than 1 Mbps of
 * traffic.
  */
+#endif
 void picoquic_set_priority_limit_for_bypass(picoquic_cnx_t* cnx, uint8_t priority_limit);
 
 /* The experimental API `picoquic_set_feedback_loss_notification` allow applications

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -88,9 +88,11 @@ extern "C" {
 
 #define PICOQUIC_CWIN_INITIAL (10 * PICOQUIC_MAX_PACKET_SIZE)
 #define PICOQUIC_CWIN_MINIMUM (2 * PICOQUIC_MAX_PACKET_SIZE)
-
+#if 1
+#else
 #define PICOQUIC_PRIORITY_BYPASS_MAX_RATE 125000
 #define PICOQUIC_PRIORITY_BYPASS_QUANTUM 2560
+#endif
 
 #define PICOQUIC_DEFAULT_CRYPTO_EPOCH_LENGTH (1<<22)
 
@@ -1490,7 +1492,10 @@ typedef struct st_picoquic_cnx_t {
     uint64_t high_priority_stream_id;
     uint64_t next_stream_id[4];
     uint64_t priority_limit_for_bypass; /* Bypass CC if dtagram or stream priority lower than this, 0 means never */
+#if 1
+#else
     picoquic_pacing_t priority_bypass_pacing;
+#endif
 
     /* Repeat queue contains packets with data frames that should be
      * sent according to priority when congestion window opens. */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3901,7 +3901,10 @@ picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
             for (int i = 0; i < 4; i++) {
                 cnx->next_stream_id[i] = i;
             }
+#if 1
+#else
             picoquic_pacing_init(&cnx->priority_bypass_pacing, start_time);
+#endif
             picoquic_register_path(cnx, cnx->path[0]);
         }
     }
@@ -5088,11 +5091,14 @@ void picoquic_set_congestion_algorithm(picoquic_cnx_t* cnx, picoquic_congestion_
 void picoquic_set_priority_limit_for_bypass(picoquic_cnx_t* cnx, uint8_t priority_limit)
 {
     cnx->priority_limit_for_bypass = priority_limit;
+#if 1
+#else
     if (priority_limit > 0) {
         picoquic_update_pacing_parameters(&cnx->priority_bypass_pacing,
             PICOQUIC_PRIORITY_BYPASS_MAX_RATE, PICOQUIC_PRIORITY_BYPASS_QUANTUM,
             cnx->path[0]->send_mtu, cnx->path[0]->smoothed_rtt, NULL);
     }
+#endif
 }
 
 void picoquic_set_feedback_loss_notification(picoquic_cnx_t* cnx, unsigned int should_notify)

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2812,7 +2812,10 @@ static uint8_t* picoquic_prepare_stream_and_datagrams(picoquic_cnx_t* cnx, picoq
         picoquic_packet_t* first_repeat = picoquic_first_data_repeat_packet(cnx);
         uint64_t current_priority = UINT64_MAX;
         uint64_t stream_priority = UINT64_MAX;
+#if 1
+#else
         uint8_t* bytes_before_iteration = bytes_next;
+#endif
         int something_sent = 0;
         int conflict_found = 0;
 
@@ -2893,11 +2896,13 @@ static uint8_t* picoquic_prepare_stream_and_datagrams(picoquic_cnx_t* cnx, picoq
                 more_data, is_pure_ack, &datagram_tried_and_failed, &datagram_sent, ret);
             something_sent = datagram_sent;
         }
-
+#if 1
+#else
         if (current_priority < cnx->priority_limit_for_bypass && bytes_next > bytes_before_iteration) {
             picoquic_update_pacing_data_after_send(&cnx->priority_bypass_pacing, bytes_next - bytes_before_iteration,
                 cnx->path[0]->send_mtu, current_time);
         }
+#endif
 
         if (is_first_round) {
             *no_data_to_send = ((first_stream == NULL && first_repeat == NULL) || stream_tried_and_failed) &&
@@ -3408,31 +3413,39 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                 length = bytes_next - bytes;
 
                 if ((path_x->cwin < path_x->bytes_in_transit || cnx->quic->cwin_max < path_x->bytes_in_transit)
-                    &&!path_x->is_pto_required) {
-                        /* Implementation of experimental API, picoquic_set_priority_limit_for_bypass */
-                        uint8_t* bytes_next_before_bypass = bytes_next;
-                        int no_data_to_send = 0;
-                        if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1 &&
-                            picoquic_is_authorized_by_pacing(&cnx->priority_bypass_pacing, current_time, next_wake_time,
-                                cnx->quic->packet_train_mode, cnx->quic)) {
-                            bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
-                                cnx->priority_limit_for_bypass, current_time,
-                                &more_data, &is_pure_ack, &no_data_to_send, &ret);
-                        }
-                        if (bytes_next != bytes_next_before_bypass) {
-                            length = bytes_next - bytes;
-                        }
-                        else {
-                            cnx->cwin_blocked = 1;
-                            path_x->last_cwin_blocked_time = current_time;
-                            if (cnx->congestion_alg != NULL) {
-                                picoquic_per_ack_state_t ack_state = { 0 };
+                    && !path_x->is_pto_required) {
+                    /* Implementation of experimental API, picoquic_set_priority_limit_for_bypass */
+                    uint8_t* bytes_next_before_bypass = bytes_next;
+                    int no_data_to_send = 0;
+#if 1
+                    if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1) {
+                        bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+                            cnx->priority_limit_for_bypass, current_time,
+                            &more_data, &is_pure_ack, &no_data_to_send, &ret);
+                    }
+#else
+                    if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1 &&
+                        picoquic_is_authorized_by_pacing(&cnx->priority_bypass_pacing, current_time, next_wake_time,
+                            cnx->quic->packet_train_mode, cnx->quic)) {
+                        bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+                            cnx->priority_limit_for_bypass, current_time,
+                            &more_data, &is_pure_ack, &no_data_to_send, &ret);
+                    }
+#endif
+                    if (bytes_next != bytes_next_before_bypass) {
+                        length = bytes_next - bytes;
+                    }
+                    else {
+                        cnx->cwin_blocked = 1;
+                        path_x->last_cwin_blocked_time = current_time;
+                        if (cnx->congestion_alg != NULL) {
+                            picoquic_per_ack_state_t ack_state = { 0 };
 
-                                cnx->congestion_alg->alg_notify(cnx, path_x,
-                                    picoquic_congestion_notification_cwin_blocked,
-                                    &ack_state, current_time);
-                            }
+                            cnx->congestion_alg->alg_notify(cnx, path_x,
+                                picoquic_congestion_notification_cwin_blocked,
+                                &ack_state, current_time);
                         }
+                    }
                 }
                 else {
                     /* Send here the frames that are subject to both congestion and pacing control.
@@ -3555,6 +3568,18 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     }
                 } /* end of CC */
             } /* End of pacing */
+#if 1
+            else if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1) {
+                /* If congestion bypass is implemented, also consider pacing bypass */
+                int no_data_to_send = 0;
+
+                if ((bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+                    cnx->priority_limit_for_bypass, current_time,
+                    &more_data, &is_pure_ack, &no_data_to_send, &ret)) != NULL) {
+                    length = bytes_next - bytes;
+                }
+            }
+#else
             else if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1 &&
                 picoquic_is_authorized_by_pacing(&cnx->priority_bypass_pacing, current_time, next_wake_time,
                     cnx->quic->packet_train_mode, cnx->quic)) {
@@ -3567,6 +3592,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     length = bytes_next - bytes;
                 }
             }
+#endif
         } /* End of challenge verified */
     }
 


### PR DESCRIPTION
The initial design tried to limit the maximum rate of data sent with the "priority bypass" feature, but that leads to a complicated interaction between "bypass pacing" and "regular pacing". Removing the "bypass pacing" would simplify the code.
This PR is not ready yet.