### PR TITLE
fix for issue 1769

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -1203,7 +1203,7 @@ int picoquic_queue_retry_packet(
 
 
     if (picoquic_prepare_retry_token(quic, addr_from,
-        current_time + PICOQUIC_TOKEN_DELAY_SHORT, &ph->dest_cnx_id,
+        current_time, &ph->dest_cnx_id,
         &s_cid, ph->pn, token_buffer, sizeof(token_buffer), &token_size) != 0) {
         ret = PICOQUIC_ERROR_MEMORY;
     }

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2662,7 +2662,7 @@ void picoquic_false_start_transition(picoquic_cnx_t* cnx, uint64_t current_time)
         picoquic_connection_id_t n_cid = picoquic_null_connection_id;
 
         if (picoquic_prepare_retry_token(cnx->quic, (struct sockaddr*) & cnx->path[0]->first_tuple->peer_addr,
-            current_time + PICOQUIC_TOKEN_DELAY_LONG, &n_cid, &n_cid, 0,
+            current_time, &n_cid, &n_cid, 0,
             token_buffer, sizeof(token_buffer), &token_size) == 0) {
             if (picoquic_queue_new_token_frame(cnx, token_buffer, token_size) != 0) {
                 picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_INTERNAL_ERROR, picoquic_frame_type_new_token);

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -2876,10 +2876,10 @@ int picoquic_prepare_retry_token(picoquic_quic_t* quic, const struct sockaddr* a
 
     /* set a short life time for short lived tokens, 24 hours otherwise */
     if (odcid->id_len == 0) {
-        token_time += 24ull * 3600ull * 1000000ull;
+        token_time += PICOQUIC_TOKEN_DELAY_LONG;
     }
     else {
-        token_time += 4000000ull;
+        token_time += PICOQUIC_TOKEN_DELAY_SHORT;
     }
     /* serialize the token components */
     if ((bytes = picoquic_frames_uint64_encode(bytes, bytes_max, token_time)) != NULL &&

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -2874,7 +2874,11 @@ int picoquic_prepare_retry_token(picoquic_quic_t* quic, const struct sockaddr* a
     uint8_t* bytes = text;
     uint8_t* bytes_max = text + sizeof(text);
 
-    /* set a short life time for short lived tokens, 24 hours otherwise */
+    /* The prepare token function can prepare two kind of tokens: immediate retry
+    * tokens, that are short lived, or "new tokens", that are valid for a
+    * a longer delay. We differentiate between these two cases by testing the
+    * presence of the Original DCID parameter, which must be present in
+    * the retry tokens, but shall never be in the new tokens. */
     if (odcid->id_len == 0) {
         token_time += PICOQUIC_TOKEN_DELAY_LONG;
     }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3666,8 +3666,8 @@ int tls_retry_token_valid_test()
     picoquic_connection_id_t* odcid[2];
     picoquic_connection_id_t odcid_found;
     uint64_t time_base = 10000;
-    uint64_t time_delta[4] = { 0, PICOQUIC_TOKEN_DELAY_SHORT, PICOQUIC_TOKEN_DELAY_SHORT + 4000001,
-     24ull * 3600ull * 1000000ull + PICOQUIC_TOKEN_DELAY_SHORT + 1000000 };
+    uint64_t time_delta[4] = { 0, 0, PICOQUIC_TOKEN_DELAY_SHORT + 1,
+        PICOQUIC_TOKEN_DELAY_LONG + 1000000 };
     uint32_t pn[3] = { 0, 1, 2 };
     uint8_t token_buffer[128];
     size_t token_size;


### PR DESCRIPTION
Fixes #1769

- Retry and NEW_TOKEN lifetimes were getting padded twice, so both ended up far longer than intended. The retry path added the short delay before calling picoquic_prepare_retry_token, which itself tacked on the configured lifetime. Same story for NEW_TOKEN frames with the long delay.

- picoquic/packet.c:1205 now passes the live current_time into picoquic_prepare_retry_token so the expiry is computed exactly once, matching the documented two‑minute retry window.

- picoquic/sender.c:2664 does the same for NEW_TOKEN generation, keeping the single long-delay application in one place.

- picoquic/tls_api.c:2878 switches the hard-coded microsecond offsets to the shared PICOQUIC_TOKEN_DELAY_* constants, ensuring both call sites derive their lifetimes from the same definitions.

- picoquictest/tls_api_test.c:3669 adjusts the validation test’s schedule so it still probes “just before” and “just after” the corrected expiry thresholds.

**Tests:** 
`cmake -S . -B build -DPROJECT_ENABLE_TESTS=ON - && cmake --build build -j && ctest --test-dir build --output-on-failure`