### PR TITLE
Do not let qlog crash on retry!

### DIFF
--- a/loglib/qlog_fns.c
+++ b/loglib/qlog_fns.c
@@ -988,6 +988,7 @@ void qlog_fns_close_connection(picoquic_cnx_t* cnx)
         path_ctx = next;
     }
     free(ctx);
+    cnx->qlog_ctx = NULL;
 }
 
 /* close resource allocated for logging in QUIC context */


### PR DESCRIPTION
Reset qlog context to NULL after closing connection, so that when the connection is retried a clean context is allocated.