### PR TITLE
Rearrange packet parsing to decrypt initial just once

### DIFF
--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -90,7 +90,8 @@ int picoquic_screen_initial_packet(
     picoquic_packet_header* ph,
     uint64_t current_time,
     picoquic_cnx_t** pcnx,
-    int* new_ctx_created)
+    int* new_ctx_created,
+    picoquic_stream_data_node_t* decrypted_data)
 {
     int ret = 0;
 
@@ -121,19 +122,20 @@ int picoquic_screen_initial_packet(
         /* Verify the AEAD checkum */
         void* aead_ctx = NULL;
         void* pn_dec_ctx = NULL;
-        uint8_t decrypted_bytes[PICOQUIC_MAX_PACKET_SIZE];
-        picoquic_packet_header dph = *ph;
 
         if (picoquic_get_initial_aead_context(quic, ph->version_index, &ph->dest_cnx_id,
             0 /* is_client=0 */, 0 /* is_enc = 0 */, &aead_ctx, &pn_dec_ctx) == 0) {
             ret = picoquic_remove_header_protection_inner((uint8_t *)bytes, ph->offset + ph->payload_length,
-                decrypted_bytes, &dph, pn_dec_ctx, 0 /* is_loss_bit_enabled_incoming */, 0 /* sack_list_last*/);
+                decrypted_data->data, ph, pn_dec_ctx, 0 /* is_loss_bit_enabled_incoming */, 0 /* sack_list_last*/);
             if (ret == 0) {
-                size_t decrypted_length = picoquic_aead_decrypt_generic(decrypted_bytes + dph.offset,
-                    bytes + dph.offset, dph.payload_length, dph.pn64, decrypted_bytes, dph.offset, 
+                size_t decrypted_length = picoquic_aead_decrypt_generic(decrypted_data->data + ph->offset,
+                    bytes + ph->offset, ph->payload_length, ph->pn64, decrypted_data->data, ph->offset, 
                     aead_ctx);
-                if (decrypted_length >= dph.payload_length) {
+                if (decrypted_length >= ph->payload_length) {
                     ret = PICOQUIC_ERROR_AEAD_CHECK;
+                }
+                else {
+                    ph->payload_length = (uint16_t)decrypted_length;
                 }
             }
         }
@@ -160,7 +162,7 @@ int picoquic_screen_initial_packet(
             if (ph->token_length > 0) {
                 /* If a token is present, verify it. */
                 if (picoquic_verify_retry_token(quic, addr_from, current_time,
-                    &is_new_token, &original_cnxid, &ph->dest_cnx_id, (uint32_t)dph.pn64,
+                    &is_new_token, &original_cnxid, &ph->dest_cnx_id, (uint32_t)ph->pn64,
                     ph->token_bytes, ph->token_length, 1) == 0) {
                     has_good_token = 1;
                 }
@@ -780,48 +782,34 @@ int picoquic_parse_header_and_decrypt(
 
     *new_ctx_created = 0;
 
-    if (ret == 0 ) {
+    if (ret == 0) {
         if (ph->ptype != picoquic_packet_version_negotiation &&
             ph->ptype != picoquic_packet_retry && ph->ptype != picoquic_packet_error) {
-            /* TODO: clarify length, payload length, packet length -- special case of initial packet */
             length = ph->offset + ph->payload_length;
             *consumed = length;
 
-            if (*pcnx == NULL) {
-                /* Redirect if proxy available */
-                if (quic->picomask_fns != NULL) {
-                    ret = (quic->picomask_fns->picomask_redirect_fn)(quic->picomask_ctx,
-                        bytes, packet_length, addr_from, consumed); 
+            if (*pcnx != NULL) {
+                if (!(*pcnx)->client_mode && ph->ptype == picoquic_packet_initial && packet_length < PICOQUIC_ENFORCED_INITIAL_MTU) {
+                    /* Unexpected packet. Reject, drop and log. */
+                    ret = PICOQUIC_ERROR_INITIAL_TOO_SHORT;
                 }
-                if (ph->ptype == picoquic_packet_initial) {
-                    ret = picoquic_screen_initial_packet(quic, bytes, packet_length, addr_from, ph, current_time, pcnx, new_ctx_created);
+                /* Test whether we need to do a version upgrade */
+                else if (ph->version_index != (*pcnx)->version_index) {
+                    if ((*pcnx)->client_mode &&
+                        (*pcnx)->cnx_state < picoquic_state_client_almost_ready &&
+                        ph->version_index >= 0 &&
+                        picoquic_supported_versions[ph->version_index].version == (*pcnx)->desired_version) {
+                        /* The server already accepted the version upgrade */
+                        ret = picoquic_process_version_upgrade(*pcnx, (*pcnx)->version_index, ph->version_index);
+                    }
+                    else {
+                        ret = PICOQUIC_ERROR_PACKET_WRONG_VERSION;
+                    }
                 }
-            }
-            else if (!(*pcnx)->client_mode && ph->ptype == picoquic_packet_initial && packet_length < PICOQUIC_ENFORCED_INITIAL_MTU) {
-                /* Unexpected packet. Reject, drop and log. */
-                ret = PICOQUIC_ERROR_INITIAL_TOO_SHORT;
-            }
+                else {
 
-            if (ret == 0) {
-                if (*pcnx != NULL) {
-                    /* Test whether we need to do a version upgrade */
-                    if (ph->version_index != (*pcnx)->version_index) {
-                        if ((*pcnx)->client_mode &&
-                            (*pcnx)->cnx_state < picoquic_state_client_almost_ready &&
-                            ph->version_index >= 0 &&
-                            picoquic_supported_versions[ph->version_index].version == (*pcnx)->desired_version) {
-                            /* The server already accepted the version upgrade */
-                            ret = picoquic_process_version_upgrade(*pcnx, (*pcnx)->version_index, ph->version_index);
-                        }
-                        else {
-                            ret = PICOQUIC_ERROR_PACKET_WRONG_VERSION;
-                        }
-                    }
-
-                    if (ret == 0) {
-                        /* Remove header protection at this point -- values of bytes will not change */
-                        ret = picoquic_remove_header_protection(*pcnx, (uint8_t*)bytes, decrypted_data->data, ph);
-                    }
+                    /* Remove header protection at this point -- values of bytes will not change */
+                    ret = picoquic_remove_header_protection(*pcnx, (uint8_t*)bytes, decrypted_data->data, ph);
 
                     if (ret == 0) {
                         decoded_length = picoquic_remove_packet_protection(*pcnx, (uint8_t*)bytes,
@@ -857,17 +845,44 @@ int picoquic_parse_header_and_decrypt(
                         ph->payload_length = (uint16_t)decoded_length;
                     }
                 }
-                else if (ph->ptype == picoquic_packet_1rtt_protected)
-                {
-                    /* This may be a stateless reset.
-                     * We test the address + putative reset secret pair against the hash table
-                     * of registered secrets. If there is a match, the corresponding connection is
-                     * found and the packet is marked as Stateless Reset */
-                    if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE) {
-                        *pcnx = picoquic_cnx_by_secret(quic, bytes + length - PICOQUIC_RESET_SECRET_SIZE, addr_from);
-                        if (*pcnx != NULL) {
-                            ret = PICOQUIC_ERROR_STATELESS_RESET;
-                            picoquic_log_app_message(*pcnx, "Found connection from reset secret, ret = %d", ret);
+            }
+            else {
+                if (ph->ptype != picoquic_packet_version_negotiation &&
+                    ph->ptype != picoquic_packet_retry && ph->ptype != picoquic_packet_error) {
+                    /* TODO: clarify length, payload length, packet length -- special case of initial packet */
+                    length = ph->offset + ph->payload_length;
+                    *consumed = length;
+
+                    /* Redirect if proxy available -- function returns 0 if the packet was *not* intercepted */
+                    if (quic->picomask_fns != NULL) {
+                        ret = (quic->picomask_fns->picomask_redirect_fn)(quic->picomask_ctx,
+                            bytes, packet_length, addr_from, consumed);
+                    }
+                    if (ret == 0) {
+                        /* If packet was not redirected, it might be an initial packet
+                         * for a new connection or a stateless redirect. Any other type
+                         * should be treated as an error.
+                         */
+                        if (ph->ptype == picoquic_packet_initial) {
+                            ret = picoquic_screen_initial_packet(quic, bytes, packet_length, addr_from, ph, current_time, pcnx,
+                                new_ctx_created, decrypted_data);
+                        }
+                        else if (ph->ptype == picoquic_packet_1rtt_protected)
+                        {
+                            /* This may be a stateless reset.
+                             * We test the address + putative reset secret pair against the hash table
+                             * of registered secrets. If there is a match, the corresponding connection is
+                             * found and the packet is marked as Stateless Reset */
+                            if (length >= PICOQUIC_RESET_PACKET_MIN_SIZE) {
+                                *pcnx = picoquic_cnx_by_secret(quic, bytes + length - PICOQUIC_RESET_SECRET_SIZE, addr_from);
+                                if (*pcnx != NULL) {
+                                    ret = PICOQUIC_ERROR_STATELESS_RESET;
+                                    picoquic_log_app_message(*pcnx, "Found connection from reset secret, ret = %d", ret);
+                                }
+                            }
+                        }
+                        else {
+                            ret = PICOQUIC_ERROR_UNEXPECTED_PACKET;
                         }
                     }
                 }
@@ -877,6 +892,7 @@ int picoquic_parse_header_and_decrypt(
             /* Clear text packet. Copy content to decrypted data */
             memmove(decrypted_data->data, bytes, length);
             *consumed = length;
+
         }
     }
     


### PR DESCRIPTION
This is the fist part of a fix for issue #1782. The parsing of packet headers was rewritten last year to introduce a filtering function, `picoquic_screen_initial_packet`, to enforce a set of tests of initial packets before accepting a new connection and creating a new connection context. This test was meant as a protection against DOS attacks, and required decrypting the initial packet -- but the packet was decrypted again once the connection was established.

This fix rearranges the parsing of packet in `picoquic_parse_header_and_decrypt` to retain the value decrypted during the screening of the initial packet and avoid the double decryption. It also rearranges the code so the most frequent path (1rtt packet on existing connection) is the first branch of the if statement.

It does not fully fixes issue #1782. The double decryption is just one of the problem flagged there, and it is solved. But the remaining issue is the double computation of the decryption key for Initial packets. This will be done in a separate PR.