### PR TITLE
Remove old ref to C4 as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "c4"]
-	path = c4
-	url = https://github.com/private-octopus/c4


### PR DESCRIPTION
House keeping. We are not in fact using C4 as a submodule, so there is no point in declaring that.