### PR TITLE
Advertize both WT draft 07 and latest

### DIFF
--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -1106,7 +1106,7 @@ void h3zero_delete_data_stream_state(h3zero_data_stream_state_t * stream_state)
 static uint8_t const h3zero_default_setting_frame_val[] = {
     0, /* Control Stream ID, varint = 0 */
     (uint8_t)h3zero_frame_settings, /* var int frame type ( < 64) */
-    13, /* Length of setting frame content */
+    22, /* Length of setting frame content */
     (uint8_t)h3zero_setting_header_table_size, 0, /* var int type ( < 64), then var int value (0) */
     (uint8_t)h3zero_qpack_blocked_streams, 0, /* var int type ( < 64),  then var int value (0) Control*/
     /* enable_connect_protocol = 0x8 */
@@ -1117,7 +1117,12 @@ static uint8_t const h3zero_default_setting_frame_val[] = {
     ((h3zero_settings_webtransport_max_sessions >> 24)&0xff)|0x80,
     (uint8_t)((h3zero_settings_webtransport_max_sessions >> 16)&0xff),
     (uint8_t)((h3zero_settings_webtransport_max_sessions >> 8)&0xff),
-    (uint8_t)((h3zero_settings_webtransport_max_sessions)&0xff), 1
+    (uint8_t)((h3zero_settings_webtransport_max_sessions)&0xff), 1,
+    0xc0, 0x00, 0x00, 0x00,
+    ((h3zero_settings_webtransport_max_sessions_old >> 24) & 0xff),
+    (uint8_t)((h3zero_settings_webtransport_max_sessions_old >> 16) & 0xff),
+    (uint8_t)((h3zero_settings_webtransport_max_sessions_old >> 8) & 0xff),
+    (uint8_t)((h3zero_settings_webtransport_max_sessions_old) & 0xff), 1
 };
 
 uint8_t const * h3zero_default_setting_frame = h3zero_default_setting_frame_val;

--- a/picohttp/h3zero_common.c
+++ b/picohttp/h3zero_common.c
@@ -2006,7 +2006,8 @@ uint8_t* h3zero_settings_encode(uint8_t* bytes, const uint8_t* bytes_max, const 
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_qpack_blocked_streams, settings->blocked_streams, UINT64_MAX)) != NULL &&
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_enable_connect_protocol, settings->enable_connect_protocol, 0)) != NULL &&
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_setting_h3_datagram, settings->h3_datagram, 0)) != NULL &&
-				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions, settings->webtransport_max_sessions, 0)) != NULL) {
+				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions, settings->webtransport_max_sessions, 0)) != NULL &&
+				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions_old, settings->webtransport_max_sessions, 0)) != NULL) {
 				size_t actual_length = bytes - bytes_after_length;
 				uint8_t* bytes_final_length = picoquic_frames_varint_encode(bytes_of_length, bytes_after_length, actual_length);
 				if (bytes_final_length == NULL) {
@@ -2046,6 +2047,7 @@ const uint8_t* h3zero_settings_components_decode(const uint8_t* bytes, const uin
 			settings->h3_datagram = (unsigned int)component_value;
 			break;
 		case h3zero_settings_webtransport_max_sessions:
+		case h3zero_settings_webtransport_max_sessions_old:
 			settings->webtransport_max_sessions = component_value;
 			break;
 		default:

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -3550,21 +3550,6 @@ int h3zero_settings_test()
     return ret;
 }
 
-            /*
-            * h3zero_content_type_none = 0,
-            * h3zero_content_type_not_supported,
-            * h3zero_content_type_text_html,
-            * h3zero_content_type_text_plain,
-            * h3zero_content_type_image_gif,
-            * h3zero_content_type_image_jpeg,
-            * h3zero_content_type_image_png,
-            * h3zero_content_type_dns_message,
-            * h3zero_content_type_javascript,
-            * h3zero_content_type_json,
-            * h3zero_content_type_www_form_urlencoded,
-            * h3zero_content_type_text_css
-            */
-
 typedef struct st_h3zero_string_content_type_compar_list_t {
     const char *path;
     const h3zero_content_type_enum content_type;


### PR DESCRIPTION
Trying to please everybody and even Chrome.

WT is still a work in progress. There are 4 big versions:

- draft 3, July 2022, setting code for ENABLE_WEBTRANSPORT = 0x2b603742
- draft 6, May 2023, setting code for ENABLE_WEBTRANSPORT = 0x3c48d522
- draft 7, June 2023, setting code for WEBTRANSPORT_MAX_SESSIONS= 0xc671706a
- draft 13, July 2025, setting code for WT_MAX_SESSIONS = 0x14e9cd29

Google Chrome still comes with draft 3, and has an experimental support for draft 7.
Draft 7 to14 may have differences in the definition of WT flow control, but we do not implement that, we stick to "WT_MAX_SESSIONS = 1". Which mean we can keep the same code for both. So this PR announces both versions in the settings.