### PR TITLE
Fix RFC9000 compatibility issues and add tests

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -1560,6 +1560,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(zero_rtt_bad_param)
+        {
+            int ret = zero_rtt_bad_param_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(zero_rtt_retry)
         {
             int ret = zero_rtt_retry_test();

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -332,6 +332,12 @@ const uint8_t * picoquic_apply_reset_stream_frame(picoquic_cnx_t* cnx, const uin
 {
     picoquic_stream_head_t* stream;
     
+    if (!IS_BIDIR_STREAM_ID(stream_id) && IS_LOCAL_STREAM_ID(stream_id, cnx->client_mode)) {
+        /* the peer cannot send data, and thus cannot reset the stream */
+        bytes = NULL;
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR,
+            picoquic_frame_type_reset_stream);
+    }
     if ((stream = picoquic_find_or_create_stream(cnx, stream_id, 1)) == NULL) {
         /* Not finding the stream is only an error if the stream
          * was expected to be present, or created on demand. If the
@@ -679,7 +685,7 @@ const uint8_t* picoquic_decode_new_connection_id_frame(picoquic_cnx_t* cnx, cons
     }
     else if (cid_length > PICOQUIC_CONNECTION_ID_MAX_SIZE) {
         /* TODO: should be PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION if retire_before > sequence */
-        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION,
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR,
             picoquic_frame_type_new_connection_id);
         bytes = NULL;
     }
@@ -1527,9 +1533,10 @@ const uint8_t* picoquic_decode_stream_frame(picoquic_cnx_t* cnx, const uint8_t* 
     int      fin;
     size_t   consumed;
     if (picoquic_parse_stream_header(bytes, bytes_max - bytes, &stream_id, &offset, &data_length, &fin, &consumed) != 0) {
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_stream_range_min);
         bytes = NULL;
     }else if (offset + data_length >= (1ull<<62)){
-        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FINAL_OFFSET_ERROR, 0);
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_stream_range_min);
         bytes = NULL;
     }
     else {
@@ -4569,6 +4576,12 @@ const uint8_t* picoquic_decode_max_stream_data_frame(picoquic_cnx_t* cnx, const 
     {
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, picoquic_frame_type_max_stream_data);
     }
+    else if (!IS_BIDIR_STREAM_ID(stream_id) && !IS_LOCAL_STREAM_ID(stream_id, cnx->client_mode)) {
+        /* the local host cannot send data, and thus cannot use max stream data */
+        bytes = NULL;
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR,
+            picoquic_frame_type_reset_stream);
+    }
     else if ((stream = picoquic_find_stream(cnx, stream_id)) == NULL) {
         /* Maybe not an error if the stream is already closed, so just be tolerant */
         stream = picoquic_create_missing_streams(cnx, stream_id, 1);
@@ -4739,7 +4752,7 @@ const uint8_t* picoquic_decode_max_streams_frame(picoquic_cnx_t* cnx, const uint
         }
 
         if (max_stream_id >= (1ull << 62)) {
-            (void)picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR, max_streams_frame_type);
+            (void)picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
             bytes = NULL;
         }
     }
@@ -5102,11 +5115,16 @@ const uint8_t* picoquic_decode_blocked_frame(picoquic_cnx_t* cnx, const uint8_t*
 
 const uint8_t* picoquic_decode_stream_blocked_frame(picoquic_cnx_t* cnx, const uint8_t* bytes, const uint8_t* bytes_max)
 {
-    /* TODO: check that the stream number is valid */
-    if ((bytes = picoquic_frames_varint_skip(bytes+1, bytes_max)) == NULL ||
+    uint64_t stream_id = 0;
+
+    if ((bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &stream_id)) == NULL ||
         (bytes = picoquic_frames_varint_skip(bytes,   bytes_max)) == NULL)
     {
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, 
+            picoquic_frame_type_stream_data_blocked);
+    }
+    else if (!IS_BIDIR_STREAM_ID(stream_id) && IS_LOCAL_STREAM_ID(stream_id, cnx->client_mode)) {
+        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR,
             picoquic_frame_type_stream_data_blocked);
     }
     return bytes;

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1095,6 +1095,26 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
     int ret = 0;
     picoquic_quic_t** ppquic = (picoquic_quic_t**)(((char*)encrypt_ticket_ctx) + sizeof(ptls_encrypt_ticket_t));
     picoquic_quic_t* quic = *ppquic;
+    uint8_t param_verif[56];
+    uint8_t* param_bytes = param_verif;
+
+    /* Encode summary of default TLS parameters in a binary token that
+    * will be used as aead. This ensure that tokens issue with different
+    * parameters will not be accepted.
+    */
+    picoformat_64(param_bytes, quic->default_tp.active_connection_id_limit);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_data);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_stream_data_bidi_local);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_stream_data_bidi_remote);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_stream_data_uni);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_stream_id_bidir);
+    param_bytes += 8;
+    picoformat_64(param_bytes, quic->default_tp.initial_max_stream_id_unidir);
 
     if (is_encrypt != 0) {
         ptls_aead_context_t* aead_enc = (ptls_aead_context_t*)quic->aead_encrypt_ticket_ctx;
@@ -1119,7 +1139,7 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             data_length += 4;
             /* Run AEAD encryption */
             dst->off += ptls_aead_encrypt(aead_enc, dst->base + dst->off,
-                dst->base + start_off, data_length, seq_num, NULL, 0);
+                dst->base + start_off, data_length, seq_num, param_verif, sizeof(param_verif));
             /* Remember issued ticket ID in connection context */
             quic->cnx_in_progress->issued_ticket_id = seq_num;
         }
@@ -1135,7 +1155,7 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             uint64_t seq_num = PICOPARSE_64(src.base);
             /* Decrypt */
             size_t decrypted = ptls_aead_decrypt(aead_dec, dst->base + dst->off,
-                src.base + 8, src.len - 8, seq_num, NULL, 0);
+                src.base + 8, src.len - 8, seq_num, param_verif, sizeof(param_verif));
 
             if (decrypted > src.len - 8) {
                 /* decryption error */

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -652,9 +652,17 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     }
                     break;
                 case picoquic_tp_ack_delay_exponent:
-                    cnx->remote_parameters.ack_delay_exponent = (uint8_t)
-                        picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
+                {
+                    uint64_t ad_exponent = picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
+                    if (ad_exponent > 20){ 
+                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0,
+                            "ack delay exponent over 20");
+                    }
+                    else {
+                        cnx->remote_parameters.ack_delay_exponent = (uint8_t)ad_exponent;
+                    }
                     break;
+                }
                 case picoquic_tp_initial_max_streams_uni: {
                     uint64_t old_limit = cnx->max_stream_id_unidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_unidir =
@@ -710,7 +718,9 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                 case picoquic_tp_active_connection_id_limit:
                     cnx->remote_parameters.active_connection_id_limit = (uint32_t)
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
-                    /* TODO: may need to check the value, but conditions are unclear */
+                    if (cnx->remote_parameters.active_connection_id_limit < 2) {
+                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "CID limit too small.");
+                    }
                     break;
                 case picoquic_tp_max_datagram_frame_size:
                     cnx->remote_parameters.max_datagram_frame_size = (uint32_t)

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -598,7 +598,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     */
                     picoquic_update_stream_initial_remote(cnx);
                     break;
-                case picoquic_tp_initial_max_stream_data_uni:
+                case picoquic_tp_initial_max_stream_data_uni: {
                     cnx->remote_parameters.initial_max_stream_data_uni =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                     /* If we sent zero rtt data, the streams were created with the
@@ -606,6 +606,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     */
                     picoquic_update_stream_initial_remote(cnx);
                     break;
+                }
                 case picoquic_tp_initial_max_data:
                     cnx->remote_parameters.initial_max_data =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
@@ -615,11 +616,15 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     uint64_t old_limit = cnx->max_stream_id_bidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_bidir =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
-                    cnx->max_stream_id_bidir_remote = STREAM_ID_FROM_RANK(
-                        (cnx->remote_parameters.initial_max_stream_id_bidir == 0xFFFFFFFF) ? 0 : cnx->remote_parameters.initial_max_stream_id_bidir,
-                        cnx->client_mode, 0);
-                    cnx->max_stream_data_remote = cnx->remote_parameters.initial_max_stream_data_bidi_remote;
-                    picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_bidir_remote, 1);
+                    if (cnx->remote_parameters.initial_max_stream_id_bidir >= (1ull << 60)) {
+                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max streams bidir");
+                    }
+                    else {
+                        cnx->max_stream_id_bidir_remote = STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_bidir,
+                            cnx->client_mode, 0);
+                        cnx->max_stream_data_remote = cnx->remote_parameters.initial_max_stream_data_bidi_remote;
+                        picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_bidir_remote, 1);
+                    }
                     break;
                 }
                 case picoquic_tp_idle_timeout:
@@ -667,10 +672,14 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     uint64_t old_limit = cnx->max_stream_id_unidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_unidir =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
-                    cnx->max_stream_id_unidir_remote = STREAM_ID_FROM_RANK(
-                        (cnx->remote_parameters.initial_max_stream_id_unidir == 0xFFFFFFFF) ? 0 : cnx->remote_parameters.initial_max_stream_id_unidir,
-                        cnx->client_mode, 1);
-                    picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_unidir_remote, 0);
+                    if (cnx->remote_parameters.initial_max_stream_id_unidir >= (1ull << 60)) {
+                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max streams unidir");
+                    }
+                    else {
+                        cnx->max_stream_id_unidir_remote = STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_unidir,
+                            cnx->client_mode, 1);
+                        picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_unidir_remote, 0);
+                    }
                     break;
                 }
                 case picoquic_tp_server_preferred_address:
@@ -691,13 +700,16 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                         cnx->remote_parameters.migration_disabled = 1;
                     }
                     break;
-                case picoquic_tp_max_ack_delay:
-                    cnx->remote_parameters.max_ack_delay = (uint32_t)
-                        picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret) * 1000;
-                    if (cnx->remote_parameters.max_ack_delay > PICOQUIC_MAX_ACK_DELAY_MAX_MS * 1000) {
-                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max ack delay TP");
+                case picoquic_tp_max_ack_delay: {
+                    uint64_t max_ack_delay_ms = picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
+                    if (max_ack_delay_ms > PICOQUIC_MAX_ACK_DELAY_MAX_MS) {
+                        ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max ack delay too large");
+                    }
+                    else {
+                        cnx->remote_parameters.max_ack_delay = (uint32_t)max_ack_delay_ms * 1000;
                     }
                     break;
+                }
                 case picoquic_tp_original_connection_id:
                     ret = picoquic_transport_param_cid_decode(cnx, bytes + byte_index, extension_length, &original_connection_id);
                     break;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -258,6 +258,7 @@ static const picoquic_test_def_t test_table[] = {
     { "packet_enc_dec", packet_enc_dec_test},
     { "pn_vector", cleartext_pn_vector_test },
     { "zero_rtt_spurious", zero_rtt_spurious_test },
+    { "zero_rtt_bad_param", zero_rtt_bad_param_test },
     { "zero_rtt_retry", zero_rtt_retry_test },
     { "zero_rtt_no_coal", zero_rtt_no_coal_test },
     { "zero_rtt_many_losses", zero_rtt_many_losses_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -173,6 +173,7 @@ int client_only_test(void);
 int packet_enc_dec_test(void);
 int cleartext_pn_vector_test(void);
 int zero_rtt_spurious_test(void);
+int zero_rtt_bad_param_test(void);
 int zero_rtt_retry_test(void);
 int zero_rtt_no_coal_test(void);
 int zero_rtt_many_losses_test(void);

--- a/picoquictest/picoquictest_internal.h
+++ b/picoquictest/picoquictest_internal.h
@@ -402,6 +402,7 @@ typedef struct st_zero_rtt_test_t {
     uint64_t extra_delay;
     int do_multipath;
     int propose_ech;
+    int change_params;
 } zero_rtt_test_t;
 
 int zero_rtt_test_one(zero_rtt_test_t* zrt);

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -622,7 +622,6 @@ static uint8_t test_frame_type_path_available_bad[] = {
     /* Missing sequence */
 };
 
-
 static uint8_t test_frame_type_bdp_bad[] = {
     (uint8_t)(0x80 | (picoquic_frame_type_bdp >> 24)), (uint8_t)(picoquic_frame_type_bdp >> 16),
     (uint8_t)(picoquic_frame_type_bdp >> 8), (uint8_t)(picoquic_frame_type_bdp & 0xFF),
@@ -653,6 +652,7 @@ static uint8_t test_frame_type_bad_ack_first_range[] = {
 #define ERR_F PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR
 #define ERR_P PICOQUIC_TRANSPORT_PROTOCOL_VIOLATION
 #define ERR_S PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR
+#define ERR_ST PICOQUIC_TRANSPORT_STREAM_STATE_ERROR
 
 test_skip_frames_t test_frame_error_list[] = {
     TEST_SKIP_ITEM_OLD("bad_reset_stream_offset", test_frame_type_bad_reset_stream_offset, 0, 0, 3, PICOQUIC_TRANSPORT_FLOW_CONTROL_ERROR, 0),
@@ -661,14 +661,14 @@ test_skip_frames_t test_frame_error_list[] = {
     TEST_SKIP_ITEM_OLD("bad_connection_close", test_type_bad_connection_close, 0, 0, 3, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_connection_close2", test_type_bad_connection_close2, 0, 1, 3, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_application_close", test_type_bad_application_close, 0, 0, 3, ERR_F, 1),
-    TEST_SKIP_ITEM_OLD("bad_max_stream_stream", test_frame_type_bad_max_stream_stream, 0, 0, 3, ERR_S, 0),
-    TEST_SKIP_ITEM_OLD("bad_max_streams_bidir", test_frame_type_max_bad_streams_bidir, 0, 0, 3, ERR_S, 0),
-    TEST_SKIP_ITEM_OLD("bad_max_streams_unidir", test_frame_type_bad_max_streams_unidir, 0, 0, 3, ERR_S, 0),
+    TEST_SKIP_ITEM_OLD("bad_max_stream_stream", test_frame_type_bad_max_stream_stream, 0, 0, 3, ERR_ST, 0),
+    TEST_SKIP_ITEM_OLD("bad_max_streams_bidir", test_frame_type_max_bad_streams_bidir, 0, 0, 3, ERR_F, 0),
+    TEST_SKIP_ITEM_OLD("bad_max_streams_unidir", test_frame_type_bad_max_streams_unidir, 0, 0, 3, ERR_F, 0),
     TEST_SKIP_ITEM_OLD("bad_new_connection_id_length", test_frame_type_bad_new_cid_length, 0, 0, 3, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_new_connection_id_retire", test_frame_type_bad_new_cid_retire, 0, 0, 3, ERR_F, 0),
     TEST_SKIP_ITEM_OLD("illegal_new_cid_retire", test_frame_type_illegal_new_cid_retire, 0, 0, 3, ERR_F, 0),
-    TEST_SKIP_ITEM_OLD("too_long_new_cid", test_frame_type_too_long_new_cid, 0, 0, 3, ERR_P, 0),
-    TEST_SKIP_ITEM_OLD("bad_stop_sending", test_frame_type_bad_stop_sending, 0, 0, 3, PICOQUIC_TRANSPORT_STREAM_STATE_ERROR, 0),
+    TEST_SKIP_ITEM_OLD("too_long_new_cid", test_frame_type_too_long_new_cid, 0, 0, 3, ERR_F, 0),
+    TEST_SKIP_ITEM_OLD("bad_stop_sending", test_frame_type_bad_stop_sending, 0, 0, 3, ERR_ST, 0),
     TEST_SKIP_ITEM_OLD("bad_stop_sending2", test_frame_type_bad_stop_sending2, 0, 1, 3, ERR_F, 0),
     TEST_SKIP_ITEM_OLD("bad_new_token", test_frame_type_bad_new_token, 0, 0, 3, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_ack_range", test_frame_type_bad_ack_range, 1, 0, 3, ERR_F, 0),
@@ -677,7 +677,7 @@ test_skip_frames_t test_frame_error_list[] = {
     TEST_SKIP_ITEM_OLD("bad_ack_blocks", test_frame_type_bad_ack_blocks, 1, 0, 3, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_crypto_hs", test_frame_type_bad_crypto_hs, 0, 0, 2, ERR_F, 1),
     TEST_SKIP_ITEM_OLD("bad_datagram", test_frame_type_bad_datagram, 1, 0, 3, ERR_F, 1),
-    TEST_SKIP_ITEM_OLD("stream_hang", test_frame_stream_hang, 1, 0, 3, PICOQUIC_TRANSPORT_FINAL_OFFSET_ERROR, 0),
+    TEST_SKIP_ITEM_OLD("stream_hang", test_frame_stream_hang, 1, 0, 3, ERR_F, 0),
     TEST_SKIP_ITEM_OLD_MPATH("bad_abandon_0", test_frame_type_path_abandon_bad_0, 0, 1, 3, ERR_F, 1, 1),
     TEST_SKIP_ITEM_OLD_MPATH("bad_abandon_1", test_frame_type_path_abandon_bad_1, 0, 0, 3, ERR_F, 1, 1),
     TEST_SKIP_ITEM_OLD_MPATH("bad_path_available", test_frame_type_path_available_bad, 0, 1, 3, ERR_F, 1, 1),

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -4420,6 +4420,11 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
                 test_ctx->cnx_client->local_parameters.enable_time_stamp = 0;
             }
 
+            if (ret == 0 && i > 0 && zrt->change_params) {
+                test_ctx->qserver->default_tp.initial_max_data -= 1;
+                test_ctx->qserver->default_tp.initial_max_stream_id_bidir += 1;
+            }
+
             if (ret == 0 && zrt->propose_ech) {
                 ret = picoquic_ech_configure_quic_ctx(test_ctx->qclient, NULL, NULL);
             }
@@ -4474,7 +4479,7 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
             }
         }
 
-        if (ret == 0 && zrt->use_badcrypt == 0 && zrt->hardreset == 0) {
+        if (ret == 0 && zrt->use_badcrypt == 0 && zrt->hardreset == 0 && zrt->change_params == 0) {
             int rtt_is_available = picoquic_is_0rtt_available(test_ctx->cnx_client);
 
             if ((rtt_is_available && i == 0) ||
@@ -4485,11 +4490,11 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
 
         if (ret == 0 && i == 1) {
             /* If resume succeeded, the second connection will have a type "PSK" */
-            if (zrt->use_badcrypt == 0 && zrt->hardreset == 0 && (
+            if (zrt->use_badcrypt == 0 && zrt->hardreset == 0 && zrt->change_params == 0 && (
                 picoquic_tls_is_psk_handshake(test_ctx->cnx_server) == 0 || 
                 picoquic_tls_is_psk_handshake(test_ctx->cnx_client) == 0)) {
-                DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d), connection %d not PSK.\n",
-                    zrt->use_badcrypt, zrt->hardreset, i);
+                DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d, change: %d), connection %d not PSK.\n",
+                    zrt->use_badcrypt, zrt->hardreset, zrt->change_params, i);
                 ret = -1;
             } else {
                 /* run a receive loop until no outstanding data */
@@ -4530,7 +4535,7 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
 
         /* Verify that the 0RTT data was sent and acknowledged */
         if (ret == 0 && i == 1) {
-            if (zrt->use_badcrypt == 0 && zrt->hardreset == 0) {
+            if (zrt->use_badcrypt == 0 && zrt->hardreset == 0 && zrt->change_params == 0) {
                 if (test_ctx->cnx_client->nb_zero_rtt_sent == 0) {
                     DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d), no zero RTT sent.\n",
                         zrt->use_badcrypt, zrt->hardreset);
@@ -4555,13 +4560,13 @@ int zero_rtt_test_one(zero_rtt_test_t * zrt)
                 }
             } else {
                 if (test_ctx->cnx_client->nb_zero_rtt_sent == 0) {
-                    DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d), no zero RTT sent.\n",
-                        zrt->use_badcrypt, zrt->hardreset);
+                    DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d, change: %d), no zero RTT sent.\n",
+                        zrt->use_badcrypt, zrt->hardreset, zrt->change_params);
                     ret = -1;
                 }
-                else if (zrt->early_loss == 0 && zrt->hardreset == 0 && test_ctx->cnx_client->nb_zero_rtt_acked != 0) {
-                    DBG_PRINTF("Zero RTT test (badcrypt: %d, hard: %d), zero acked, not expected.\n",
-                        zrt->use_badcrypt, zrt->hardreset);
+                else if ((zrt->early_loss || zrt->change_params) && test_ctx->cnx_client->nb_zero_rtt_acked != 0) {
+                    DBG_PRINTF("Zero RTT test (badcrypt: %d, change : %d), zero rtt acked, not expected.\n",
+                        zrt->use_badcrypt, zrt->change_params);
                     ret = -1;
                 }
                 else if (test_ctx->sum_data_received_at_server == 0) {
@@ -4650,6 +4655,21 @@ int zero_rtt_spurious_test(void)
 {
     zero_rtt_test_t zrt = { 0 };
     zrt.use_badcrypt = 1;
+    return zero_rtt_test_one(&zrt);
+}
+
+
+/*
+* Zero RTT bad param test.
+* Check what happens if the client attempts to resume a connection using a ticket
+* issued on a previous instance, and the default TP parameters have changed.
+* We expect that the connection will not use 0RTT.
+*/
+
+int zero_rtt_bad_param_test(void)
+{
+    zero_rtt_test_t zrt = { 0 };
+    zrt.change_params = 1;
     return zero_rtt_test_one(&zrt);
 }
 

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -365,6 +365,23 @@ uint8_t client_param_err9[] = {
     picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID
 };
 
+/* error 10, Active CID limit too small */
+uint8_t client_param_err10[] = {
+    picoquic_tp_initial_max_stream_data_bidi_local, 4, 0x80, 0, 0xFF, 0xFF,
+    picoquic_tp_initial_max_data, 4, 0x80, 0x40, 0, 0,
+    picoquic_tp_idle_timeout, 1, 0x1E,
+    picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID,
+    picoquic_tp_active_connection_id_limit, 1, 1
+};
+
+/* error 11, ack_delay_exponent over 20 */
+uint8_t client_param_err11[] = {
+    picoquic_tp_initial_max_stream_data_bidi_local, 4, 0x80, 0, 0xFF, 0xFF,
+    picoquic_tp_initial_max_data, 4, 0x80, 0x40, 0, 0,
+    picoquic_tp_idle_timeout, 1, 0x1E,
+    picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID,
+    picoquic_tp_ack_delay_exponent , 1, 21
+};
 
 typedef struct st_transport_param_error_test_t {
     int mode;
@@ -380,8 +397,10 @@ static transport_param_error_test_t transport_param_error_case[] = {
     { 0, client_param_err5, sizeof(client_param_err5), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
     { 0, client_param_err6, sizeof(client_param_err6), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
     { 0, client_param_err7, sizeof(client_param_err7), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
-    { 0, client_param_err8, sizeof(client_param_err7), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
-    { 0, client_param_err9, sizeof(client_param_err7), PICOQUIC_TRANSPORT_PARAMETER_ERROR}
+    { 0, client_param_err8, sizeof(client_param_err8), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err9, sizeof(client_param_err9), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err10, sizeof(client_param_err10), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err11, sizeof(client_param_err11), PICOQUIC_TRANSPORT_PARAMETER_ERROR}
 };
 
 static size_t nb_transport_param_error_case = sizeof(transport_param_error_case) / sizeof(transport_param_error_test_t);

--- a/picoquictest/transport_param_test.c
+++ b/picoquictest/transport_param_test.c
@@ -383,6 +383,35 @@ uint8_t client_param_err11[] = {
     picoquic_tp_ack_delay_exponent , 1, 21
 };
 
+/* error 12, max_ack_delay larger than 2^16 */
+uint8_t client_param_err12[] = {
+    picoquic_tp_initial_max_stream_data_bidi_local, 4, 0x80, 0, 0xFF, 0xFF,
+    picoquic_tp_initial_max_data, 4, 0x80, 0x40, 0, 0,
+    picoquic_tp_idle_timeout, 1, 0x1E,
+    picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID,
+    picoquic_tp_max_ack_delay , 4, 0x80, 0x00, 0x40, 0x01
+};
+
+/* error 13, max_streams_bidir larger than or equal to 2^60 */
+uint8_t client_param_err13[] = {
+    picoquic_tp_initial_max_stream_data_bidi_local, 4, 0x80, 0, 0xFF, 0xFF,
+    picoquic_tp_initial_max_data, 4, 0x80, 0x40, 0, 0,
+    picoquic_tp_idle_timeout, 1, 0x1E,
+    picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID,
+    picoquic_tp_initial_max_streams_bidi, 8,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
+/* error 14, max_streams_unidir larger than or equal to 2^60 */
+uint8_t client_param_err14[] = {
+    picoquic_tp_initial_max_stream_data_bidi_local, 4, 0x80, 0, 0xFF, 0xFF,
+    picoquic_tp_initial_max_data, 4, 0x80, 0x40, 0, 0,
+    picoquic_tp_idle_timeout, 1, 0x1E,
+    picoquic_tp_handshake_connection_id, 8, LOCAL_CONNECTION_ID,
+    picoquic_tp_initial_max_streams_uni, 8,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF
+};
+
 typedef struct st_transport_param_error_test_t {
     int mode;
     uint8_t * target;
@@ -400,7 +429,10 @@ static transport_param_error_test_t transport_param_error_case[] = {
     { 0, client_param_err8, sizeof(client_param_err8), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
     { 0, client_param_err9, sizeof(client_param_err9), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
     { 0, client_param_err10, sizeof(client_param_err10), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
-    { 0, client_param_err11, sizeof(client_param_err11), PICOQUIC_TRANSPORT_PARAMETER_ERROR}
+    { 0, client_param_err11, sizeof(client_param_err11), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err12, sizeof(client_param_err12), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err13, sizeof(client_param_err13), PICOQUIC_TRANSPORT_PARAMETER_ERROR},
+    { 0, client_param_err14, sizeof(client_param_err14), PICOQUIC_TRANSPORT_PARAMETER_ERROR}
 };
 
 static size_t nb_transport_param_error_case = sizeof(transport_param_error_case) / sizeof(transport_param_error_test_t);


### PR DESCRIPTION
Fixing the compatibility bugs listed in issue #2091:

1. 0-RTT Transport Parameter Limits Not Currently Guarded Against Reduction: add the current version of the protected transport parameters in the authenticated additional data when encrypting and decrypting the session ticket. If the parameters change, 0RTT will not be used, as if the ticket had expired. Added test `zero_rtt_bad_param`
2. Stream Direction Validation Differs from RFC for Several Frame Types: implemented the test, and verified that the frame parsing tests provide the right error code.
3. MAX_STREAMS Threshold and Error Code Differ from RFC: fixed the error code and updated the frame test. Also fixed the threshold tests for the initial max streams transport parameters.
4. Oversized STREAM Frame Offset Uses FINAL_OFFSET_ERROR Rather Than FRAME_ENCODING_ERROR: fixed the error code and updated the frame test.
5. NEW_CONNECTION_ID Length Exceeding 20 Bytes Sends PROTOCOL_VIOLATION Rather Than FRAME_ENCODING_ERROR: fixed the error code and updated the frame test.
6. active_connection_id_limit Values Below 2 Not Currently Validated: added validation, and added a test case in the transport parameters test.
7. Transport Parameter Range Validation Not Enforced for ack_delay_exponent and max_ack_delay: fixed, added test cases for transport parameters. 

