### PR TITLE
Add SETTINGS_ENABLE_WEBTRANSPORT for Chrome compatibility

### DIFF
--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -1106,23 +1106,29 @@ void h3zero_delete_data_stream_state(h3zero_data_stream_state_t * stream_state)
 static uint8_t const h3zero_default_setting_frame_val[] = {
     0, /* Control Stream ID, varint = 0 */
     (uint8_t)h3zero_frame_settings, /* var int frame type ( < 64) */
-    22, /* Length of setting frame content */
+    27, /* Length of setting frame content */
     (uint8_t)h3zero_setting_header_table_size, 0, /* var int type ( < 64), then var int value (0) */
     (uint8_t)h3zero_qpack_blocked_streams, 0, /* var int type ( < 64),  then var int value (0) Control*/
     /* enable_connect_protocol = 0x8 */
     (uint8_t)h3zero_settings_enable_connect_protocol, 1,
     /* datagram support */
     (uint8_t)h3zero_setting_h3_datagram, 1,
-    /* Declare max 1 web transport session */
+    /* Declare max 1 web transport session (draft-14: SETTINGS_WT_MAX_SESSIONS) */
     ((h3zero_settings_webtransport_max_sessions >> 24)&0xff)|0x80,
     (uint8_t)((h3zero_settings_webtransport_max_sessions >> 16)&0xff),
     (uint8_t)((h3zero_settings_webtransport_max_sessions >> 8)&0xff),
     (uint8_t)((h3zero_settings_webtransport_max_sessions)&0xff), 1,
+    /* Old draft: SETTINGS_WEBTRANSPORT_MAX_SESSIONS */
     0xc0, 0x00, 0x00, 0x00,
     ((h3zero_settings_webtransport_max_sessions_old >> 24) & 0xff),
     (uint8_t)((h3zero_settings_webtransport_max_sessions_old >> 16) & 0xff),
     (uint8_t)((h3zero_settings_webtransport_max_sessions_old >> 8) & 0xff),
-    (uint8_t)((h3zero_settings_webtransport_max_sessions_old) & 0xff), 1
+    (uint8_t)((h3zero_settings_webtransport_max_sessions_old) & 0xff), 1,
+    /* Chrome compatibility: SETTINGS_ENABLE_WEBTRANSPORT (0x2b603742) */
+    ((h3zero_settings_enable_webtransport >> 24)&0xff)|0x80,
+    (uint8_t)((h3zero_settings_enable_webtransport >> 16)&0xff),
+    (uint8_t)((h3zero_settings_enable_webtransport >> 8)&0xff),
+    (uint8_t)((h3zero_settings_enable_webtransport)&0xff), 1
 };
 
 uint8_t const * h3zero_default_setting_frame = h3zero_default_setting_frame_val;

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -209,6 +209,8 @@ typedef struct st_h3zero_header_parts_t {
 #define h3zero_setting_h3_datagram 0x33
 #define h3zero_settings_webtransport_max_sessions 0x14e9cd29
 #define h3zero_settings_webtransport_max_sessions_old 0xc671706aull
+/* Chrome compatibility: SETTINGS_ENABLE_WEBTRANSPORT from older draft */
+#define h3zero_settings_enable_webtransport 0x2b603742
 
 typedef struct st_h3zero_settings_t {
     uint64_t webtransport_max_sessions;

--- a/picohttp/h3zero_common.c
+++ b/picohttp/h3zero_common.c
@@ -2009,7 +2009,9 @@ uint8_t* h3zero_settings_encode(uint8_t* bytes, const uint8_t* bytes_max, const 
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_enable_connect_protocol, settings->enable_connect_protocol, 0)) != NULL &&
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_setting_h3_datagram, settings->h3_datagram, 0)) != NULL &&
 				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions, settings->webtransport_max_sessions, 0)) != NULL &&
-				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions_old, settings->webtransport_max_sessions, 0)) != NULL) {
+				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_webtransport_max_sessions_old, settings->webtransport_max_sessions, 0)) != NULL &&
+				/* Chrome compatibility: also send SETTINGS_ENABLE_WEBTRANSPORT (0x2b603742) */
+				(bytes = h3zero_settings_component_encode(bytes, bytes_max, h3zero_settings_enable_webtransport, (settings->webtransport_max_sessions > 0) ? 1 : 0, 0)) != NULL) {
 				size_t actual_length = bytes - bytes_after_length;
 				uint8_t* bytes_final_length = picoquic_frames_varint_encode(bytes_of_length, bytes_after_length, actual_length);
 				if (bytes_final_length == NULL) {
@@ -2051,6 +2053,12 @@ const uint8_t* h3zero_settings_components_decode(const uint8_t* bytes, const uin
 		case h3zero_settings_webtransport_max_sessions:
 		case h3zero_settings_webtransport_max_sessions_old:
 			settings->webtransport_max_sessions = component_value;
+			break;
+		case h3zero_settings_enable_webtransport:
+			/* Chrome sends SETTINGS_ENABLE_WEBTRANSPORT (0x2b603742) instead of WT_MAX_SESSIONS */
+			if (component_value > 0 && settings->webtransport_max_sessions == 0) {
+				settings->webtransport_max_sessions = 1;
+			}
 			break;
 		default:
 			break;


### PR DESCRIPTION
Chrome's WebTransport implementation requires SETTINGS_ENABLE_WEBTRANSPORT (0x2b603742) from an older draft, in addition to the current draft's SETTINGS_WT_MAX_SESSIONS (0x14e9cd29).

Changes:
- Add h3zero_settings_enable_webtransport constant (0x2b603742)
- Include in default SETTINGS frame (length increased from 22 to 27 bytes)
- Encode when webtransport_max_sessions > 0
- Decode and set webtransport_max_sessions = 1 if received

Without this, Chrome returns ERR_METHOD_NOT_SUPPORTED when attempting WebTransport CONNECT requests.