### PR TITLE
Silly unit conversion mistake!

### DIFF
--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -354,7 +354,7 @@ static void c4_apply_rate_and_cwin(
         if (c4_state->nominal_max_rtt < 4* C4_RTT_MARGIN_DELAY) {
             delta_rtt_target = c4_state->nominal_max_rtt / 4;
         }
-        target_cwin += delta_rtt_target * pacing_rate;
+        target_cwin += (delta_rtt_target * pacing_rate) / 1000000;
 
         if (c4_state->alg_state == c4_pushing) {
             uint64_t delta_alpha = c4_state->alpha_1024_current - 1024;


### PR DESCRIPTION
I was plotting the new results when I saw something strange. On the graphs showing both CWND and bytes in flight, the bytes in flight where all plotted as almost 0. Took me a moment to check the scale of the graph, showing values of the CWND of order 10^10...

In the code computing the "margin", I had:

~~~
        target_cwin += delta_rtt_target * pacing_rate;
~~~

That looks good, and we did not see anything when reviewing the code, but it is wrong! the delta_rtt_target is expressed in microseconds, the pacing_rate in bytes per second. To get the correct value one must write:

~~~
        target_cwin += (delta_rtt_target * pacing_rate) / 1000000;
~~~

With the previous code, we were adding 15,000,000,000 bytes to the CWND. Let's fix that immediately. I may need to do more tuning later...