### PR TITLE
Fix number of cli parameters in PQbench

### DIFF
--- a/pqbench_app/pqbench.c
+++ b/pqbench_app/pqbench.c
@@ -60,7 +60,7 @@ int main(int argc, char ** argv)
     picoquic_register_all_congestion_control_algorithms();
     picoquic_config_init(&config);
     memcpy(option_string, "S:", 2);
-    ret = picoquic_config_option_letters(option_string + 7, sizeof(option_string) - 7, NULL);
+    ret = picoquic_config_option_letters(option_string + 2, sizeof(option_string) - 2, NULL);
 
     if (ret == 0) {
         /* Get the parameters */

--- a/pqbench_app/pqbench_app.vcxproj
+++ b/pqbench_app/pqbench_app.vcxproj
@@ -70,6 +70,9 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <TargetName>pqbench</TargetName>
+  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>


### PR DESCRIPTION
Error in declaration of command line parameter code prevented parsing parameters like log, congestion control or port number.