### PR TITLE
Expose authority in WebTransport requests

### DIFF
--- a/picohttp/h3zero.c
+++ b/picohttp/h3zero.c
@@ -478,6 +478,16 @@ uint8_t * h3zero_parse_qpack_header_value(uint8_t * bytes, uint8_t * bytes_max,
                         decoded_length, &parts->path, &parts->path_length);
                 }
                 break;
+            case http_pseudo_header_authority:
+                if (parts->authority != NULL) {
+                    /* Duplicate authority! */
+                    bytes = 0;
+                }
+                else {
+                    bytes = h3zero_parse_qpack_header_value_string(bytes, decoded,
+                        decoded_length, &parts->authority, &parts->authority_length);
+                }
+                break;
             case http_header_range:
                 if (parts->range != NULL) {
                     /* Duplicate content type! */
@@ -537,11 +547,12 @@ uint8_t * h3zero_parse_qpack_header_value(uint8_t * bytes, uint8_t * bytes_max,
 int h3zero_get_interesting_header_type(uint8_t * name, size_t name_length, int is_huffman)
 {
     char const  * interesting_header_name[] = {
-     ":method", ":path", ":status", "content-type", ":protocol", "origin", "range",
+     ":method", ":path", ":authority", ":status", "content-type", ":protocol", "origin", "range",
      H3ZERO_WT_AVAILABLE_PROTOCOLS, H3ZERO_WT_PROTOCOL,
      NULL};
     const http_header_enum_t interesting_header[] = {
         http_pseudo_header_method, http_pseudo_header_path,
+        http_pseudo_header_authority,
         http_pseudo_header_status, http_header_content_type,
         http_pseudo_header_protocol, http_header_origin,
         http_header_range, http_header_wt_available_protocols, http_header_wt_protocol
@@ -1112,6 +1123,11 @@ void h3zero_release_header_parts(h3zero_header_parts_t* header)
         free((uint8_t*)header->path);
         *((uint8_t**)&header->path) = NULL;
         header->path_length = 0;
+    }
+    if (header->authority != NULL) {
+        free((uint8_t*)header->authority);
+        *((uint8_t**)&header->authority) = NULL;
+        header->authority_length = 0;
     }
     if (header->range != NULL) {
         free((uint8_t*)header->range);

--- a/picohttp/h3zero.h
+++ b/picohttp/h3zero.h
@@ -190,6 +190,8 @@ typedef struct st_h3zero_header_parts_t {
     h3zero_method_enum method;
     uint8_t const * path;
     size_t path_length;
+    uint8_t const * authority;
+    size_t authority_length;
     uint8_t const * range;
     size_t range_length;
     int status;

--- a/picohttp/pico_webtransport.h
+++ b/picohttp/pico_webtransport.h
@@ -116,6 +116,12 @@ extern "C" {
      */
     int picowt_select_wt_protocol(h3zero_stream_ctx_t* stream_ctx, char const* supported);
 
+    /* Get the authority from a WebTransport request.
+     * Returns a pointer to the null-terminated authority string, or NULL if not present.
+     * The pointer is valid for the lifetime of the stream context.
+     */
+    const char* picowt_get_authority(h3zero_stream_ctx_t* stream_ctx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/picohttp/webtransport.c
+++ b/picohttp/webtransport.c
@@ -332,6 +332,11 @@ int picowt_select_wt_protocol(h3zero_stream_ctx_t* stream_ctx, char const* suppo
     return ret;
 }
 
+const char* picowt_get_authority(h3zero_stream_ctx_t* stream_ctx)
+{
+    return (const char*)stream_ctx->ps.stream_state.header.authority;
+}
+
 /*
 * Connect
 */

--- a/picoquictest/h3zerotest.c
+++ b/picoquictest/h3zerotest.c
@@ -713,116 +713,116 @@ typedef struct st_qpack_test_case_t {
 static qpack_test_case_t qpack_test_case[] = {
     {
         qpack_test_get_slash, sizeof(qpack_test_get_slash),
-        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_slash_null, sizeof(qpack_test_get_slash_null),
-        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_slash_prefix, sizeof(qpack_test_get_slash_prefix),
-        { h3zero_method_get, qpack_test_string_slash, 1, NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_slash, 1, NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_index_html, sizeof(qpack_test_get_index_html),
-        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_index_html_long, sizeof(qpack_test_get_index_html_long),
-        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_index_html, QPACK_TEST_HEADER_INDEX_HTML_LEN, NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_status_404, sizeof(qpack_test_status_404),
-        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 404, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_status_404_code, sizeof(qpack_test_status_404_code),
-        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 404, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_status_404_long, sizeof(qpack_test_status_404_long),
-        { 0, NULL, 0, NULL, 0, 404, 0, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 404, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_response_html, sizeof(qpack_test_response_html),
-        { 0, NULL, 0, NULL, 0, 200, h3zero_content_type_text_html, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 200, h3zero_content_type_text_html, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_status_405_code, sizeof(qpack_test_status_405_code),
-        { 0, NULL, 0, NULL, 0, 405, 0, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 405, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_status_405_null, sizeof(qpack_test_status_405_null),
-        { 0, NULL, 0, NULL, 0, 405, 0, NULL, 0,
+        { 0, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 405, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_zzz, sizeof(qpack_test_get_zzz),
-        { h3zero_method_get, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_1234, sizeof(qpack_test_get_1234),
-        { h3zero_method_get, qpack_test_string_1234, sizeof(qpack_test_string_1234), NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_1234, sizeof(qpack_test_string_1234), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_ats, sizeof(qpack_test_get_ats),
-        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_ats2, sizeof(qpack_test_get_ats2),
-        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_slash, sizeof(qpack_test_string_slash), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_post_zzz, sizeof(qpack_test_post_zzz),
-        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0,
+        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_post_zzz_null, sizeof(qpack_test_post_zzz_null),
-        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0,
+        { h3zero_method_post, qpack_test_string_zzz, sizeof(qpack_test_string_zzz), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, h3zero_content_type_text_plain, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_status200_akamai, sizeof(qpack_status200_akamai),
-        { h3zero_method_none, NULL, 0, NULL, 0, 200, h3zero_content_type_not_supported, NULL, 0,
+        { h3zero_method_none, NULL, 0, NULL /* authority */, 0 /* authority_length */, NULL, 0, 200, h3zero_content_type_not_supported, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_get_long_file_name, sizeof(qpack_get_long_file_name),
-        { h3zero_method_get, qpack_test_string_long, sizeof(qpack_test_string_long), NULL, 0, 0, 0, NULL, 0,
+        { h3zero_method_get, qpack_test_string_long, sizeof(qpack_test_string_long), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_connect_webtransport, sizeof(qpack_connect_webtransport),
-        { h3zero_method_connect, qpack_test_string_wtp, sizeof(qpack_test_string_wtp), NULL, 0, 0, 0,
+        { h3zero_method_connect, qpack_test_string_wtp, sizeof(qpack_test_string_wtp), NULL /* authority */, 0 /* authority_length */, NULL, 0, 0, 0,
         (uint8_t *)web_transport_str, CONNECT_TEST_PROTOCOL_WTP_LEN,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_slash_range, sizeof(qpack_test_get_slash_range),
         { h3zero_method_get, qpack_test_string_slash, 1,
-        qpack_test_range_text, sizeof(qpack_test_range_text),
+        NULL /* authority */, 0 /* authority_length */, qpack_test_range_text, sizeof(qpack_test_range_text),
         0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     },
     {
         qpack_test_get_slash_range_long, sizeof(qpack_test_get_slash_range_long),
         { h3zero_method_get, qpack_test_string_slash, 1,
-        qpack_test_range_text, sizeof(qpack_test_range_text),
+        NULL /* authority */, 0 /* authority_length */, qpack_test_range_text, sizeof(qpack_test_range_text),
         0, 0, NULL, 0,
         NULL /* wt_available_protocols */, 0 /* wt_available_protocols_length */, NULL /* wt_protocol */, 0 /* wt_protocol_length */, 0 }
     }


### PR DESCRIPTION
Add authority/authority_length fields to h3zero_header_parts_t, parse the :authority pseudo-header in incoming requests, and expose it via picowt_get_authority() in the pico_webtransport API.