### PR TITLE
Improve qlog testing

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1865,6 +1865,14 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+
+        TEST_METHOD(qlog_trace_parallel)
+        {
+            int ret = qlog_trace_parallel_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(qlog_fns)
         {
             int ret = qlog_fns_test();

--- a/picoquic/config.c
+++ b/picoquic/config.c
@@ -30,6 +30,7 @@
 #include "picoquic.h"
 #include "picoquic_utils.h"
 #include "picoquic_binlog.h"
+#include "picoquic_qlog.h"
 #include "picoquic_logger.h"
 #include "picoquic_unified_log.h"
 #include "tls_api.h"
@@ -887,15 +888,17 @@ picoquic_quic_t* picoquic_create_and_configure(picoquic_quic_config_t* config,
          /* TODO: parameters to define padding policy */
         picoquic_set_padding_policy(quic, 39, 128);
 
-        picoquic_set_binlog(quic, config->bin_dir);
+        if (config->bin_dir != NULL) {
+            picoquic_set_binlog(quic, config->bin_dir);
+        }
 
-        /* We cannot set qlog here, because of the dependency on libraries
-         * that are not linked with picoquic by default. The application
-         * will have to call:
-         *    picoquic_set_qlog(quic, config->qlog_dir);
-         */
+        if (config->qlog_dir != NULL) {
+            picoquic_set_qlog(quic, config->qlog_dir);
+        }
 
-        picoquic_set_textlog(quic, config->log_file);
+        if (config->log_file != NULL) {
+            picoquic_set_textlog(quic, config->log_file);
+        }
 
         picoquic_set_log_level(quic, config->use_long_log);
 

--- a/picoquic/picoquic_qlog.h
+++ b/picoquic/picoquic_qlog.h
@@ -1,0 +1,37 @@
+/*
+* Author: Christian Huitema
+* Copyright (c) 2020, Private Octopus, Inc.
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL Private Octopus, Inc. BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+* ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_QLOG_FNS_H
+#define PICOQUIC_QLOG_FNS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "picoquic.h"
+    /* Set the qlog directory and start streaming qlog traces for
+    * each connection.
+    */
+    int picoquic_set_qlog(picoquic_quic_t* quic, char const* qlog_dir);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* PICOQUIC_QLOG_FNS_H */

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -309,6 +309,7 @@ static const picoquic_test_def_t test_table[] = {
     { "qlog_error", qlog_error_test },
     { "qlog_trace", qlog_trace_test },
     { "qlog_trace_ecn", qlog_trace_ecn_test },
+    { "qlog_trace_parallel", qlog_trace_parallel_test },
     { "qlog_fns", qlog_fns_test },
     { "qlog_fns_ecn", qlog_fns_ecn_test },
     { "perflog", perflog_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -245,6 +245,7 @@ int qlog_auto_test();
 int qlog_error_test();
 int qlog_trace_test();
 int qlog_trace_ecn_test();
+int qlog_trace_parallel_test();
 int qlog_fns_test();
 int qlog_fns_ecn_test();
 int perflog_test();

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4006,6 +4006,7 @@ int tls_api_retry_test_one(int large_client_hello)
         if (large_client_hello) {
             test_ctx->cnx_client->test_large_chello = 1;
         }
+        picoquic_set_qlog(test_ctx->qclient, ".");
         ret = picoquic_start_client_cnx(test_ctx->cnx_client);
     }
 
@@ -8952,7 +8953,7 @@ void qlog_trace_cid_fn(picoquic_quic_t* quic, picoquic_connection_id_t cnx_id_lo
     }
 }
 
-int qlog_trace_test_one(uint8_t recv_ecn)
+int qlog_trace_test_one(uint8_t recv_ecn, int parallel)
 {
     uint64_t simulated_time = 0;
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
@@ -8975,6 +8976,9 @@ int qlog_trace_test_one(uint8_t recv_ecn)
     if (ret == 0) {
         test_ctx->recv_ecn_client = recv_ecn;
         test_ctx->recv_ecn_server = recv_ecn;
+        if (parallel) {
+            picoquic_set_binlog(test_ctx->qserver, ".");
+        }
         picoquic_set_qlog(test_ctx->qserver, ".");
         (void)picoquic_set_default_spinbit_policy(test_ctx->qserver, picoquic_spinbit_on);
         (void)picoquic_set_default_spinbit_policy(test_ctx->qclient, picoquic_spinbit_on);
@@ -9047,13 +9051,19 @@ int qlog_trace_test_one(uint8_t recv_ecn)
 
 int qlog_trace_test()
 {
-    return qlog_trace_test_one(0);
+    return qlog_trace_test_one(0, 0);
 }
 
 int qlog_trace_ecn_test()
 {
-    return qlog_trace_test_one(0x02);
+    return qlog_trace_test_one(0x02, 0);
 }
+
+int qlog_trace_parallel_test()
+{
+    return qlog_trace_test_one(0, 1);
+}
+
 
 #define QLOG_FNS_QLOG "0102030405060708.server.qlog"
 


### PR DESCRIPTION
Improve the setting and testing of qlog:

- Add a "qlog_parallel" test to verify that the results of qlog are unchanged if a binlog generated in parallel.
- Add qlog tracing to the "retry" test to implicitly verify that qlog are generated through retry.
- Modify config to only start binlog, qlog or textlog if explicitly required.

The tests would have detected issue #2055 and issue #2059 before merging the code.
The changes in configuration ensure that the configuration does not "force" usage of textlog or binlog.