### PR TITLE
Do not compute initial AEAD decryption key twice.

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1573,6 +1573,15 @@ typedef struct st_picoquic_packet_data_t {
     } path_ack[PICOQUIC_NB_PATH_TARGET];
 } picoquic_packet_data_t;
 
+/* Create a connection context without recomputing initial_aead_dec and
+* initial_pn_dec if they were already computed.
+*/
+picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
+    picoquic_connection_id_t initial_cnx_id, picoquic_connection_id_t remote_cnx_id,
+    const struct sockaddr* addr_to, uint64_t start_time, uint32_t preferred_version,
+    char const* sni, char const* alpn, char client_mode,
+    void* initial_aead_dec, void* initial_pn_dec);
+
 /* Load the stash of retry tokens. */
 int picoquic_load_token_file(picoquic_quic_t* quic, char const * token_file_name);
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1485,7 +1485,6 @@ int picoquic_setup_initial_traffic_keys(picoquic_cnx_t* cnx)
             secret1 = client_secret;
             secret2 = server_secret;
         }
-        
         ret = picoquic_set_key_from_secret(cipher, 1, 0, &cnx->crypto_context[0], secret1, prefix_label);
 
         if (ret == 0) {


### PR DESCRIPTION
This is the second part of the fix for issue #1782. The fix in PR #1947 ensured that packets would not be decrypted
twice, but did not pass the computed AEAD and PN decryption keys to the new context, which means the
key generation had to be done twice. This PR fixes that last point. It introduces an "internal" variant
of connection context creation that takes as additional parameters the AEAD and PN decryption contexts,
and avoids recomputing them, and it makes sure that this variant is called when creating a connection context
in the `picoquic_screen_initial_packet` function.

We have to pay attention to the way memory is handled to not have either crashes or memory leak. The convention is that if the call to `picoquic_create_cnx_internal` succeeds, the objects pointed to by the AEAD and PN decryption handles
is `owned` by the connection context, but if it fails it remains owned by the calling code and should be cleared
inside for example `picoquic_screen_initial_packet`.