### PR TITLE
Fix build failures under FreeBSD

### DIFF
--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -92,7 +92,7 @@
 #endif
 #endif
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
 #ifdef __LINUX__
 #include <linux/prctl.h>  /* Definition of PR_* constants */
 #else
@@ -1735,6 +1735,8 @@ void picoquic_internal_thread_setname(char const * thread_name)
 #else
 #ifdef __APPLE__
     pthread_setname_np(thread_name);
+#elif defined(__FreeBSD__)
+    pthread_setname_np(pthread_self(), thread_name);
 #else
     int r=prctl(PR_SET_NAME, thread_name, 0, 0, 0);
     if (r != 0) {

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -1733,7 +1733,7 @@ void picoquic_internal_thread_setname(char const * thread_name)
         }
     }
 #else
-#ifdef __APPLE__
+#if defined(__APPLE__)
     pthread_setname_np(thread_name);
 #elif defined(__FreeBSD__)
     pthread_setname_np(pthread_self(), thread_name);


### PR DESCRIPTION
- FreeBSD, like Apple, doesn't have sys/prctl.h: Follow APPLE logic and don't try to include it
- pthread_setname_np() requires 2 args under FreeBSD: pthread_setname_np(pthread_t thread, const char *name)