### PR TITLE
Do not grease ECH by default.

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1562,7 +1562,13 @@ namespace UnitTest1
 
             Assert::AreEqual(ret, 0);
         }
+#if 0
+        TEST_METHOD(zero_rtt_ech) {
+            int ret = zero_rtt_ech_test();
 
+            Assert::AreEqual(ret, 0);
+        }
+#endif
         TEST_METHOD(cnxid_transmit)
         {
             int ret = transmit_cnxid_test();

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -935,7 +935,7 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
             }
         }
 
-        if (ret == 0) {
+        if (ret == 0 && (config->ech_key_file != NULL || config->ech_target != NULL)) {
             ret = picoquic_ech_configure_quic_ctx(quic, config->ech_key_file, config->ech_config_file);
         }
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -259,6 +259,9 @@ static const picoquic_test_def_t test_table[] = {
     { "zero_rtt_many_losses", zero_rtt_many_losses_test },
     { "zero_rtt_long", zero_rtt_long_test },
     { "zero_rtt_delay", zero_rtt_delay_test },
+#if 0
+    { "zero_rtt_ech", zero_rtt_ech_test },
+#endif
     { "random_tester", random_tester_test},
     { "random_gauss", random_gauss_test},
     { "random_public_tester", random_public_tester_test},

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -1702,12 +1702,12 @@ int monopath_rotation_test()
 /* The zero RTT test uses the unipath code, with a special parameter.
  * Test both regular 0RTT set up, and case of losses.
  */
-int zero_rtt_test_one(int use_badcrypt, int hardreset, uint64_t early_loss,
-    unsigned int no_coal, unsigned int long_data, uint64_t extra_delay, int do_multipath);
 
 int monopath_0rtt_test()
 {
-    return zero_rtt_test_one(0, 0, 0, 0, 0, 0, 1);
+    zero_rtt_test_t zrt = { 0 };
+    zrt.do_multipath = 1;
+    return zero_rtt_test_one(&zrt);
 }
 
 int monopath_0rtt_loss_test()
@@ -1715,8 +1715,10 @@ int monopath_0rtt_loss_test()
     int ret = 0;
 
     for (unsigned int i = 1; ret == 0 && i < 16; i++) {
-        uint64_t early_loss = 1ull << i;
-        ret = zero_rtt_test_one(0, 0, early_loss, 0, 0, 0, 1);
+        zero_rtt_test_t zrt = { 0 };
+        zrt.early_loss = 1ull << i;
+        zrt.do_multipath = 1;
+        ret = zero_rtt_test_one(&zrt);
         if (ret != 0) {
             DBG_PRINTF("Monopath 0 RTT test fails when packet #%d is lost.\n", i);
         }

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -174,6 +174,7 @@ int zero_rtt_no_coal_test();
 int zero_rtt_many_losses_test();
 int zero_rtt_long_test();
 int zero_rtt_delay_test();
+int zero_rtt_ech_test();
 int parse_frame_test();
 int frames_repeat_test();
 int frames_ackack_error_test();

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -392,6 +392,19 @@ int picoquic_test_set_minimal_cnx_with_time(picoquic_quic_t** quic, picoquic_cnx
 int picoquic_test_reset_minimal_cnx(picoquic_quic_t* quic, picoquic_cnx_t** cnx);
 void picoquic_test_delete_minimal_cnx(picoquic_quic_t** quic, picoquic_cnx_t** cnx);
 
+typedef struct st_zero_rtt_test_t {
+    int use_badcrypt;
+    int hardreset;
+    uint64_t early_loss;
+    unsigned int no_coal;
+    unsigned int long_data;
+    uint64_t extra_delay;
+    int do_multipath;
+    int propose_ech;
+} zero_rtt_test_t;
+
+int zero_rtt_test_one(zero_rtt_test_t* zrt);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Picoquicdemo was always sending an ECH "grease" parameter, even if when it did not know whether the target server was ECH capable. That behavior triggers some kind of bug in the picotls handling of 0RTT, the net result being that when the client sends the resume ticket back to the server, the server cannot decrypt it.

This PR adds an unit test to verify the issue. This unit test is disabled by default, will only be reinstated when the picotls behanvior is properly understood.

The default ECH grease in picoquicdemo is also disabled. Clients will only send the ECH parameter if an ECH target is explicitly configured.

Manual tests verified that the 0RTT functionality is restored.

Close #1993