### PR TITLE
Fix WebTransport header handling for browser compatibility

### DIFF
--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -34,6 +34,12 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+#ifdef _WINDOWS
+#define picoquic_strncasecmp _strnicmp
+#else
+#include <strings.h>
+#define picoquic_strncasecmp strncasecmp
+#endif
 #include "h3zero.h"
 
 /*
@@ -553,7 +559,7 @@ int h3zero_get_interesting_header_type(uint8_t * name, size_t name_length, int i
 
     for (int i = 0; interesting_header_name[i] != NULL; i++) {
         if (strlen(interesting_header_name[i]) == name_length &&
-            memcmp(interesting_header_name[i], name, name_length) == 0) {
+            picoquic_strncasecmp(interesting_header_name[i], (const char*)name, name_length) == 0) {
             val = interesting_header[i];
             break;
         }

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -50,8 +50,8 @@ extern "C" {
 #define H3ZERO_WEBTRANSPORT_APPLICATION_ERROR(code) (0x52e4a40fa8dbull + code) /* see spec for skipping grease points when mapping codes */
 #define H3ZERO_USER_AGENT_STRING "H3Zero/1.0"
 
-#define H3ZERO_WT_AVAILABLE_PROTOCOLS "WT-Available-Protocols"
-#define H3ZERO_WT_PROTOCOL "WT-Protocol"
+#define H3ZERO_WT_AVAILABLE_PROTOCOLS "wt-available-protocols"
+#define H3ZERO_WT_PROTOCOL "wt-protocol"
 
 #define H3ZERO_CAPSULE_CLOSE_WEBTRANSPORT_SESSION 0x2843
 #define H3ZERO_CAPSULE_DRAIN_WEBTRANSPORT_SESSION 0x78ae

--- a/picohttp/webtransport.c
+++ b/picohttp/webtransport.c
@@ -286,9 +286,12 @@ int picowt_select_wt_protocol(h3zero_stream_ctx_t* stream_ctx, char const* suppo
             a++;
         }
         while (*a != ',' && *a != 0 && *a != ' ' && *a != '\t' && candidate_length < 254) {
-            candidate[candidate_length] = *a;
+            /* Skip quotes - HTTP structured fields use quoted strings */
+            if (*a != '"') {
+                candidate[candidate_length] = *a;
+                candidate_length++;
+            }
             a++;
-            candidate_length++;
         }
         while (*a == ' ' || *a == '\t') {
             a++;


### PR DESCRIPTION
Three fixes for WebTransport over HTTP/3:

1. Use lowercase header names (RFC 9114 compliance)
   
2. Case-insensitive header matching when parsing
   
3. Strip quotes from wt-available-protocols values
   - HTTP Structured Fields (RFC 8941) encode strings with quotes
   - Browsers send: "moqt-16", "moqt-15" (quoted per RFC 8941)
   - Protocol matching now strips quotes before comparison

These fixes enable interoperability with browser WebTransport clients (Chrome, Firefox) that follow the HTTP/3 and Structured Fields specs.