### PR TITLE
Fix WT-Protocol header: quote response value, fix length field, add test

### DIFF
--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -31,6 +31,7 @@
  * The server will start the connection by sending a setting frame, which will
  * specify a zero-length dynamic dictionary for QPACK.
  */
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -517,7 +518,16 @@ uint8_t * h3zero_parse_qpack_header_value(uint8_t * bytes, uint8_t * bytes_max,
                 }
                 else {
                     bytes = h3zero_parse_qpack_header_value_string(bytes, decoded,
-                        decoded_length, &parts->wt_protocol, &parts->wt_available_protocols_length);
+                        decoded_length, &parts->wt_protocol, &parts->wt_protocol_length);
+                    /* WT-Protocol is a Structured Header String — strip surrounding quotes */
+                    if (parts->wt_protocol != NULL && parts->wt_protocol_length >= 2 &&
+                        parts->wt_protocol[0] == '"' &&
+                        parts->wt_protocol[parts->wt_protocol_length - 1] == '"') {
+                        uint8_t* p = (uint8_t*)parts->wt_protocol;
+                        parts->wt_protocol_length -= 2;
+                        memmove(p, p + 1, parts->wt_protocol_length);
+                        p[parts->wt_protocol_length] = 0;
+                    }
                 }
                 break;
 
@@ -998,9 +1008,12 @@ uint8_t * h3zero_create_response_header_frame_ex(uint8_t * bytes, uint8_t * byte
     }
 
     if (wt_protocol != NULL) {
+        /* WT-Protocol is a Structured Header String and must be quoted per spec */
+        char quoted[258];
+        int quoted_len = snprintf(quoted, sizeof(quoted), "\"%s\"", wt_protocol);
         bytes = h3zero_qpack_literal_plus_name_encode(bytes, bytes_max,
             (uint8_t*)H3ZERO_WT_PROTOCOL, strlen(H3ZERO_WT_PROTOCOL),
-            (uint8_t*)wt_protocol, strlen(wt_protocol));
+            (uint8_t*)quoted, (size_t)quoted_len);
     }
 
     return bytes;

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -57,6 +57,7 @@ static const picoquic_test_def_t test_table[] = {
     { "h3zero_parse_qpack", h3zero_parse_qpack_test },
     { "h3zero_prepare_qpack", h3zero_prepare_qpack_test },
     { "h3zero_user_agent", h3zero_user_agent_test },
+    { "h3zero_wt_protocol_response", h3zero_wt_protocol_response_test },
     { "h3zero_uri", h3zero_uri_test },
     { "h3zero_url_template", h3zero_url_template_test },
     { "h3zero_null_sni", h3zero_null_sni_test },

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -4370,3 +4370,42 @@ int demo_error_test(void)
 
     return ret;
 }
+/* Test that h3zero_create_response_header_frame_ex quotes the WT-Protocol
+ * value as a Structured Header String on the wire (e.g., WT-Protocol: "moqt-16"),
+ * and that the parser correctly strips the quotes so callers see the bare protocol name.
+ */
+int h3zero_wt_protocol_response_test(void)
+{
+    int ret = 0;
+    uint8_t buffer[256];
+    uint8_t* bytes_max = buffer + sizeof(buffer);
+    uint8_t* bytes;
+    h3zero_header_parts_t parts = { 0 };
+    char const* wt_protocol = "moqt-16";
+    size_t expected_len = strlen(wt_protocol);
+
+    /* Encode a 200 response with wt_protocol set */
+    bytes = h3zero_create_response_header_frame_ex(buffer, bytes_max,
+        h3zero_content_type_none, NULL, wt_protocol);
+    if (bytes == NULL) {
+        DBG_PRINTF("%s", "h3zero_create_response_header_frame_ex returned NULL");
+        return -1;
+    }
+
+    /* Decode and verify the parser strips quotes, yielding the bare protocol name */
+    if (h3zero_parse_qpack_header_frame(buffer, bytes, &parts) == NULL) {
+        DBG_PRINTF("%s", "Failed to parse response header frame");
+        ret = -1;
+    } else if (parts.wt_protocol == NULL) {
+        DBG_PRINTF("%s", "wt_protocol not found in parsed header");
+        ret = -1;
+    } else if (parts.wt_protocol_length != expected_len ||
+               memcmp(parts.wt_protocol, wt_protocol, expected_len) != 0) {
+        DBG_PRINTF("wt_protocol value wrong: got \"%.*s\", expected \"%s\"",
+            (int)parts.wt_protocol_length, parts.wt_protocol, wt_protocol);
+        ret = -1;
+    }
+
+    h3zero_release_header_parts(&parts);
+    return ret;
+}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -357,6 +357,7 @@ int h3zero_stream_fuzz_test(void);
 int parse_demo_scenario_test(void);
 int h3zero_server_test(void);
 int h3zero_migration_disabled_test(void);
+int h3zero_wt_protocol_response_test(void);
 int h09_server_test(void);
 int h09_header_test(void);
 int generic_server_test(void);


### PR DESCRIPTION
Three bugs fixed in WebTransport protocol negotiation:

1. h3zero_create_response_header_frame_ex sent WT-Protocol as a bare token (e.g. moqt-16) instead of a Structured Header String (e.g. "moqt-16") as required by the WebTransport spec.

2. The wt_protocol case in h3zero_parse_qpack_header_block wrote the parsed length into wt_available_protocols_length instead of wt_protocol_length, leaving wt_protocol_length always zero.

3. The parser now strips the surrounding quotes from the WT-Protocol response header value so callers receive the bare protocol name.

Add h3zero_wt_protocol_response_test to verify encode/decode round-trip produces the correct unquoted protocol name.