### PR TITLE
Handle `picoquic_callback_app_wakeup` in TLS API callback.

### DIFF
--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -625,7 +625,8 @@ int test_api_callback(picoquic_cnx_t* cnx,
     if (fin_or_event == picoquic_callback_close ||
         fin_or_event == picoquic_callback_application_close ||
         fin_or_event == picoquic_callback_almost_ready ||
-        fin_or_event == picoquic_callback_ready) {
+        fin_or_event == picoquic_callback_ready ||
+        fin_or_event == picoquic_callback_app_wakeup) {
         /* do nothing in our tests */
         return 0;
     }


### PR DESCRIPTION
If `picoquic_set_app_wake_time()` is called in a test, the `picoquic_callback_app_wakeup` event fired from `picoquic_handle_app_wake_time()` isn't handled in `test_api_callback()`.

This will end in an error [here](https://github.com/private-octopus/picoquic/blob/2624403a63af2d4ec83e0093265adb7ae62a5d70/picoquictest/tls_api_test.c#L777), and the test will fail.

PR is a simple fix to ignore `picoquic_callback_app_wakeup` in the callback.