### PR TITLE
Avoid bouncing into congestion after recovery

### DIFF
--- a/picoquic/cc_common.c
+++ b/picoquic/cc_common.c
@@ -52,6 +52,14 @@ uint64_t picoquic_cc_get_ack_number(picoquic_cnx_t* cnx, picoquic_path_t* path_x
     return highest_acknowledged;
 }
 
+uint64_t picoquic_cc_get_lowest_not_ack(picoquic_path_t* path_x)
+{
+    picoquic_packet_context_t* pkt_ctx = (path_x->cnx->is_multipath_enabled) ? &path_x->pkt_ctx : &path_x->cnx->pkt_ctx[picoquic_packet_context_application];
+    uint64_t lowest_not_ack = (pkt_ctx->pending_first != NULL) ? pkt_ctx->pending_first->sequence_number : pkt_ctx->highest_acknowledged + 1;
+
+    return lowest_not_ack;
+}
+
 uint64_t picoquic_cc_get_ack_sent_time(picoquic_cnx_t* cnx, picoquic_path_t* path_x)
 {
     uint64_t latest_time_acknowledged;

--- a/picoquic/cc_common.h
+++ b/picoquic/cc_common.h
@@ -76,6 +76,7 @@ typedef struct st_picoquic_min_max_rtt_t {
 uint64_t picoquic_cc_get_sequence_number(picoquic_cnx_t* cnx, picoquic_path_t* path_x);
 
 uint64_t picoquic_cc_get_ack_number(picoquic_cnx_t* cnx, picoquic_path_t * path_x);
+uint64_t picoquic_cc_get_lowest_not_ack(picoquic_path_t* path_x);
 
 uint64_t picoquic_cc_get_ack_sent_time(picoquic_cnx_t* cnx, picoquic_path_t* path_x);
 


### PR DESCRIPTION
When analysing ECN traces, I found several instance of "bounces", which happens as follow:

* C4 goes into "pushing" mode (+25%)
* Queue builds up rapidly because sending rate is too large
* ECN/CE marks cause an early detection of congestion, C4 enters recovery mode
* after acknowledging the packets in flight during the pushing phase, C4 enters "cruising"
* the residual queue causes a rapid influx of ECN marks, thus congestion notification and drop in nominal rate
* that drop is too large, and it takes a long time to recover and retrieve the proper rate

The root cause here is that recovery only dropped to 15/16 of the "nominal rate", but that rate was a bit over estimated so the queue is not reduced. The solution lies in two changes:

* if a second congestion is notified during recovery, reset the `alpha_current' multiplier to 7/8 (instead of 15/16), and reset the "era_sequence" to the current send pointer to increase the duration in recovery.
* in general, detect end of era by testing the era sequence against the "lowest sequence number not acked" rather than the "highest number acked". This is more robust in case of out of order deliveries, or if there are holes in the acknowledgement sequence.


