### PR TITLE
cmake: export picohttp-core as picoquic::picohttp-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,8 +438,9 @@ if (BUILD_LOGLIB)
         PRIVATE
             ${PTLS_INCLUDE_DIRS}
         PUBLIC
-            picoquic
-            loglib)
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picoquic>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/loglib>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     set_picoquic_compile_settings(picoquic-log)
 endif()
 
@@ -451,6 +452,7 @@ endif()
 
 if (BUILD_HTTP)
     add_library(picohttp-core ${PICOHTTP_LIBRARY_FILES})
+    add_library(picoquic::picohttp-core ALIAS picohttp-core)
     target_link_libraries(picohttp-core
         PRIVATE
             ${PTLS_LIBRARIES}
@@ -465,8 +467,9 @@ if (BUILD_HTTP)
             ${OPENSSL_INCLUDE_DIR}
             ${MBEDTLS_INCLUDE_DIRS}
         PUBLIC
-            picoquic
-            picohttp)
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picoquic>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picohttp>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     set_picoquic_compile_settings(picohttp-core)
 endif()
 
@@ -629,7 +632,9 @@ endif()
 
 if (TARGET picohttp-core)
     install(TARGETS picohttp-core
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        EXPORT picoquic-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(FILES
         ${PICOHTTP_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
@@ -642,7 +647,9 @@ endif()
 
 if (TARGET picoquic-log)
     install(TARGETS picoquic-log
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        EXPORT picoquic-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
     install(FILES
         ${PICOQUIC_LOGLIB_HEADERS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,6 +446,7 @@ endif()
 
 if (BUILD_HTTP)
     add_library(picohttp-core ${PICOHTTP_LIBRARY_FILES})
+    add_library(picoquic::picohttp-core ALIAS picohttp-core)
     target_link_libraries(picohttp-core
         PRIVATE
             ${PTLS_LIBRARIES}
@@ -459,7 +460,9 @@ if (BUILD_HTTP)
             ${OPENSSL_INCLUDE_DIR}
             ${MBEDTLS_INCLUDE_DIRS}
         PUBLIC
-            picoquic)
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picoquic>
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picohttp>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     set_picoquic_compile_settings(picohttp-core)
 endif()
 
@@ -606,7 +609,9 @@ endif()
 
 if (TARGET picohttp-core)
     install(TARGETS picohttp-core
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        EXPORT picoquic-targets
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
     install(FILES
         ${PICOHTTP_HEADERS}
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/ci/embedding-test/install_test/CMakeLists.txt
+++ b/ci/embedding-test/install_test/CMakeLists.txt
@@ -3,7 +3,13 @@ project(install_test LANGUAGES C)
 
 # Validate that an installed picoquic exports INTERFACE_INCLUDE_DIRECTORIES so
 # that consumers can #include <picoquic.h> without manually specifying the path.
+# Also validates that picohttp-core is exported as picoquic::picohttp-core.
 find_package(picoquic REQUIRED)
 
 add_executable(install_test main.c)
 target_link_libraries(install_test PRIVATE picoquic::picoquic-core)
+
+if(TARGET picoquic::picohttp-core)
+    add_executable(install_test_http main_http.c)
+    target_link_libraries(install_test_http PRIVATE picoquic::picohttp-core)
+endif()

--- a/ci/embedding-test/install_test/main_http.c
+++ b/ci/embedding-test/install_test/main_http.c
@@ -1,0 +1,8 @@
+#include <h3zero.h>
+#include <stdio.h>
+
+int main(void)
+{
+    printf("picohttp-core available\n");
+    return 0;
+}

--- a/ci/embedding-test/run.sh
+++ b/ci/embedding-test/run.sh
@@ -42,6 +42,9 @@ cmake -S "$SCRIPT_DIR/install_test" -B "$BUILD_DIR/install_test" \
     -DCMAKE_BUILD_TYPE=Release
 cmake --build "$BUILD_DIR/install_test"
 "$BUILD_DIR/install_test/install_test"
+if [ -f "$BUILD_DIR/install_test/install_test_http" ]; then
+    "$BUILD_DIR/install_test/install_test_http"
+fi
 
 # --- FetchContent re-export test ---
 # Validates that a library embedding picoquic via FetchContent correctly

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -21,6 +21,9 @@
 #ifndef H3ZERO_H
 #define H3ZERO_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
picohttp-core was installed as a static library but never added to the picoquic-targets export set, so find_package(picoquic) provided picoquic::picoquic-core but not picohttp-core. Consumers needing H3/HTTP support had no cmake target to link against.

- h3zero.h: add missing #include <stdint.h> / <stddef.h> so the header is self-contained and can be included without preconditions.

- CMakeLists.txt: 
  - add ALIAS picoquic::picohttp-core so the namespaced target works during FetchContent builds (matching picoquic::picoquic-core).
  - Add EXPORT picoquic-targets + INCLUDES DESTINATION to the install rule so find_package(picoquic) exposes picoquic::picohttp-core. 
  - Fix picohttp-core's INTERFACE_INCLUDE_DIRECTORIES to use BUILD_INTERFACE / INSTALL_INTERFACE so the source path isn't baked into installed targets.

- ci/embedding-test: extend install_test to build against picoquic::picohttp-core, validating the export end-to-end.