### PR TITLE
Udp connect send

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -677,6 +677,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(datagram_too_long)
+        {
+            int ret = datagram_too_long_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(datagram_wifi)
         {
             int ret = datagram_wifi_test();

--- a/picohttp/picomask.c
+++ b/picohttp/picomask.c
@@ -229,6 +229,7 @@ int picomask_ctx_init(picomask_ctx_t* ctx)
 {
     int ret = 0;
 
+    memset(ctx, 0, sizeof(picomask_ctx_t));
     picomask_udp_init_tree(&ctx->udp_tree);
 
     return ret;
@@ -334,6 +335,11 @@ int picomask_accept(picoquic_cnx_t* cnx,
     if (ret == 0) {
         ret = picomask_udp_ctx_create(picomask_ctx, (struct sockaddr*)&target_addr, stream_ctx, &udp_ctx);
     }
+    if (ret == 0) {
+        h3zero_callback_ctx_t* h3_ctx = (h3zero_callback_ctx_t*)cnx->callback_ctx;
+        ret = h3zero_declare_stream_prefix(h3_ctx, stream_ctx->stream_id,
+            picomask_callback, picomask_ctx);
+    }
     /* TODO: should provide return parameters such as local address */
     return ret;
 }
@@ -392,47 +398,6 @@ int picomask_expand_udp_path(char* text, size_t text_size, size_t* text_length, 
     return ret;
 }
 
-/* Connect proxy declares a proxy for use as a proxy service for connections that
-* need it. 
-*/
-int picomask_register_proxy(picoquic_quic_t * quic, char const * proxy_sni, size_t max_nb_udp,
-    struct sockaddr* proxy_addr,  uint64_t current_time, const char * path_template)
-{
-    int ret = 0;
-    picomask_ctx_t* picomask_ctx = quic->picomask_ctx;
-
-    if (picomask_ctx == NULL) {
-        picomask_ctx = (picomask_ctx_t*)malloc(sizeof(picomask_ctx_t));
-        if (picomask_ctx == NULL) {
-            ret = -1;
-        }
-        else {
-            memset(picomask_ctx, 0, sizeof(picomask_ctx_t));
-            quic->picomask_ctx = picomask_ctx;
-            picomask_ctx->path_template = path_template;
-            ret = picomask_ctx_init(picomask_ctx);
-        }
-    }
-
-    if (ret == 0 && picomask_ctx->cnx == NULL &&
-        (picomask_ctx->cnx = picoquic_create_cnx(quic, picoquic_null_connection_id, picoquic_null_connection_id,
-            proxy_addr, current_time, 0, proxy_sni, "h3", 1)) == NULL) {
-        ret = -1;
-    }
-
-    if (ret == 0 && picomask_ctx->h3_ctx == NULL) {
-        if ((picomask_ctx->h3_ctx = h3zero_callback_create_context(NULL)) == NULL) {
-            ret = -1;
-        }
-        else {
-            picoquic_set_callback(picomask_ctx->cnx, h3zero_callback, picomask_ctx->h3_ctx);
-            ret = h3zero_protocol_init(picomask_ctx->cnx);
-        }
-    }
-    /* TODO: release picomask_ctx on error */
-    return ret;
-}
-
 int picomask_connect_udp(picoquic_quic_t* quic, const char* authority, struct sockaddr* target_addr)
 {
     int ret = 0;
@@ -485,7 +450,7 @@ int picomask_connect_udp(picoquic_quic_t* quic, const char* authority, struct so
     return ret;
 }
 
-
+#if 0
 /* Get an empty packet */
 picomask_packet_t* picomask_get_packet(picomask_ctx_t* picomask_ctx)
 {
@@ -510,8 +475,10 @@ void picomask_recycle_packet(picomask_ctx_t* picomask_ctx, picomask_packet_t* pa
     picomask_ctx->packet_heap = packet;
 }
 
+
 /* add packet to queue in picomask context */
-int picomask_add_to_queue(picomask_ctx_t* picomask_ctx, picomask_packet_t** pp_last_packet,
+int picomask_add_to_queue(picomask_ctx_t* picomask_ctx, 
+    picomask_packet_t** pp_first_packet, picomask_packet_t** pp_last_packet,
     uint8_t* bytes, size_t length, struct sockaddr* addr_from, struct sockaddr* addr_to,
     uint8_t ecn_recv, uint64_t current_time)
 {
@@ -528,13 +495,17 @@ int picomask_add_to_queue(picomask_ctx_t* picomask_ctx, picomask_packet_t** pp_l
         packet->ecn_mark = ecn_recv;
         packet->next_packet = NULL;
         packet->arrival_time = current_time;
-        if (*pp_last_packet != NULL) {
+
+        if (*pp_last_packet == NULL) {
+            *pp_first_packet = packet;
+        } else {
             (*pp_last_packet)->next_packet = packet;
         }
         *pp_last_packet = packet;
     }
     return ret;
 }
+#endif
 
 /* Receive datagram.
 * The datagram contains an encapsulated QUIC packet, in which the quarter stream ID 
@@ -561,9 +532,19 @@ int picomask_receive_datagram(picoquic_cnx_t* cnx,
             picomask_interface_id, 0, NULL, current_time);
     }
     else {
-        ret = picomask_add_to_queue(picomask_ctx, &picomask_ctx->forwarding_last,
-            bytes, length, (struct sockaddr*)&udp_ctx->target_addr, (struct sockaddr*)&udp_ctx->local_addr,
-            0, current_time);
+        picoquic_stateless_packet_t* sp = picoquic_create_stateless_packet(cnx->quic);
+        if (sp != NULL) {
+            sp->length = length;
+            memcpy(sp->bytes, bytes, length);
+            /* Fill up control fields */
+            sp->ptype = picoquic_packet_1rtt_protected;
+            picoquic_store_addr(&sp->addr_to, (struct sockaddr*)&udp_ctx->target_addr);
+            picoquic_store_addr(&sp->addr_local, (struct sockaddr*)&cnx->path[0]->first_tuple->local_addr);
+            sp->if_index_local = cnx->path[0]->first_tuple->if_index;
+            sp->cnxid_log64 = picoquic_val64_connection_id(cnx->path[0]->first_tuple->p_local_cnxid->cnx_id);
+            picoquic_queue_stateless_packet(quic, sp);
+        }
+        /* No action if memory allocation fails, because this indicates congestion. */
     }
     return ret;
 }
@@ -616,11 +597,12 @@ int picomask_should_intercept(int if_index, size_t * max_length)
 #endif
 
 int picomask_intercept(void* proxy_ctx, uint64_t current_time,
-    uint8_t* send_buffer, size_t send_length, size_t send_msg_size,
-    struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int if_index)
+    uint8_t* send_buffer, size_t* send_length, size_t* send_msg_size,
+    struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int *if_index)
 {
     int ret = 0;
     picomask_ctx_t* picomask_ctx = (picomask_ctx_t*)proxy_ctx;
+    picomask_udp_ctx_t* udp_ctx;
     picomask_ctx;
     current_time;
     send_buffer;
@@ -631,11 +613,34 @@ int picomask_intercept(void* proxy_ctx, uint64_t current_time,
     if_index;
 
     /* Check whether there is a context associated with the 4-tuple */
-
-    /* If not, create a local context and queue a context request */
+    udp_ctx = picomask_udp_ctx_find(picomask_ctx, (struct sockaddr*)p_addr_to);
+    if (udp_ctx == NULL) {
+        /* TODO: create a UDP CTX, and if needed create a connection */
+    }
 
     /* Queue a datagram in the context */
+    if (udp_ctx != NULL) {
+        /* TODO: this code is horrific, we need a way to bypass the datagram queue */
+        uint8_t buffer[PICOQUIC_MAX_PACKET_SIZE];
+        size_t v_ll = picoquic_varint_encode(buffer, PICOQUIC_MAX_PACKET_SIZE, udp_ctx->h3_stream->stream_id / 4);
 
+        if (v_ll + *send_length > PICOQUIC_MAX_PACKET_SIZE) {
+            ret = -1;
+        }
+        else {
+            memcpy(buffer + v_ll, send_buffer, *send_length);
+
+            if (picomask_ctx->cnx->path[0]->send_mtu < PICOMASK_MTU_MIN) {
+                picomask_ctx->cnx->path[0]->send_mtu = PICOMASK_MTU_MIN;
+            }
+            ret = picoquic_queue_datagram_frame(picomask_ctx->cnx, v_ll + *send_length, buffer);
+        }
+    }
+    else {
+        ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+    }
+    /* Confirm the interception */
+    *send_length = 0;
 #if 0
     if (if_index == picomask_interface_id) {
         /* TODO: queue packet to destination */
@@ -796,11 +801,6 @@ int picomask_callback(picoquic_cnx_t* cnx,
     return ret;
 }
 
-
-/* Init of the proxy context.
-* Allocate the memory, and then 
- */
-
 /* Creation of an outer connection.
  * On client, this is done explicitly: create a connection to
  * a proxy, get a unique UDP connection ID. This requires
@@ -833,4 +833,50 @@ int picomask_outgoing()
     /* if not, return an error */
     /* if yes, create a Connect UDP context, queue the packet to it */
     return -1;
+}
+
+struct st_picomask_fns_t picomask_fns = {
+    picomask_intercept
+};
+
+/* Connect proxy declares a proxy for use as a proxy service for connections that
+* need it.
+*/
+int picomask_register_proxy(picoquic_quic_t* quic, char const* proxy_sni, size_t max_nb_udp,
+    struct sockaddr* proxy_addr, uint64_t current_time, const char* path_template)
+{
+    int ret = 0;
+    picomask_ctx_t* picomask_ctx = quic->picomask_ctx;
+
+    if (picomask_ctx == NULL) {
+        picomask_ctx = (picomask_ctx_t*)malloc(sizeof(picomask_ctx_t));
+        if (picomask_ctx == NULL) {
+            ret = -1;
+        }
+        else {
+            ret = picomask_ctx_init(picomask_ctx);
+            picomask_ctx->path_template = path_template;
+            quic->picomask_ctx = picomask_ctx;
+            quic->picomask_fns = &picomask_fns;
+        }
+    }
+
+    if (ret == 0 && picomask_ctx->cnx == NULL &&
+        (picomask_ctx->cnx = picoquic_create_cnx(quic, picoquic_null_connection_id, picoquic_null_connection_id,
+            proxy_addr, current_time, 0, proxy_sni, "h3", 1)) == NULL) {
+        ret = -1;
+    }
+
+    if (ret == 0 && picomask_ctx->h3_ctx == NULL) {
+        picomask_ctx->cnx->local_parameters.max_datagram_frame_size = PICOQUIC_MAX_PACKET_SIZE;
+        if ((picomask_ctx->h3_ctx = h3zero_callback_create_context(NULL)) == NULL) {
+            ret = -1;
+        }
+        else {
+            picoquic_set_callback(picomask_ctx->cnx, h3zero_callback, picomask_ctx->h3_ctx);
+            ret = h3zero_protocol_init(picomask_ctx->cnx);
+        }
+    }
+    /* TODO: release picomask_ctx on error */
+    return ret;
 }

--- a/picohttp/picomask.c
+++ b/picohttp/picomask.c
@@ -810,31 +810,6 @@ int picomask_callback(picoquic_cnx_t* cnx,
  * a client.
  */
 
-
-
-/* management of outgoing packets at the client */
-int picomask_outgoing()
-{
-    /* Is there an established context for these addresses? 
-     * if yes, queue it there.
-     */
-
-    /* If not, is there yet an established H3 connection for
-     * the source address?
-     */
-
-    /* If not, establish the h3 connection. 
-    * TODO: provide credentials.
-     */
-
-    /* is there now an established H3 connection for
-     * the source address?*/
-
-    /* if not, return an error */
-    /* if yes, create a Connect UDP context, queue the packet to it */
-    return -1;
-}
-
 struct st_picomask_fns_t picomask_fns = {
     picomask_intercept
 };

--- a/picohttp/picomask.c
+++ b/picohttp/picomask.c
@@ -549,6 +549,7 @@ int picomask_receive_datagram(picoquic_cnx_t* cnx,
     return ret;
 }
 
+#if 0
 /* Prepare datagram. 
 * Take the next packet in the "intercept" queue and copy it to the content of the
 * datagram. 
@@ -581,6 +582,7 @@ int picomask_provide_datagram(picoquic_cnx_t* cnx,
 
     return ret;
 }
+#endif
 
 /*
 * Implementation of the picoquic "proxy intercept" API.
@@ -603,14 +605,6 @@ int picomask_intercept(void* proxy_ctx, uint64_t current_time,
     int ret = 0;
     picomask_ctx_t* picomask_ctx = (picomask_ctx_t*)proxy_ctx;
     picomask_udp_ctx_t* udp_ctx;
-    picomask_ctx;
-    current_time;
-    send_buffer;
-    send_length;
-    send_msg_size;
-    p_addr_to;
-    p_addr_from;
-    if_index;
 
     /* Check whether there is a context associated with the 4-tuple */
     udp_ctx = picomask_udp_ctx_find(picomask_ctx, (struct sockaddr*)p_addr_to);
@@ -778,9 +772,8 @@ int picomask_callback(picoquic_cnx_t* cnx,
         ret = picomask_receive_datagram(cnx, bytes, length, stream_ctx, picomask_ctx);
         break;
     case picohttp_callback_provide_datagram: 
-        /* callback to provide data. This will translate to a "prepare data" call
-        * on the next available connection context and path context */
-        ret = picomask_provide_datagram(cnx, bytes, length, stream_ctx, picomask_ctx);
+        /* callback to provide a datagram. Not used in the current code. */
+        ret = -1;
         break;
     case picohttp_callback_reset: 
         /* Control stream has been abandoned. */

--- a/picohttp/picomask.c
+++ b/picohttp/picomask.c
@@ -598,12 +598,11 @@ int picomask_should_intercept(int if_index, size_t * max_length)
 }
 #endif
 
-int picomask_intercept(void* proxy_ctx, uint64_t current_time,
+int picomask_intercept(struct st_picomask_ctx_t* picomask_ctx, uint64_t current_time,
     uint8_t* send_buffer, size_t* send_length, size_t* send_msg_size,
     struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int *if_index)
 {
     int ret = 0;
-    picomask_ctx_t* picomask_ctx = (picomask_ctx_t*)proxy_ctx;
     picomask_udp_ctx_t* udp_ctx;
 
     /* Check whether there is a context associated with the 4-tuple */

--- a/picohttp/picomask.c
+++ b/picohttp/picomask.c
@@ -648,7 +648,7 @@ int picomask_intercept(void* proxy_ctx, uint64_t current_time,
 #endif
     return ret;
 }
-
+#if 0
 /*
 * Implementation of the picoquic "proxy forwarding" API.
 * This is an opportunity to prepare outgoing datagrams, which will
@@ -688,7 +688,9 @@ void picomask_forwarding(void* proxy_ctx,
 
     /* recycle the packet */
 }
+#endif
 
+#if 0
 /*
 * Implementation of the picoquic "proxying" API.
 * This is an opportunity to capture incoming datagrams
@@ -722,6 +724,7 @@ int picomask_proxying(
     */
     return -1;
 }
+#endif
 
 /* picomask callback. This will be called from the web server
 * when the path points to a picomask callback.

--- a/picohttp/picomask.h
+++ b/picohttp/picomask.h
@@ -119,6 +119,10 @@ int picomask_connect_udp(picoquic_quic_t* quic, const char* authority, struct so
 
 int picomask_expand_udp_path(char* text, size_t text_size, size_t* text_length, char const* path_template, struct sockaddr* addr);
 
+int picomask_intercept(struct st_picomask_ctx_t* picomask_ctx, uint64_t current_time,
+    uint8_t* send_buffer, size_t* send_length, size_t* send_msg_size,
+    struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int* if_index);
+
 #ifdef __cplusplus
 }
 #endif

--- a/picohttp/picomask.h
+++ b/picohttp/picomask.h
@@ -53,7 +53,9 @@ extern "C" {
 * 2798c62715dd8ce6e2c6dd92a37a8276f16c029e
 */
 #define picomask_interface_id 0x2798c627
+#define PICOMASK_MTU_MIN 1300
 
+#if 0
 typedef struct st_picomask_packet_t {
     struct st_picomask_packet_t* next_packet;
     uint64_t arrival_time;
@@ -63,6 +65,7 @@ typedef struct st_picomask_packet_t {
     uint8_t ecn_mark;
     uint8_t bytes[PICOQUIC_MAX_PACKET_SIZE];
 } picomask_packet_t;
+#endif
 
 typedef struct st_picomask_ctx_t {
     picoquic_cnx_t* cnx; /* Null on server. On client, the connection to the proxy */
@@ -70,12 +73,11 @@ typedef struct st_picomask_ctx_t {
     char const* path_template; /* Null on server */
     picosplay_tree_t udp_tree;
     picohash_table* table_udp_ctx;
-    uint64_t picomask_number_next;
+#if 0
     picomask_packet_t* intercepted_first; /* queue of packets waitting to be sent to peer */
     picomask_packet_t* intercepted_last;
-    picomask_packet_t* forwarding_first; /* queue of packets waiting to be sent to network */
-    picomask_packet_t* forwarding_last;
     picomask_packet_t* packet_heap;
+#endif
 } picomask_ctx_t;
 
 typedef struct st_picomask_h3_ctx_t {
@@ -90,17 +92,17 @@ typedef struct st_picomask_udp_ctx_t {
     struct sockaddr_storage local_addr;
     picomask_ctx_t* picomask_ctx;
     h3zero_stream_ctx_t* h3_stream;
+#if 0
     /* Management of capsule protocol on control stream */
     /* Management of datagram queue -- incoming packets
      * that have to be processed locally */
     picomask_packet_t* outgoing_first;
     picomask_packet_t* outgoing_last;
+#endif
 } picomask_udp_ctx_t;
 
 int picomask_ctx_init(picomask_ctx_t* ctx);
 void picomask_ctx_release(picomask_ctx_t* ctx);
-
-picomask_udp_ctx_t* picomask_udp_ctx_by_number(picomask_ctx_t* ctx, uint64_t picomask_number);
 
 int picomask_callback(picoquic_cnx_t* cnx,
     uint8_t* bytes, size_t length,

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1123,7 +1123,7 @@ int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t 
  * i.e., must fit in the minimum packet length supported by Quic. Trying to
  * queue a larger datagram will result in an error PICOQUIC_ERROR_DATAGRAM_TOO_LONG.
  */
-#define PICOQUIC_DATAGRAM_QUEUE_MAX_LENGTH 1200
+#define PICOQUIC_DATAGRAM_QUEUE_MAX_LENGTH 1253
 int picoquic_queue_datagram_frame(picoquic_cnx_t* cnx, size_t length, const uint8_t* bytes);
 
 /* The incoming packet API is used to pass incoming packets to a 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1119,11 +1119,16 @@ int picoquic_queue_misc_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, size_t 
     int is_pure_ack, picoquic_packet_context_enum pc);
 
 /* Queue a datagram frame for sending later.
- * The datagram length must be no more than PICOQUIC_DATAGRAM_QUEUE_MAX_LENGTH,
- * i.e., must fit in the minimum packet length supported by Quic. Trying to
- * queue a larger datagram will result in an error PICOQUIC_ERROR_DATAGRAM_TOO_LONG.
+* The datagram frame must fit into the path MTU, not be larger than
+* the locally specified maximum, and if the connection is complete
+* not be larger than the max allowed by the peer.
+* 
+* We cannot estimate all that at the time of queuing, because the path MTU
+* may change between the time the datagram is queued and the time it is
+* sent. The test at queuing time are based on the current path MTU. If
+* that changes, datagrams that are too long will be dropped.
  */
-#define PICOQUIC_DATAGRAM_QUEUE_MAX_LENGTH 1253
+#define PICOQUIC_DATAGRAM_QUEUE_CAUTIOUS_LENGTH PICOQUIC_ENFORCED_INITIAL_MTU
 int picoquic_queue_datagram_frame(picoquic_cnx_t* cnx, size_t length, const uint8_t* bytes);
 
 /* The incoming packet API is used to pass incoming packets to a 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -2051,7 +2051,7 @@ void picoquic_delete_misc_or_dg(picoquic_misc_frame_header_t** first, picoquic_m
 void picoquic_clear_ack_ctx(picoquic_ack_context_t* ack_ctx);
 void picoquic_reset_ack_context(picoquic_ack_context_t* ack_ctx);
 int picoquic_queue_handshake_done_frame(picoquic_cnx_t* cnx);
-uint8_t* picoquic_format_first_datagram_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack);
+uint8_t* picoquic_format_first_datagram_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int is_first_in_packet, int* more_data, int* is_pure_ack);
 uint8_t* picoquic_format_ready_datagram_frame(picoquic_cnx_t* cnx, picoquic_path_t * path_x, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack, int* ret);
 uint8_t* picoquic_decode_datagram_frame_header(uint8_t* bytes, const uint8_t* bytes_max,
     uint8_t* frame_id, uint64_t* length);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -608,6 +608,7 @@ typedef struct st_picoquic_quic_t {
     picoquic_stream_data_cb_fn default_callback_fn;
     void* default_callback_ctx;
     struct st_picomask_ctx_t* picomask_ctx;
+    struct st_picomask_fns_t* picomask_fns;
     char const* default_alpn;
     picoquic_alpn_select_fn alpn_select_fn;
     uint8_t reset_seed[PICOQUIC_RESET_SECRET_SIZE];
@@ -2120,6 +2121,16 @@ picoquic_misc_frame_header_t* picoquic_create_misc_frame(const uint8_t* bytes, s
  * upgrade is possible, -1 if it is not.
  */
 int picoquic_process_version_upgrade(picoquic_cnx_t* cnx, int old_version_index, int new_version_index);
+
+
+/* Support for the proxy function.
+* We use a function table, so that we do not have to link the picomask code 
+* for servers or clients that do not use the Masque proxy. */
+typedef struct st_picomask_fns_t {
+    int (*picomask_intercept_fn)(struct st_picomask_ctx_t* picomask_ctx, uint64_t current_time,
+        uint8_t* send_buffer, size_t* send_length, size_t* send_msg_size,
+        struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int* if_index);
+} picomask_fns_t;
 
 #ifdef __cplusplus
 }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2737,12 +2737,12 @@ void picoquic_ready_state_transition(picoquic_cnx_t* cnx, uint64_t current_time)
 
 /* sending of datagrams */
 static uint8_t* picoquic_prepare_datagram_ready(picoquic_cnx_t* cnx, picoquic_path_t * path_x, uint8_t* bytes_next, uint8_t* bytes_max,
-    int* more_data, int* is_pure_ack, int* datagram_tried_and_failed, int* datagram_sent, int * ret)
+    int is_first_in_packet, int* more_data, int* is_pure_ack, int* datagram_tried_and_failed, int* datagram_sent, int * ret)
 {
     uint8_t* bytes0 = bytes_next;
 
     if (cnx->first_datagram != NULL) {
-        bytes_next = picoquic_format_first_datagram_frame(cnx, bytes_next, bytes_max, more_data, is_pure_ack);
+        bytes_next = picoquic_format_first_datagram_frame(cnx, bytes_next, bytes_max, is_first_in_packet, more_data, is_pure_ack);
         *more_data |= (cnx->first_datagram != NULL);
     }
     else {
@@ -2807,7 +2807,7 @@ static uint8_t* picoquic_prepare_datagram_ready(picoquic_cnx_t* cnx, picoquic_pa
 */
 
 static uint8_t* picoquic_prepare_stream_and_datagrams(picoquic_cnx_t* cnx, picoquic_path_t* path_x, uint8_t* bytes_next, uint8_t* bytes_max,
-    uint64_t max_priority_allowed, uint64_t current_time,
+    int is_first_in_packet, uint64_t max_priority_allowed, uint64_t current_time,
     int* more_data, int* is_pure_ack, int* no_data_to_send, int* ret)
 {
     int datagram_sent = 0;
@@ -2856,7 +2856,7 @@ static uint8_t* picoquic_prepare_stream_and_datagrams(picoquic_cnx_t* cnx, picoq
         if (datagram_present &&
             cnx->datagram_priority == current_priority &&
             (cnx->datagram_priority < stream_priority || datagram_first)) {
-            bytes_next = picoquic_prepare_datagram_ready(cnx, path_x, bytes_next, bytes_max,
+            bytes_next = picoquic_prepare_datagram_ready(cnx, path_x, bytes_next, bytes_max, is_first_in_packet,
                 &more_data_this_round, is_pure_ack, &datagram_tried_and_failed, &datagram_sent, ret);
             something_sent = datagram_sent;
         }
@@ -2902,7 +2902,7 @@ static uint8_t* picoquic_prepare_stream_and_datagrams(picoquic_cnx_t* cnx, picoq
             cnx->datagram_priority == current_priority &&
             cnx->datagram_priority <= stream_priority &&
             !datagram_first) {
-            bytes_next = picoquic_prepare_datagram_ready(cnx, path_x, bytes_next, bytes_max,
+            bytes_next = picoquic_prepare_datagram_ready(cnx, path_x, bytes_next, bytes_max, is_first_in_packet,
                 more_data, is_pure_ack, &datagram_tried_and_failed, &datagram_sent, ret);
             something_sent = datagram_sent;
         }
@@ -3124,7 +3124,7 @@ int picoquic_prepare_packet_almost_ready(picoquic_cnx_t* cnx, picoquic_path_t* p
                             }
                             if (ret == 0) {
                                 bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
-                                    UINT64_MAX, current_time,
+                                    (size_t)(bytes_next - bytes) <= packet->offset, UINT64_MAX, current_time,
                                     &more_data, &is_pure_ack, &no_data_to_send, &ret);
                             }
                             /* TODO: replace this by posting of frame when CWIN estimated */
@@ -3422,7 +3422,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                     int no_data_to_send = 0;
                     if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1) {
                         bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
-                            cnx->priority_limit_for_bypass, current_time,
+                            (size_t)(bytes_next - bytes) <= packet->offset, cnx->priority_limit_for_bypass, current_time,
                             &more_data, &is_pure_ack, &no_data_to_send, &ret);
                     }
                     if (bytes_next != bytes_next_before_bypass) {
@@ -3477,7 +3477,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                         }
                         if (ret == 0) {
                             bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
-                                UINT64_MAX, current_time, &more_data, &is_pure_ack, &no_data_to_send, &ret);
+                                (size_t)(bytes_next - bytes) <= packet->offset, UINT64_MAX, current_time, &more_data, &is_pure_ack, &no_data_to_send, &ret);
                         }
 
                         /* TODO: replace this by scheduling of BDP frame when window has been estimated */
@@ -3566,7 +3566,7 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
                 int no_data_to_send = 0;
 
                 if ((bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
-                    cnx->priority_limit_for_bypass, current_time,
+                    (size_t)(bytes_next - bytes) <= packet->offset, cnx->priority_limit_for_bypass, current_time,
                     &more_data, &is_pure_ack, &no_data_to_send, &ret)) != NULL) {
                     length = bytes_next - bytes;
                 }
@@ -4085,7 +4085,7 @@ int picoquic_prepare_packet_ex(picoquic_cnx_t* cnx,
             /* Account for the bytes in the packet. */
             *send_length += coalesced_packet_size;
 
-            if (*if_index == PICOQUIC_RESERVED_IF_INDEX &&  *send_length > 0 && cnx->quic->picomask_ctx != NULL && cnx->quic->picomask_fns != NULL) {
+            if (*if_index == PICOQUIC_RESERVED_IF_INDEX && *send_length > 0 && cnx->quic->picomask_ctx != NULL && cnx->quic->picomask_fns != NULL) {
                 /* Ask the proxy to handle the packet */
                 /* if we queue it as a datagram, set packet_size to 0 */
                 /* If we can do some short cut, rewrite the packet in place per shortcut spec. */
@@ -4134,6 +4134,11 @@ int picoquic_prepare_packet(picoquic_cnx_t* cnx,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
     struct sockaddr_storage* p_addr_to, struct sockaddr_storage* p_addr_from, int* if_index)
 {
+    int if_index_null;
+    if (if_index == NULL) {
+        if_index = &if_index_null;
+    }
+
     return picoquic_prepare_packet_ex(cnx, current_time, send_buffer, send_buffer_max, send_length,
         p_addr_to, p_addr_from, if_index, NULL);
 }

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -146,6 +146,7 @@ static const picoquic_test_def_t test_table[] = {
     { "datagram_small", datagram_small_test },
     { "datagram_small_new", datagram_small_new_test },
     { "datagram_small_packet", datagram_small_packet_test },
+    { "datagram_too_long_test", datagram_too_long_test },
     { "datagram_wifi", datagram_wifi_test },
     { "ddos_amplification", ddos_amplification_test },
     { "ddos_amplification_0rtt", ddos_amplification_0rtt_test },

--- a/picoquictest/edge_cases.c
+++ b/picoquictest/edge_cases.c
@@ -791,10 +791,11 @@ int idle_server_test_one(uint8_t test_id, uint64_t client_timeout, uint64_t hand
             size_t send_length = 0;
             struct sockaddr_storage addr_to;
             struct sockaddr_storage addr_from;
+            int if_index;
 
             ret = picoquic_prepare_packet_ex(test_ctx->cnx_client, simulated_time,
                 send_buffer, sizeof(send_buffer), &send_length,
-                &addr_to, &addr_from, 0, NULL);
+                &addr_to, &addr_from, &if_index, NULL);
             if (ret != 0) {
                 break;
             }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -408,6 +408,7 @@ int datagram_size_test();
 int datagram_small_test();
 int datagram_small_new_test();
 int datagram_small_packet_test();
+int datagram_too_long_test();
 int datagram_wifi_test();
 int ddos_amplification_test();
 int ddos_amplification_0rtt_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -84,6 +84,7 @@ typedef struct st_test_datagram_send_recv_ctx_t {
     unsigned int is_skipping[2];
     unsigned int test_affinity;
     unsigned int test_wifi;
+    unsigned int test_too_long;
     unsigned int one_datagram_per_packet;
 
 } test_datagram_send_recv_ctx_t;

--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -671,10 +671,12 @@ static int stress_handle_packet_prepare(picoquic_stress_ctx_t * stress_ctx, pico
 
 
         if (c_ctx == NULL || cnx->cnx_state == picoquic_state_disconnected 
-            || simulate_disconnect == 0) { 
+            || simulate_disconnect == 0) {
+            int if_index;
+
             ret = picoquic_prepare_packet(cnx, stress_ctx->simulated_time,
                 packet->bytes, PICOQUIC_MAX_PACKET_SIZE, &packet->length,
-                &packet->addr_to, &packet->addr_from, NULL);
+                &packet->addr_to, &packet->addr_from, &if_index);
         }
 
         if (ret == 0 && packet->length > 0) {

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -1420,12 +1420,13 @@ static int tls_api_server_departure(picoquic_test_tls_api_ctx_t* test_ctx,
     picoquictest_sim_link_t** target_link, uint64_t simulated_time)
 {
     int ret = 0;
+    int if_index;
 
     test_ctx->server_endpoint.last_send_time = simulated_time;
 
     ret = picoquic_prepare_packet_ex(test_ctx->cnx_server, simulated_time,
         test_ctx->send_buffer, test_ctx->send_buffer_size, send_length,
-        addr_to, addr_from, NULL, p_segment_size);
+        addr_to, addr_from, &if_index, p_segment_size);
     test_ctx->server_endpoint.next_time_ready = simulated_time +
         test_ctx->server_endpoint.prepare_cpu_time;
     if (ret == PICOQUIC_ERROR_DISCONNECTED) {
@@ -1477,6 +1478,7 @@ static int tls_api_client_departure(picoquic_test_tls_api_ctx_t* test_ctx,
     /* check whether the client has something to send */
     size_t coalesced_length = 0;
     size_t send_buffer_size = test_ctx->send_buffer_size;
+    int if_index;
 
     test_ctx->client_endpoint.last_send_time = simulated_time;
 
@@ -1488,7 +1490,7 @@ static int tls_api_client_departure(picoquic_test_tls_api_ctx_t* test_ctx,
 
     ret = picoquic_prepare_packet_ex(test_ctx->cnx_client, simulated_time,
         test_ctx->send_buffer + coalesced_length, send_buffer_size - coalesced_length, send_length,
-        addr_to, addr_from, NULL, p_segment_size);
+        addr_to, addr_from, &if_index, p_segment_size);
 
     test_ctx->client_endpoint.next_time_ready = simulated_time +
         test_ctx->client_endpoint.prepare_cpu_time;
@@ -10030,6 +10032,7 @@ static int connection_drop_test_one(picoquic_state_enum target_client_state, pic
         while (ret == 0 && nb_trials < 1024 && nb_inactive < 512) {
             struct sockaddr_storage a_from;
             struct sockaddr_storage a_to;
+            int if_index;
             uint8_t packet[PICOQUIC_MAX_PACKET_SIZE];
             size_t length = 0;
 
@@ -10042,7 +10045,7 @@ static int connection_drop_test_one(picoquic_state_enum target_client_state, pic
             }
 
             ret = picoquic_prepare_packet(target_cnx, simulated_time, packet, PICOQUIC_MAX_PACKET_SIZE,
-                &length, &a_to, &a_from, NULL);
+                &length, &a_to, &a_from, &if_index);
 
             if (ret == PICOQUIC_ERROR_DISCONNECTED) {
                 ret = 0;


### PR DESCRIPTION
Verify that the implementation of Masque UDP-Connect can correctly intercept a packet and queue it at the proxy for transmission to the target.

This required ensuring that the client always document the "if_index" attribute when waiting for a packet.
It also required checking the transmission of queued datagrams, to perform correct checks on the length of datagrams and delete those that are too long and could clog the queue -- but be cautious in these deletions.