### PR TITLE
Add wildcard '*' path matcher for WebTransport CONNECT dispatch

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -3512,6 +3512,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(picowt_baton_wildcard) {
+            int ret = picowt_baton_wildcard_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(picowt_baton_krome) {
             int ret = picowt_baton_krome_test();
 

--- a/picohttp/h3zero_common.c
+++ b/picohttp/h3zero_common.c
@@ -983,18 +983,23 @@ Picoquic POST Response\
 int h3zero_server_parse_path(const uint8_t* path, size_t path_length, uint64_t* echo_size,
 	char** file_path, char const* web_folder, int* file_error);
 
-int h3zero_find_path_item(const uint8_t * path, size_t path_length, const picohttp_server_path_item_t * path_table, size_t path_table_nb)
+int h3zero_find_path_item(const uint8_t* path, size_t path_length, const picohttp_server_path_item_t* path_table, size_t path_table_nb)
 {
-	size_t i = 0;
+    int wildcard_index = -1;
+    size_t i = 0;
 
-	while (i < path_table_nb) {
-		if (path_length >= path_table[i].path_length && memcmp(path, path_table[i].path, path_table[i].path_length) == 0){
-			if (path_length == path_table[i].path_length || path[path_table[i].path_length] == (uint8_t)'?')
-				return (int)i;
-		}
-		i++;
-	}
-	return -1;
+    while (i < path_table_nb) {
+        if (wildcard_index < 0 && path_table[i].path_length == 1 && path_table[i].path[0] == '*') {
+            /* Record wildcard as fallback; keep scanning for a specific match.
+             * Convention: place '*' last in the table for readability. */
+            wildcard_index = (int)i;
+        } else if (path_length >= path_table[i].path_length && memcmp(path, path_table[i].path, path_table[i].path_length) == 0) {
+            if (path_length == path_table[i].path_length || path[path_table[i].path_length] == (uint8_t)'?')
+                return (int)i;
+        }
+        i++;
+    }
+    return wildcard_index;
 }
 
 /* TODO find a better place. */

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -106,6 +106,7 @@ static const picoquic_test_def_t test_table[] = {
     { "picowt_baton_uri", picowt_baton_uri_test },
     { "picowt_baton_wrong", picowt_baton_wrong_test },
     { "picowt_baton_reset", picowt_baton_reset_test },
+    { "picowt_baton_wildcard", picowt_baton_wildcard_test },
     { "picowt_drain", picowt_drain_test },
     { "picowt_tp", picowt_tp_test },
     { "quicperf_parse", quicperf_parse_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -617,6 +617,7 @@ int picowt_baton_wrong_test(void);
 int picowt_baton_uri_test(void);
 int picowt_baton_krome_test(void);
 int picowt_baton_reset_test(void);
+int picowt_baton_wildcard_test(void);
 int picowt_drain_test(void);
 int picowt_tp_test(void);
 int quicperf_parse_test(void);

--- a/picoquictest/webtransport_test.c
+++ b/picoquictest/webtransport_test.c
@@ -91,10 +91,10 @@ static int picowt_baton_test_reset(wt_baton_ctx_t * baton_ctx, int* reset_needed
     return ret;
 }
 
-static int picowt_baton_test_one(
+static int picowt_baton_test_one_ex(
     uint8_t test_id, const char* baton_path,
     uint64_t do_losses, uint64_t completion_target, const char* client_qlog_dir,
-    const char* server_qlog_dir)
+    const char* server_qlog_dir, picohttp_server_path_item_t* table, size_t table_nb)
 {
     char const* alpn = "h3";
     uint64_t simulated_time = 0;
@@ -178,8 +178,8 @@ static int picowt_baton_test_one(
             /* Initialize the server -- should include the path setup for connect action */
             memset(&server_param, 0, sizeof(picohttp_server_parameters_t));
             server_param.web_folder = NULL;
-            server_param.path_table = path_item_list;
-            server_param.path_table_nb = 1;
+            server_param.path_table = table;
+            server_param.path_table_nb = table_nb;
 
             picoquic_set_alpn_select_fn_v2(test_ctx->qserver, picoquic_demo_server_callback_select_alpn);
             picoquic_set_default_callback(test_ctx->qserver, h3zero_callback, &server_param);
@@ -281,6 +281,15 @@ static int picowt_baton_test_one(
     return ret;
 }
 
+static int picowt_baton_test_one(
+    uint8_t test_id, const char* baton_path,
+    uint64_t do_losses, uint64_t completion_target, const char* client_qlog_dir,
+    const char* server_qlog_dir)
+{
+    return picowt_baton_test_one_ex(test_id, baton_path, do_losses, completion_target,
+        client_qlog_dir, server_qlog_dir, path_item_list, 1);
+}
+
 int picowt_baton_basic_test(void)
 {
     int ret = picowt_baton_test_one(1, "/baton?baton=240", 0, 2000000, ".", ".");
@@ -342,6 +351,16 @@ int picowt_baton_reset_test(void)
     int ret = picowt_baton_test_one(9, "/baton?count=8", 0, 5000000, ".", ".");
 
     return ret;
+}
+
+int picowt_baton_wildcard_test(void)
+{
+    picohttp_server_path_item_t wildcard_table[1] = {
+        { "*", 1, wt_baton_callback, NULL }
+    };
+    /* /baton is not a specific entry in wildcard_table; the '*' handler must catch it */
+    return picowt_baton_test_one_ex(1, "/baton?baton=240", 0, 2000000, ".", ".",
+        wildcard_table, 1);
 }
 
 int picowt_tp_test(void)


### PR DESCRIPTION
Register a path entry with path "*" and path_length 1 to catch any incoming WT CONNECT that has no specific path match. Specific paths still take priority; the wildcard is recorded as a fallback during the scan and returned only when no exact prefix match is found.

Comparing only on paths discards the possibility that multiple :authority's could share the same picoquic, with different webtransport paths.  Also, applications may want to do different types of matching besides exact matching.