### PR TITLE
Update call to `c4_exit_initial` to use congestion notification enum

### DIFF
--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -1072,7 +1072,7 @@ void c4_notify(
                         && c4_state->nb_eras_no_increase > 1
                         && c4_state->push_rate_old >= c4_state->nominal_rate) {
 
-                        c4_exit_initial(path_x, c4_state, c4_congestion_ecn, current_time);
+                        c4_exit_initial(path_x, c4_state, picoquic_congestion_notification_ecn_ec, current_time);
                     }
                 }
                 else {


### PR DESCRIPTION
Get a compiler warning. I think `c4_congestion_t` and `picoquic_congestion_notification_t` type is mixed up here.

`/Users/matthias/Developer/picoquic/picoquic/c4.c:1075:59: warning: implicit conversion from enumeration type 'c4_congestion_t' to different enumeration type 'picoquic_congestion_notification_t' [-Wenum-conversion]
 1075 |                         c4_exit_initial(path_x, c4_state, c4_congestion_ecn, current_time);
      |                         ~~~~~~~~~~~~~~~                   ^~~~~~~~~~~~~~~~~`