### PR TITLE
delete quicperf stream ctx after stop sending

### DIFF
--- a/picohttp/quicperf.c
+++ b/picohttp/quicperf.c
@@ -1127,6 +1127,11 @@ void quicperf_receive_media_data(picoquic_cnx_t* cnx, quicperf_ctx_t* ctx, quicp
                         picoquic_stop_sending(cnx, stream_ctx->stream_id, QUICPERF_ERROR_DELAY_TOO_HIGH);
                     }
                     stream_ctx->is_stopped = 1;
+#if 1
+                    /* Close the stream context, remove its association with the stream id, do not send any more */
+                    stream_ctx->is_closed = 1;
+                    quicperf_terminate_and_delete_stream(cnx, ctx, stream_ctx);
+#endif
                 }
             }
         }


### PR DESCRIPTION
Fix a bug in "quicperf" implementation. There was a race condition. If the client asks to "stop sending" a stream, the server confirms with a "reset stream", and all is good. However, if the sender has already sent the entire stream and the FIN bit, the sender will not send the "reset stream" frame. The quicperf context for the stream will hang as a zombie. 

The solution is to delete the quicperf stream context immediately after requesting to stop sending.