### PR TITLE
cmake: add picoquic::picoquic-log namespace alias

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,7 @@ endif()
 
 if (BUILD_LOGLIB)
     add_library(picoquic-log ${LOGLIB_LIBRARY_FILES})
+    add_library(picoquic::picoquic-log ALIAS picoquic-log)
     target_link_libraries(picoquic-log PUBLIC picoquic-core)
     target_include_directories(picoquic-log
         PRIVATE


### PR DESCRIPTION
## Summary
\`picoquic-core\` (line 403) and \`picohttp-core\` (line 455) both have ALIAS targets under the \`picoquic::\` namespace; \`picoquic-log\` was missing one. This adds it for symmetry.

\`\`\`cmake
add_library(picoquic-log ${LOGLIB_LIBRARY_FILES})
+add_library(picoquic::picoquic-log ALIAS picoquic-log)
 target_link_libraries(picoquic-log PUBLIC picoquic-core)
\`\`\`

## Why
The install EXPORT (line 681, \`NAMESPACE picoquic::\`) already produces \`picoquic::picoquic-log\` for downstream \`find_package(picoquic)\` consumers. Build-tree consumers (via \`add_subdirectory\` or \`FetchContent\`) currently see only the bare \`picoquic-log\` target, so \`target_link_libraries(... picoquic::picoquic-log)\` fails with "target not found" in that context.

This is the same gap that existed for picoquic-core and picohttp-core before their aliases were added; the addition makes the same target reference work in both build-tree and install-tree contexts, which matters for consumers (e.g. moxygen, moqx) that mix both topologies.

## Risk
Pure addition. No existing line is modified. No behaviour change for any current consumer; just makes the namespaced reference resolve in one more scope.

## Test plan
- [ ] Picoquic CI (existing test suite — alias addition shouldn't affect any existing target's link semantics)