### PR TITLE
Do Not Coalesce stream option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 endif()
 
 project(picoquic
-        VERSION 1.1.36.0
+        VERSION 1.1.37.0
         DESCRIPTION "picoquic library"
         LANGUAGES C CXX)
 

--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2576,6 +2576,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(mediatest_no_coal) {
+            int ret = mediatest_no_coal_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(mediatest_suspension) {
             int ret = mediatest_suspension_test();
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -40,7 +40,7 @@
 extern "C" {
 #endif
 
-#define PICOQUIC_VERSION "1.1.36.0"
+#define PICOQUIC_VERSION "1.1.37.0"
 #define PICOQUIC_ERROR_CLASS 0x400
 #define PICOQUIC_ERROR_DUPLICATE (PICOQUIC_ERROR_CLASS + 1)
 #define PICOQUIC_ERROR_AEAD_CHECK (PICOQUIC_ERROR_CLASS + 3)
@@ -1265,6 +1265,27 @@ void picoquic_unlink_app_stream_ctx(picoquic_cnx_t* cnx, uint64_t stream_id);
  */
 int picoquic_mark_active_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, int is_active, void* v_stream_ctx);
+
+/* Handling of stream packetisation and head-of-line blocking:
+* 
+* When preparing a packet, if a stream is available, picoquic will fill the
+* content of a packet with bytes from that stream. In some cases,
+* there are not enough bytes from completely fill the packet.
+* By default, picoquic will then fill the reminder of the packet with data from
+* other available streams. This default behavior minimizes per packet
+* overhead, but it can reintroduce a form of "head of line blocking":
+* if a packet containing data from multiple streams is lost, all of
+* these streams will be blocked until the missing data is resent.
+* This is less-than-ideal for some real-time applications.
+* 
+* The default behavior can be controlled by setting a stream as "not-coalesced".
+* If that property is set, packets that contain data for the stream will
+* not be contain data for any other stream. Setting the is_not_coalesced
+* flag to zero (default) reverts to the default behavior.
+*/
+
+int picoquic_set_stream_not_coalesced(picoquic_cnx_t* cnx,
+    uint64_t stream_id, int is_not_coalesced);
 
 /* Handling of stream priority. 
  * 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -846,6 +846,7 @@ typedef struct st_picoquic_stream_head_t {
     unsigned int is_closed : 1; /* Stream is closed, closure is accouted for */
     unsigned int is_discarded : 1; /* There should be no more callback for that stream, the application has discarded it */
     unsigned int use_app_flow_control : 1; /* Do not automatically increment the flow control window, wait for app calls. */
+    unsigned int is_not_coalesced : 1; /* do not mix data for this stream with data from other stream in same packet */
 } picoquic_stream_head_t;
 
 #define IS_CLIENT_STREAM_ID(id) (unsigned int)(((id) & 1) == 0)
@@ -1914,7 +1915,7 @@ picoquic_stream_head_t * picoquic_last_stream(picoquic_cnx_t * cnx);
 picoquic_stream_head_t * picoquic_next_stream(picoquic_stream_head_t * stream);
 picoquic_stream_head_t* picoquic_find_stream(picoquic_cnx_t* cnx, uint64_t stream_id);
 void picoquic_add_output_streams(picoquic_cnx_t * cnx, uint64_t old_limit, uint64_t new_limit, unsigned int is_bidir);
-picoquic_stream_head_t* picoquic_find_ready_stream_path(picoquic_cnx_t* cnx, picoquic_path_t* path_x);
+picoquic_stream_head_t* picoquic_find_ready_stream_path(picoquic_cnx_t* cnx, picoquic_path_t* path_x, int is_coalesced);
 picoquic_stream_head_t* picoquic_find_ready_stream(picoquic_cnx_t* cnx);
 int picoquic_is_tls_stream_ready(picoquic_cnx_t* cnx);
 const uint8_t* picoquic_decode_stream_frame(picoquic_cnx_t* cnx, const uint8_t* bytes,

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -433,6 +433,7 @@ static const picoquic_test_def_t test_table[] = {
     { "mediatest_video2_probe", mediatest_video2_probe_test },
     { "mediatest_wifi", mediatest_wifi_test },
     { "mediatest_worst", mediatest_worst_test },
+    { "mediatest_no_coal", mediatest_no_coal_test },
     { "mediatest_suspension", mediatest_suspension_test },
     { "mediatest_suspension2", mediatest_suspension2_test },
     { "warptest_video", warptest_video_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -449,6 +449,7 @@ int mediatest_wifi_test();
 int mediatest_suspension_test();
 int mediatest_suspension2_test();
 int mediatest_worst_test();
+int mediatest_no_coal_test();
 int warptest_video_test();
 int warptest_video_audio_test();
 int warptest_video_data_audio_test();


### PR DESCRIPTION
Add option to declare stream as "is_not_coalesced".

If option is set, packets containing data for that stream will not contain data for any other stream.

Add a test of the option (media_no_coal), verify that the option is safe to use. In that test, the performance are actually a little worse if the option is set:

latency vs option | not set | do not coalesce
-------------------|---------|-------------------
Audio average | 12ms | 12 ms
Audio max | 19ms | 35ms
Video average | 13ms | 14ms
Video max | 38ms | 86ms

This is expected, since coalescing multiple streams in a packet is more efficient on average than sending separate streams in separate packets. The goal of the option is to minimize "head of line blocking", which would happen if there was a lot of packet losses.