### PR TITLE
Expose per-path byte transfer stats

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1027,6 +1027,8 @@ typedef struct st_picoquic_path_quality_t {
     uint64_t max_reorder_delay; /* maximum time gap for out of order packets */
     uint64_t max_reorder_gap; /* maximum number gap for out of order packets */
     uint64_t bytes_in_transit; /* number of bytes currently in transit */
+    uint64_t bytes_sent; /* Total amount of bytes sent on the path */
+    uint64_t bytes_received; /* Total amount of bytes received from the path */
 
 } picoquic_path_quality_t;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2532,6 +2532,8 @@ static void picoquic_get_path_quality_from_context(picoquic_path_t* path_x, pico
     quality->max_reorder_delay = path_x->max_reorder_delay;
     quality->max_reorder_gap = path_x->max_reorder_gap;
     quality->bytes_in_transit = path_x->bytes_in_transit;
+    quality->bytes_sent = path_x->bytes_sent;
+    quality->bytes_received = path_x->received;
 }
 
 int picoquic_get_path_quality(picoquic_cnx_t* cnx, uint64_t unique_path_id, picoquic_path_quality_t* quality)


### PR DESCRIPTION
In the current implementation of PicoQUIC, per-path byte statistics (bytes sent and bytes received) are tracked internally in the st_picoquic_path_t structure but are not exposed via the public API.

This PR intends on extending the st_picoquic_path_quality_t structure in [picoquic.h](https://github.com/private-octopus/picoquic/blob/1a537c8ef1d2c93374ba69f1f41bef85cd4c112e/picoquic/picoquic.h) and updating the picoquic_get_path_quality_from_context() function in [quicctx.c](https://github.com/private-octopus/picoquic/blob/1a537c8ef1d2c93374ba69f1f41bef85cd4c112e/picoquic/quicctx.c) to expose these statistics to applications.

Since this data is already maintained internally, the change is minimal.