### PR TITLE
fix for issue 1782

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -126,16 +126,8 @@ int picoquic_screen_initial_packet(
 
         if (picoquic_get_initial_aead_context(quic, ph->version_index, &ph->dest_cnx_id,
             0 /* is_client=0 */, 0 /* is_enc = 0 */, &aead_ctx, &pn_dec_ctx) == 0) {
-            ret = picoquic_remove_header_protection_inner((uint8_t *)bytes, ph->offset + ph->payload_length,
+            ret = picoquic_remove_header_protection_inner((uint8_t*)bytes, ph->offset + ph->payload_length,
                 decrypted_bytes, &dph, pn_dec_ctx, 0 /* is_loss_bit_enabled_incoming */, 0 /* sack_list_last*/);
-            if (ret == 0) {
-                size_t decrypted_length = picoquic_aead_decrypt_generic(decrypted_bytes + dph.offset,
-                    bytes + dph.offset, dph.payload_length, dph.pn64, decrypted_bytes, dph.offset, 
-                    aead_ctx);
-                if (decrypted_length >= dph.payload_length) {
-                    ret = PICOQUIC_ERROR_AEAD_CHECK;
-                }
-            }
         }
         else {
             ret = PICOQUIC_ERROR_MEMORY;

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1254,15 +1254,6 @@ typedef struct st_picoquic_crypto_context_t {
     void* pn_dec; /* Used for PN decryption */
 } picoquic_crypto_context_t;
 
-typedef struct st_picoquic_initial_packet_context_t {
-    void* aead_decrypt;
-    void* pn_dec;
-    void* aead_encrypt;
-    void* pn_enc;
-    const uint8_t* decrypted_packet;
-    size_t decrypted_packet_length;
-} picoquic_initial_packet_context_t;
-
 /*
 * Per connection context.
 */
@@ -1469,8 +1460,6 @@ typedef struct st_picoquic_cnx_t {
     /* Data accounting for limiting amplification attacks */
     uint64_t initial_data_received;
     uint64_t initial_data_sent;
-    uint8_t* initial_decrypted_packet;
-    size_t initial_decrypted_packet_length;
 
     /* Flow control information */
     uint64_t data_sent;
@@ -2056,12 +2045,11 @@ uint8_t* picoquic_format_max_path_id_frame(uint8_t* bytes, const uint8_t* bytes_
 uint8_t* picoquic_format_blocked_frames(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack);
 int picoquic_queue_retire_connection_id_frame(picoquic_cnx_t * cnx, uint64_t unique_path_id, uint64_t sequence);
 int picoquic_queue_new_token_frame(picoquic_cnx_t * cnx, uint8_t * token, size_t token_length);
-
-picoquic_cnx_t* picoquic_create_cnx_with_initial(picoquic_quic_t* quic,
-    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
-    const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
-    char const* sni, char const* alpn, char client_mode,
-    picoquic_initial_packet_context_t* initial_ctx);
+int picoquic_set_initial_crypto_contexts(picoquic_cnx_t* cnx,
+    void* aead_decrypt,
+    void* pn_dec,
+    void* aead_encrypt,
+    void* pn_enc);
 uint8_t* picoquic_format_one_blocked_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack, picoquic_stream_head_t* stream);
 uint8_t* picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack,
     picoquic_misc_frame_header_t* misc_frame, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last);

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1254,6 +1254,15 @@ typedef struct st_picoquic_crypto_context_t {
     void* pn_dec; /* Used for PN decryption */
 } picoquic_crypto_context_t;
 
+typedef struct st_picoquic_initial_packet_context_t {
+    void* aead_decrypt;
+    void* pn_dec;
+    void* aead_encrypt;
+    void* pn_enc;
+    const uint8_t* decrypted_packet;
+    size_t decrypted_packet_length;
+} picoquic_initial_packet_context_t;
+
 /*
 * Per connection context.
 */
@@ -1460,6 +1469,8 @@ typedef struct st_picoquic_cnx_t {
     /* Data accounting for limiting amplification attacks */
     uint64_t initial_data_received;
     uint64_t initial_data_sent;
+    uint8_t* initial_decrypted_packet;
+    size_t initial_decrypted_packet_length;
 
     /* Flow control information */
     uint64_t data_sent;
@@ -2045,6 +2056,12 @@ uint8_t* picoquic_format_max_path_id_frame(uint8_t* bytes, const uint8_t* bytes_
 uint8_t* picoquic_format_blocked_frames(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack);
 int picoquic_queue_retire_connection_id_frame(picoquic_cnx_t * cnx, uint64_t unique_path_id, uint64_t sequence);
 int picoquic_queue_new_token_frame(picoquic_cnx_t * cnx, uint8_t * token, size_t token_length);
+
+picoquic_cnx_t* picoquic_create_cnx_with_initial(picoquic_quic_t* quic,
+    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
+    const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn, char client_mode,
+    picoquic_initial_packet_context_t* initial_ctx);
 uint8_t* picoquic_format_one_blocked_frame(picoquic_cnx_t* cnx, uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack, picoquic_stream_head_t* stream);
 uint8_t* picoquic_format_first_misc_or_dg_frame(uint8_t* bytes, uint8_t* bytes_max, int* more_data, int* is_pure_ack,
     picoquic_misc_frame_header_t* misc_frame, picoquic_misc_frame_header_t** first, picoquic_misc_frame_header_t** last);

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3894,71 +3894,32 @@ picoquic_local_cnxid_t* picoquic_find_local_cnxid(picoquic_cnx_t* cnx, uint64_t 
 
 /* Connection management
  */
-
-static int picoquic_apply_initial_packet_context(
-    picoquic_cnx_t* cnx,
-    picoquic_initial_packet_context_t* initial_ctx)
+int picoquic_set_initial_crypto_contexts(picoquic_cnx_t* cnx,
+   void* aead_decrypt,
+   void* pn_dec,
+   void* aead_encrypt,
+   void* pn_enc)
 {
-    int ret = 0;
+   if (cnx == NULL || aead_decrypt == NULL || pn_dec == NULL ||
+      aead_encrypt == NULL || pn_enc == NULL)
+   {
+      return -1;
+   }
 
-    if (initial_ctx == NULL) {
-        ret = picoquic_setup_initial_traffic_keys(cnx);
-    }
-    else {
-        if (initial_ctx->aead_decrypt == NULL || initial_ctx->pn_dec == NULL ||
-            initial_ctx->aead_encrypt == NULL || initial_ctx->pn_enc == NULL) {
-            ret = -1;
-        }
-        else {
-            cnx->crypto_context[picoquic_epoch_initial].aead_decrypt = initial_ctx->aead_decrypt;
-            cnx->crypto_context[picoquic_epoch_initial].pn_dec = initial_ctx->pn_dec;
-            cnx->crypto_context[picoquic_epoch_initial].aead_encrypt = initial_ctx->aead_encrypt;
-            cnx->crypto_context[picoquic_epoch_initial].pn_enc = initial_ctx->pn_enc;
+   picoquic_crypto_context_free(&cnx->crypto_context[picoquic_epoch_initial]);
 
-            if (initial_ctx->decrypted_packet != NULL && initial_ctx->decrypted_packet_length > 0) {
-                cnx->initial_decrypted_packet = (uint8_t*)malloc(initial_ctx->decrypted_packet_length);
-                if (cnx->initial_decrypted_packet == NULL) {
-                    ret = PICOQUIC_ERROR_MEMORY;
-                }
-                else {
-                    memcpy(cnx->initial_decrypted_packet, initial_ctx->decrypted_packet, initial_ctx->decrypted_packet_length);
-                    cnx->initial_decrypted_packet_length = initial_ctx->decrypted_packet_length;
-                }
-            }
-        }
+   cnx->crypto_context[picoquic_epoch_initial].aead_decrypt = aead_decrypt;
+   cnx->crypto_context[picoquic_epoch_initial].pn_dec = pn_dec;
+   cnx->crypto_context[picoquic_epoch_initial].aead_encrypt = aead_encrypt;
+   cnx->crypto_context[picoquic_epoch_initial].pn_enc = pn_enc;
 
-        if (ret != 0) {
-            picoquic_crypto_context_free(&cnx->crypto_context[picoquic_epoch_initial]);
-            if (cnx->initial_decrypted_packet != NULL) {
-                free(cnx->initial_decrypted_packet);
-                cnx->initial_decrypted_packet = NULL;
-                cnx->initial_decrypted_packet_length = 0;
-            }
-            initial_ctx->aead_decrypt = NULL;
-            initial_ctx->pn_dec = NULL;
-            initial_ctx->aead_encrypt = NULL;
-            initial_ctx->pn_enc = NULL;
-            initial_ctx->decrypted_packet = NULL;
-            initial_ctx->decrypted_packet_length = 0;
-        }
-        else {
-            initial_ctx->aead_decrypt = NULL;
-            initial_ctx->pn_dec = NULL;
-            initial_ctx->aead_encrypt = NULL;
-            initial_ctx->pn_enc = NULL;
-            initial_ctx->decrypted_packet = NULL;
-            initial_ctx->decrypted_packet_length = 0;
-        }
-    }
-
-    return ret;
+   return 0;
 }
 
-static picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
-    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
+picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
+    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id, 
     const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
-    char const* sni, char const* alpn, char client_mode,
-    picoquic_initial_packet_context_t* initial_ctx)
+    char const* sni, char const* alpn, char client_mode)
 {
     picoquic_cnx_t* cnx = (picoquic_cnx_t*)malloc(sizeof(picoquic_cnx_t));
 
@@ -4211,7 +4172,7 @@ static picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
     }
 
     if (cnx != NULL) {
-        if (picoquic_apply_initial_packet_context(cnx, initial_ctx) != 0) {
+        if (picoquic_setup_initial_traffic_keys(cnx)) {
             /* Cannot initialize aead for initial packets */
             picoquic_delete_cnx(cnx);
             cnx = NULL;
@@ -4235,25 +4196,6 @@ static picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
     }
 
     return cnx;
-}
-
-picoquic_cnx_t* picoquic_create_cnx(picoquic_quic_t* quic,
-    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
-    const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
-    char const* sni, char const* alpn, char client_mode)
-{
-    return picoquic_create_cnx_internal(quic, initial_cnx_id, remote_cnx_id,
-        addr_to, start_time, preferred_version, sni, alpn, client_mode, NULL);
-}
-
-picoquic_cnx_t* picoquic_create_cnx_with_initial(picoquic_quic_t* quic,
-    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
-    const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
-    char const* sni, char const* alpn, char client_mode,
-    picoquic_initial_packet_context_t* initial_ctx)
-{
-    return picoquic_create_cnx_internal(quic, initial_cnx_id, remote_cnx_id,
-        addr_to, start_time, preferred_version, sni, alpn, client_mode, initial_ctx);
 }
 
 picoquic_cnx_t* picoquic_create_client_cnx(picoquic_quic_t* quic,
@@ -4938,12 +4880,6 @@ void picoquic_delete_cnx(picoquic_cnx_t* cnx)
         if (cnx->retry_token != NULL) {
             free(cnx->retry_token);
             cnx->retry_token = NULL;
-        }
-
-        if (cnx->initial_decrypted_packet != NULL) {
-            free(cnx->initial_decrypted_packet);
-            cnx->initial_decrypted_packet = NULL;
-            cnx->initial_decrypted_packet_length = 0;
         }
 
         picoquic_delete_sooner_packets(cnx);


### PR DESCRIPTION
Fixes #1782: 

avoid double-decrypting Initial packets on the server path. We now only strip header protection during initial screening and leave payload decryption to the normal receive flow, eliminating redundant AEAD work while preserving token validation and handshake checks.