### PR TITLE
Create path should return -1 if failure.

### DIFF
--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1661,9 +1661,7 @@ int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, const struct 
             path_x->cnx = cnx;
             picoquic_tuple_t* tuple = picoquic_create_tuple(path_x, local_addr, peer_addr, if_index);
 
-            if (tuple == NULL) {
-                ret = PICOQUIC_ERROR_MEMORY;
-            } else {
+            if (tuple != NULL) {
                 /* Initialize per path time measurement */
                 path_x->smoothed_rtt = PICOQUIC_INITIAL_RTT;
                 path_x->rtt_variant = 0;


### PR DESCRIPTION
The internal API for creating path contexts is:
~~~
/* Path management -- returns the index of the path that was created. */
int picoquic_create_path(picoquic_cnx_t* cnx, uint64_t start_time, const struct sockaddr* local_addr,
    const struct sockaddr* peer_addr, int if_index, uint64_t requested_id);
~~~
In case of failure, the expectation was to return a negative number. Typical code using the API would be:
~~~
        if (picoquic_create_path(cnx, current_time, addr_local, addr_peer, if_index, UINT64_MAX) > 0) {
            path_id = cnx->nb_paths - 1;
            picoquic_path_t* path_x = cnx->path[path_id];
            ...
~~~
There was a code path in which `picoquic_create_path` would return `PICOQUIC_ERROR_MEMORY` (1029) instead of -1. This leads to the calling code trying to access `cnx->path[1029];`, which would most like cause a crash.

This may explain the behavior seen in issue #1890 
