### PR TITLE
Remove is_multipath_enabled parameter

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -381,7 +381,6 @@ typedef struct st_picoquic_tp_t {
     int do_grease_quic_bit;
     picoquic_tp_version_negotiation_t version_negotiation;
     int enable_bdp_frame;
-    int is_multipath_enabled;
     uint64_t initial_max_path_id;
     int address_discovery_mode; /* 0=none, 1=provide only, 2=receive only, 3=both */
     int is_reset_stream_at_enabled; /* 1: enabled. 0: not there. (default) */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -925,7 +925,6 @@ void picoquic_set_default_multipath_option(picoquic_quic_t* quic, int multipath_
     quic->default_multipath_option = multipath_option;
 
     if (multipath_option & 1) {
-        /* quic->default_tp.is_multipath_enabled = 1;*/
         quic->default_tp.initial_max_path_id = 2;
     }
 }

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -286,8 +286,8 @@ int picoquic_negotiate_multipath_option(picoquic_cnx_t* cnx)
 
     cnx->is_multipath_enabled = 0;
 
-    if (cnx->remote_parameters.is_multipath_enabled &&
-        cnx->local_parameters.is_multipath_enabled) {
+    if (cnx->remote_parameters.initial_max_path_id > 0 &&
+        cnx->local_parameters.initial_max_path_id > 0) {
         /* Enable the multipath option */
         cnx->is_multipath_enabled = 1;
         cnx->max_path_id_acknowledged = cnx->local_parameters.initial_max_path_id;
@@ -296,7 +296,7 @@ int picoquic_negotiate_multipath_option(picoquic_cnx_t* cnx)
     }
     else {
         if (!cnx->client_mode) {
-            cnx->local_parameters.is_multipath_enabled = 0;
+            cnx->local_parameters.initial_max_path_id = 0;
         } 
     }
 
@@ -454,7 +454,7 @@ int picoquic_prepare_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
             (uint64_t)cnx->local_parameters.enable_bdp_frame);
     }
 
-    if (cnx->local_parameters.is_multipath_enabled > 0 && bytes != NULL){
+    if (cnx->local_parameters.initial_max_path_id > 0 && bytes != NULL){
         bytes = picoquic_transport_param_type_varint_encode(bytes, bytes_max, 
             picoquic_tp_initial_max_path_id,
             (uint64_t)cnx->local_parameters.initial_max_path_id);
@@ -772,7 +772,6 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     }
                     break;
                 case picoquic_tp_initial_max_path_id: {
-                    cnx->remote_parameters.is_multipath_enabled = 1;
                     cnx->remote_parameters.initial_max_path_id = 
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                     break;

--- a/picoquictest/memlog_test.c
+++ b/picoquictest/memlog_test.c
@@ -78,9 +78,9 @@ int memlog_test_one(int is_multipath, char const * memlog_file_name, int expect_
 
     if (is_multipath) {
         /* Add negotiation of multipath option */
-        test_ctx->qserver->default_tp.is_multipath_enabled = 1;
-        test_ctx->qclient->default_tp.is_multipath_enabled = 1;
-        test_ctx->cnx_client->local_parameters.is_multipath_enabled = 1;
+        test_ctx->qserver->default_tp.initial_max_path_id = 1;
+        test_ctx->qclient->default_tp.initial_max_path_id = 1;
+        test_ctx->cnx_client->local_parameters.initial_max_path_id = 1;
     }
 
     if (ret == 0) {

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -384,7 +384,6 @@ void multipath_init_params(picoquic_tp_t *test_parameters, int enable_time_stamp
     memset(test_parameters, 0, sizeof(picoquic_tp_t));
 
     picoquic_init_transport_parameters(test_parameters, 1);
-    test_parameters->is_multipath_enabled = 1;
     test_parameters->initial_max_path_id = 2;
     test_parameters->enable_time_stamp = 3;
 }
@@ -891,7 +890,6 @@ int multipath_test_one(uint64_t max_completion_microsec, multipath_test_enum_t t
         picoquic_set_default_tp(test_ctx->qserver, &server_parameters);
         test_ctx->cnx_client->local_parameters.enable_time_stamp = 3;
 
-        test_ctx->cnx_client->local_parameters.is_multipath_enabled = 1; 
         test_ctx->cnx_client->local_parameters.initial_max_path_id = 3;
     }
 

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4265,7 +4265,6 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
                 /* Set the multipath option at both client and server */
                 multipath_init_params(&server_parameters, 0);
                 picoquic_set_default_tp(test_ctx->qserver, &server_parameters);
-                test_ctx->cnx_client->local_parameters.is_multipath_enabled = 1;
                 test_ctx->cnx_client->local_parameters.initial_max_path_id = 3;
                 test_ctx->cnx_client->local_parameters.enable_time_stamp = 0;
             }

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -74,42 +74,42 @@
 
 static picoquic_tp_t transport_param_test1 = {
     65535, 0, 0, 0x400000, 16384, 16384, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT,
-    PICOQUIC_NB_PATH_TARGET, 3, 0,  TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 3, 0
+    PICOQUIC_NB_PATH_TARGET, 3, 0,  TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 3, 0
 };
 
 static picoquic_tp_t transport_param_test2 = {
     0x1000000, 0, 0, 0x1000000, 1, 0, 255, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0, 
-    TRANSPORT_PREFERED_ADDRESS_NULL, 1480, 2, 3, 0, 1, { 0 }, 0, 0, 0, 0, 1
+    TRANSPORT_PREFERED_ADDRESS_NULL, 1480, 2, 3, 0, 1, { 0 }, 0, 0, 0, 1
 };
 
 static picoquic_tp_t transport_param_test3 = {
     0x1000000, 0, 0, 0x1000000, 1, 0, 255, 0, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0, 
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 3, 0x3e8, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 3, 0x3e8, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test4 = {
     65535, 0, 0, 0x400000, 16384, 0, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0,
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test5 = {
     0x1000000, 0, 0, 0x1000000, 2, 0, 255, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0, 
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test6 = {
     0x10000, 0, 0, 0xffffffff, 0, 0, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0,
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 1, 4, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 4, 0, 0
 };
 
 static picoquic_tp_t transport_param_test7 = {
     8192, 0, 0, 16384, 2, 0, 10, 1472, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 17, 0, 
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test8 = {
     65535, 0, 0, 0x400000, 0, 0, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 0, 
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test9 = {
@@ -117,17 +117,17 @@ static picoquic_tp_t transport_param_test9 = {
     { 1, { 10, 0, 0, 1}, 4433, { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0,
     {{1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },4},
         { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 }},
-        0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+        0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test10 = {
     65535, 0, 0, 0x400000, 16384, 16384, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT, 0, 3, 1,
-    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0, 0
+    TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 0, { 0 }, 0, 0, 0, 0
 };
 
 static picoquic_tp_t transport_param_test11 = {
     65535, 0, 0, 0x400000, 16384, 16384, 30, 1480, PICOQUIC_ACK_DELAY_MAX_DEFAULT,
-    PICOQUIC_NB_PATH_TARGET, 3, 0,  TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 1, { 0 }, 0, 0, 0, 0, 0
+    PICOQUIC_NB_PATH_TARGET, 3, 0,  TRANSPORT_PREFERED_ADDRESS_NULL, 0, 0, 0, 0, 1, { 0 }, 0, 0, 0, 0
 };
 
 #define LOCAL_CONNECTION_ID  2, 3, 4, 5, 6, 7, 8, 9
@@ -488,11 +488,6 @@ static int transport_param_compare(picoquic_tp_t* param, picoquic_tp_t* ref) {
     else if (param->enable_bdp_frame != ref->enable_bdp_frame) {
         DBG_PRINTF("enable_bdp_frame: got %d, expected %d\n",
             param->enable_bdp_frame, ref->enable_bdp_frame);
-        ret = -1;
-    }
-    else if (param->is_multipath_enabled != ref->is_multipath_enabled) {
-        DBG_PRINTF("is_multipath_enabled: got %d, expected %d\n",
-            param->is_multipath_enabled, ref->is_multipath_enabled);
         ret = -1;
     }
     else if (param->initial_max_path_id != ref->initial_max_path_id) {


### PR DESCRIPTION
The previous version of the multipath draft had two separate Transport Parameters: enable multipath, and maximum number of paths. The latest version has just one: maximum path ID, which has to be set to at least 1 to negotiate the multipath option.