### PR TITLE
Support systems without IP_PKTINFO

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2420,6 +2420,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(af_undef) {
+            int ret = af_undef_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(app_limit_cc) {
             int ret = app_limit_cc_test();
 

--- a/picoquic/paths.c
+++ b/picoquic/paths.c
@@ -653,11 +653,6 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header* ph,
     }
     else
     {
-#if 1
-        if (cnx->client_mode) {
-            DBG_PRINTF("%s", "Bug");
-        }
-#endif
         path_x = cnx->path[path_id];
         tuple = path_x->first_tuple;
 

--- a/picoquic/paths.c
+++ b/picoquic/paths.c
@@ -653,6 +653,11 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header* ph,
     }
     else
     {
+#if 1
+        if (cnx->client_mode) {
+            DBG_PRINTF("%s", "Bug");
+        }
+#endif
         path_x = cnx->path[path_id];
         tuple = path_x->first_tuple;
 
@@ -669,7 +674,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header* ph,
 
         /* Treat the special case of the unkown local address, which should only happen
          * for clients and for the first tuple. */
-        if (path_x->first_tuple->local_addr.ss_family == AF_UNSPEC) {
+        if (path_x->first_tuple->local_addr.ss_family == AF_UNSPEC && addr_to->sa_family != AF_UNSPEC) {
             picoquic_store_addr(&cnx->path[path_id]->first_tuple->local_addr, addr_to);
         }
 
@@ -703,7 +708,7 @@ int picoquic_find_incoming_path(picoquic_cnx_t* cnx, picoquic_packet_header* ph,
             /* TODO: clean up in case of failure. */
         }
         else {
-            /* If the addresses do match, but the CID do not, we have a case of NAT rebinding.
+            /* If the addresses do match, but the CID do not, we have a case of CID migration.
              */
             if (tuple == path_x->first_tuple &&
                 picoquic_compare_connection_id(&path_x->first_tuple->p_local_cnxid->cnx_id, &ph->dest_cnx_id) != 0) {

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -841,6 +841,8 @@ void* picoquic_packet_loop_v3(void* v_ctx)
         loop_immediate = 0;
         /* Remember the time before the select call, so it duration be monitored */
         previous_time = current_time;
+        /* Initialize the dest addr family to UNSPEC yo handle systems that cannot set it. */
+        addr_to.ss_family = AF_UNSPEC;
 #ifdef _WINDOWS
         bytes_recv = picoquic_packet_loop_wait(s_ctx, nb_sockets_available,
             &addr_from, &addr_to, &if_index_to, &received_ecn, &received_buffer,

--- a/picoquic/util.c
+++ b/picoquic/util.c
@@ -475,7 +475,10 @@ int picoquic_compare_ip_addr(const struct sockaddr* expected, const struct socka
     int ret = -1;
 
     if (expected->sa_family == actual->sa_family) {
-        if (expected->sa_family == AF_INET6) {
+        if (expected->sa_family == AF_UNSPEC) {
+            ret = 0;
+        }
+        else if (expected->sa_family == AF_INET6) {
             struct sockaddr_in6* ex = (struct sockaddr_in6*)expected;
             struct sockaddr_in6* ac = (struct sockaddr_in6*)actual;
 
@@ -504,7 +507,7 @@ uint16_t picoquic_get_addr_port(const struct sockaddr* addr)
 int picoquic_compare_addr(const struct sockaddr* expected, const struct sockaddr* actual)
 {
     int ret = picoquic_compare_ip_addr(expected, actual);
-    if (ret == 0 &&
+    if (ret == 0 && expected->sa_family != AF_UNSPEC &&
         picoquic_get_addr_port(expected) != picoquic_get_addr_port(actual)) {
         ret = -1;
     }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -405,6 +405,7 @@ static const picoquic_test_def_t test_table[] = {
     { "quality_update", quality_update_test },
     { "direct_receive", direct_receive_test },
     { "address_discovery", address_discovery_test },
+    { "af_undef", af_undef_test },
     { "app_limit_cc", app_limit_cc_test },
     { "app_limited_bbr", app_limited_bbr_test },
     { "app_limited_cubic", app_limited_cubic_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -419,6 +419,7 @@ int pacing_update_test();
 int quality_update_test();
 int direct_receive_test();
 int address_discovery_test();
+int af_undef_test();
 int app_limit_cc_test();
 int app_limited_bbr_test();
 int app_limited_cubic_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -162,6 +162,8 @@ typedef struct st_picoquic_test_endpoint_t {
     uint64_t prepare_cpu_time;
     uint64_t incoming_cpu_time;
     size_t packet_queue_max;
+    /* flag to mark use of AF_UNSPEC for receiving "addr_to" */
+    int addr_to_unspec;
     /* next time endpoint ready */
     uint64_t next_time_ready;
     /* last time client sent something */


### PR DESCRIPTION
1- In socket loop, add an initialization of addr_to->sa_family to "AF_UNSPEC", so the application can see if the address is not initialized.

2- Add a unit test for a connection in which the client address is always set to AF_UNSPEC -- with only the family properly initialized.

3- Fix the issues that caused the unit test to send a flurry of PATH_CHALLENGES (because address tests were not handling AF_UNSPEC properly.