### PR TITLE
test what happens without ssldev.

### DIFF
--- a/.github/workflows/ci-tests-no-openssl.yml
+++ b/.github/workflows/ci-tests-no-openssl.yml
@@ -25,11 +25,11 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           submodules: 'recursive'
-            
+
       - name: Building picoquic
         run: |
           sudo apt-get install clangd
-          sudo apt-get remove openssl
+          sudo apt-get install -y libssl-dev
           echo $CC
           echo $CXX
           # $CC --version

--- a/.github/workflows/ci-tests-no-openssl.yml
+++ b/.github/workflows/ci-tests-no-openssl.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Building picoquic
         run: |
           sudo apt-get install clangd
-          sudo apt-get install -y libssl-dev
+          # sudo apt-get install -y libssl-dev
           echo $CC
           echo $CXX
           # $CC --version

--- a/.github/workflows/ci-tests-no-openssl.yml
+++ b/.github/workflows/ci-tests-no-openssl.yml
@@ -25,11 +25,11 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           submodules: 'recursive'
-
+            
       - name: Building picoquic
         run: |
           sudo apt-get install clangd
-          # sudo apt-get install -y libssl-dev
+          sudo apt-get remove openssl
           echo $CC
           echo $CXX
           # $CC --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,8 @@ set(PICOHTTP_TEST_LIBRARY_FILES
     picoquictest/quicperf_test.c
     picoquictest/webtransport_test.c)
 
+OPTION(WITH_OPENSSL "build with OpenSSL" ON)
+
 OPTION(PICOQUIC_FETCH_PTLS "Fetch PicoTLS during configuration" OFF)
 if(PICOQUIC_FETCH_PTLS)
     include(FetchContent)
@@ -295,8 +297,6 @@ else()
     message(STATUS "PTLS compiled without support for Fusion")
     list(APPEND PICOQUIC_COMPILE_DEFINITIONS PTLS_WITHOUT_FUSION)
 endif()
-
-OPTION(WITH_OPENSSL "build with OpenSSL" ON)
 
 if(WITH_OPENSSL)
     find_package(OpenSSL REQUIRED)

--- a/cmake/FindPTLS.cmake
+++ b/cmake/FindPTLS.cmake
@@ -15,7 +15,7 @@ if (PICOQUIC_FETCH_PTLS)
             set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
             set(PTLS_WITH_FUSION_DEFAULT OFF)
         endif()
-    else()
+    elseif(WITH_OPENSSL)
         set(PTLS_OPENSSL_LIBRARY picotls-openssl)
         if(WITH_FUSION)
             set(PTLS_FUSION_LIBRARY picotls-fusion)
@@ -26,11 +26,21 @@ if (PICOQUIC_FETCH_PTLS)
             set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_OPENSSL_LIBRARY}  ${PTLS_MINICRYPTO_LIBRARY})
             unset(PTLS_FUSION_LIBRARY)
         endif()
+    else()
+        if(WITH_FUSION)
+            set(PTLS_FUSION_LIBRARY picotls-fusion)
+            set(PTLS_WITH_FUSION_DEFAULT ON)
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+        else()
+            set(PTLS_WITH_FUSION_DEFAULT OFF)
+            set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY}  ${PTLS_MINICRYPTO_LIBRARY})
+            unset(PTLS_FUSION_LIBRARY)
+        endif()
     endif()
     set(PTLS_INCLUDE_DIRS ${picotls_SOURCE_DIR}/include)
 else(PICOQUIC_FETCH_PTLS)
     find_path(PTLS_INCLUDE_DIR
-        NAMES picotls/openssl.h
+        NAMES picotls/minicrypto.h
         HINTS ${PTLS_PREFIX}/include/picotls
             ${CMAKE_SOURCE_DIR}/../picotls/include
             ${CMAKE_BINARY_DIR}/../picotls/include
@@ -52,7 +62,7 @@ else(PICOQUIC_FETCH_PTLS)
             set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
             set(PTLS_WITH_FUSION_DEFAULT OFF)
         endif()
-    else()
+    elseif(WITH_OPENSSL)
         find_library(PTLS_OPENSSL_LIBRARY picotls-openssl HINTS ${PTLS_HINTS})
         find_library(PTLS_FUSION_LIBRARY picotls-fusion HINTS ${PTLS_HINTS})
 
@@ -89,6 +99,42 @@ else(PICOQUIC_FETCH_PTLS)
                 set(PTLS_WITH_FUSION_DEFAULT ON)
             endif()
         endif()
+    else()
+        MESSAGE(STATUS "Finding PTLS with no OpenSSL")
+        find_library(PTLS_FUSION_LIBRARY picotls-fusion HINTS ${PTLS_HINTS})
+
+        if(NOT PTLS_FUSION_LIBRARY)
+            include(FindPackageHandleStandardArgs)
+            # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+            # if all listed variables are TRUE
+
+            find_package_handle_standard_args(PTLS REQUIRED_VARS
+                PTLS_CORE_LIBRARY
+                PTLS_MINICRYPTO_LIBRARY
+                PTLS_INCLUDE_DIR)
+
+            if(PTLS_FOUND)
+                set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+                set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+                set(PTLS_WITH_FUSION_DEFAULT OFF)
+            endif()
+        else()
+            include(FindPackageHandleStandardArgs)
+            # handle the QUIETLY and REQUIRED arguments and set PTLS_FOUND to TRUE
+            # if all listed variables are TRUE
+            find_package_handle_standard_args(PTLS REQUIRED_VARS
+                PTLS_CORE_LIBRARY
+                PTLS_FUSION_LIBRARY
+                PTLS_MINICRYPTO_LIBRARY
+                PTLS_INCLUDE_DIR)
+
+            if(PTLS_FOUND)
+                set(PTLS_LIBRARIES ${PTLS_CORE_LIBRARY} ${PTLS_FUSION_LIBRARY} ${PTLS_MINICRYPTO_LIBRARY})
+                set(PTLS_INCLUDE_DIRS ${PTLS_INCLUDE_DIR})
+                set(PTLS_WITH_FUSION_DEFAULT ON)
+            endif()
+        endif()
+        
     endif()
 endif(PICOQUIC_FETCH_PTLS)
 

--- a/picohttp/webtransport.c
+++ b/picohttp/webtransport.c
@@ -310,7 +310,7 @@ int picowt_select_wt_protocol(h3zero_stream_ctx_t* stream_ctx, char const* suppo
                 else {
                     if ((os + candidate_length == s_len ||
                         supported[os + candidate_length] == ' ' ||
-                        supported[os + candidate_length] == '\t ' ||
+                        supported[os + candidate_length] == '\t' ||
                         supported[os + candidate_length] == ',') &&
                         memcmp(&supported[os], candidate, candidate_length) == 0) {
                         /* found it. set the value. */


### PR DESCRIPTION
Update the PTLS finder (cmake/FindPTLS.cmake) so that it does not add openssl references if PicoQUIC is build with OpenSSL=OFF.

Close #2076