### PR TITLE
Prague recovery fix

### DIFF
--- a/picoquic/prague.c
+++ b/picoquic/prague.c
@@ -352,7 +352,7 @@ void picoquic_prague_notify(
         case picoquic_congestion_notification_repeat:
             /* enter recovery on loss. We should do nothing on timeout */
             if (picoquic_cc_hystart_loss_test(&pr_state->rtt_filter, notification, ack_state->lost_packet_number,
-                PICOQUIC_SMOOTHED_LOSS_THRESHOLD) && current_time - pr_state->recovery_sequence > path_x->smoothed_rtt) {
+                PICOQUIC_SMOOTHED_LOSS_THRESHOLD) && current_time - pr_state->recovery_stamp > path_x->smoothed_rtt) {
                 picoquic_prague_enter_recovery(cnx, path_x, notification, pr_state, current_time);
             }
             break;


### PR DESCRIPTION
HyStart is hiding this bug in the test suite, because it exits SS without overshooting the buffer.

HyStart:
<img width="1624" height="978" alt="Screenshot 2025-11-10 at 22 31 00" src="https://github.com/user-attachments/assets/4a1825d0-6195-44b4-a7ed-de33d3315f8b" />

If I disable HyStart in #1840 recovery is entered multiple times in a single recovery sequence and halves the congestion window repeatedly.

HyStart disabled:
<img width="1624" height="978" alt="Screenshot 2025-11-10 at 22 05 56" src="https://github.com/user-attachments/assets/f098b847-d6b7-4125-8661-92d682e80175" />

I think the intention was to compare the recovery timestamp, not the sequence.

HyStart disabled with fix:
<img width="1624" height="978" alt="Screenshot 2025-11-10 at 22 32 17" src="https://github.com/user-attachments/assets/c73e8fbd-c991-4c0b-ad8c-489c4fa5698e" />