### PR TITLE
perf: split due-now connections out of the wake tree

### DIFF
--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -642,6 +642,8 @@ typedef struct st_picoquic_quic_t {
 
     struct st_picoquic_cnx_t* cnx_list;
     struct st_picoquic_cnx_t* cnx_last;
+    struct st_picoquic_cnx_t* cnx_wake_ready_first;
+    struct st_picoquic_cnx_t* cnx_wake_ready_last;
     picosplay_tree_t cnx_wake_tree;
 
     struct st_picoquic_cnx_t* cnx_in_progress;
@@ -1273,6 +1275,8 @@ typedef struct st_picoquic_cnx_t {
     unsigned int initial_repeat_needed : 1; /* Path has not been validated, repeated initial was received */
     unsigned int is_loss_bit_enabled_incoming : 1; /* Read the loss bits in incoming packets */
     unsigned int is_loss_bit_enabled_outgoing : 1; /* Insert the loss bits in outgoing packets */
+    unsigned int is_wake_ready : 1; /* Connection is in the due-now wake FIFO */
+    unsigned int is_wake_tree : 1; /* Connection is in the future wake-time tree */
     unsigned int is_ack_frequency_negotiated : 1; /* Ack Frequency extension negotiated */
     unsigned int is_ack_frequency_updated : 1; /* Should send an ack frequency frame asap. */
     unsigned int recycle_sooner_needed : 1; /* There may be a need to recycle "sooner" packets */
@@ -1365,6 +1369,8 @@ typedef struct st_picoquic_cnx_t {
     /* Next time sending data is expected */
     uint64_t next_wake_time;
     picosplay_node_t cnx_wake_node;
+    struct st_picoquic_cnx_t* cnx_wake_next;
+    struct st_picoquic_cnx_t* cnx_wake_previous;
     /* Wakeup time requested by the application */
     uint64_t app_wake_time;
     /* TLS context, TLS Send Buffer, streams, epochs */

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1502,14 +1502,67 @@ static void picoquic_wake_list_init(picoquic_quic_t * quic)
         picoquic_wake_list_create_node, picoquic_wake_list_delete_node, picoquic_wake_list_node_value);
 }
 
+static void picoquic_insert_cnx_in_wake_ready_list(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
+{
+    cnx->cnx_wake_previous = quic->cnx_wake_ready_last;
+    cnx->cnx_wake_next = NULL;
+
+    if (quic->cnx_wake_ready_last != NULL) {
+        quic->cnx_wake_ready_last->cnx_wake_next = cnx;
+    }
+    else {
+        quic->cnx_wake_ready_first = cnx;
+    }
+    quic->cnx_wake_ready_last = cnx;
+    cnx->is_wake_ready = 1;
+}
+
+static void picoquic_remove_cnx_from_wake_ready_list(picoquic_cnx_t* cnx)
+{
+    if (cnx->cnx_wake_previous != NULL) {
+        cnx->cnx_wake_previous->cnx_wake_next = cnx->cnx_wake_next;
+    }
+    else {
+        cnx->quic->cnx_wake_ready_first = cnx->cnx_wake_next;
+    }
+
+    if (cnx->cnx_wake_next != NULL) {
+        cnx->cnx_wake_next->cnx_wake_previous = cnx->cnx_wake_previous;
+    }
+    else {
+        cnx->quic->cnx_wake_ready_last = cnx->cnx_wake_previous;
+    }
+
+    cnx->cnx_wake_next = NULL;
+    cnx->cnx_wake_previous = NULL;
+    cnx->is_wake_ready = 0;
+}
+
 static void picoquic_remove_cnx_from_wake_list(picoquic_cnx_t* cnx)
 {
-    picosplay_delete_hint(&cnx->quic->cnx_wake_tree, &cnx->cnx_wake_node);
+    if (cnx->is_wake_ready) {
+        picoquic_remove_cnx_from_wake_ready_list(cnx);
+    }
+    else if (cnx->is_wake_tree) {
+        cnx->is_wake_tree = 0;
+        picosplay_delete_hint(&cnx->quic->cnx_wake_tree, &cnx->cnx_wake_node);
+    }
+}
+
+static void picoquic_insert_cnx_in_wake_tree(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
+{
+    picosplay_insert(&quic->cnx_wake_tree, cnx);
+    cnx->is_wake_tree = 1;
 }
 
 static void picoquic_insert_cnx_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx)
 {
-    picosplay_insert(&quic->cnx_wake_tree, cnx);
+    if (cnx->next_wake_time <= picoquic_get_quic_time(quic)) {
+        picoquic_insert_cnx_in_wake_ready_list(quic, cnx);
+    }
+    else {
+        picoquic_insert_cnx_in_wake_tree(quic, cnx);
+    }
 }
 
 void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t next_time)
@@ -1519,9 +1572,34 @@ void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, 
     picoquic_insert_cnx_by_wake_time(quic, cnx);
 }
 
+static void picoquic_wake_list_promote_ready(picoquic_quic_t* quic, uint64_t max_wake_time)
+{
+    uint64_t due_time = (max_wake_time == 0) ? picoquic_get_quic_time(quic) : max_wake_time;
+
+    for (;;) {
+        picoquic_cnx_t* cnx = (picoquic_cnx_t*)picoquic_wake_list_node_value(picosplay_first(&quic->cnx_wake_tree));
+        if (cnx == NULL || cnx->next_wake_time > due_time) {
+            break;
+        }
+        cnx->is_wake_tree = 0;
+        picosplay_delete_hint(&quic->cnx_wake_tree, &cnx->cnx_wake_node);
+        picoquic_insert_cnx_in_wake_ready_list(quic, cnx);
+    }
+}
+
 picoquic_cnx_t* picoquic_get_earliest_cnx_to_wake(picoquic_quic_t* quic, uint64_t max_wake_time)
 {
-    picoquic_cnx_t* cnx = (picoquic_cnx_t *)picoquic_wake_list_node_value(picosplay_first(&quic->cnx_wake_tree));
+    picoquic_cnx_t* cnx;
+
+    picoquic_wake_list_promote_ready(quic, max_wake_time);
+
+    cnx = quic->cnx_wake_ready_first;
+    while (cnx != NULL && max_wake_time != 0 && cnx->next_wake_time > max_wake_time) {
+        cnx = cnx->cnx_wake_next;
+    }
+    if (cnx == NULL) {
+        cnx = (picoquic_cnx_t*)picoquic_wake_list_node_value(picosplay_first(&quic->cnx_wake_tree));
+    }
     if (cnx != NULL && max_wake_time != 0 && cnx->next_wake_time > max_wake_time)
     {
         cnx = NULL;
@@ -1538,7 +1616,10 @@ uint64_t picoquic_get_next_wake_time(picoquic_quic_t* quic, uint64_t current_tim
     if (quic->pending_stateless_packet != NULL) {
         wake_time = current_time;
     }
-    else{
+    else if (quic->cnx_wake_ready_first != NULL) {
+        wake_time = quic->cnx_wake_ready_first->next_wake_time;
+    }
+    else {
         picoquic_cnx_t* cnx_wake_first = (picoquic_cnx_t*)picoquic_wake_list_node_value(
             picosplay_first(&quic->cnx_wake_tree));
 

--- a/picoquictest/getter_test.c
+++ b/picoquictest/getter_test.c
@@ -398,6 +398,60 @@ int getter_test(void)
     }
 
     if (ret == 0) {
+        uint64_t now = simulated_time;
+        picoquic_connection_id_t cid1 = { { 0x42, 0, 0, 0, 0, 0, 0, 1 }, 8 };
+        picoquic_connection_id_t cid2 = { { 0x42, 0, 0, 0, 0, 0, 0, 2 }, 8 };
+        picoquic_cnx_t* cnx1 = picoquic_create_cnx(test_ctx->qclient, cid1, cid1,
+            (struct sockaddr*)&test_ctx->server_addr, now + 1000000,
+            PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, 1);
+        picoquic_cnx_t* cnx2 = picoquic_create_cnx(test_ctx->qclient, cid2, cid2,
+            (struct sockaddr*)&test_ctx->server_addr, now + 2000000,
+            PICOQUIC_INTERNAL_TEST_VERSION_1, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, 1);
+
+        if (cnx1 == NULL || cnx2 == NULL) {
+            ret = -1;
+        }
+        else {
+            picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx, now + 3000000);
+            picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx1, now);
+            picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx2, now);
+
+            if (!cnx1->is_wake_ready || !cnx2->is_wake_ready ||
+                cnx1->is_wake_tree || cnx2->is_wake_tree ||
+                test_ctx->qclient->cnx_wake_ready_first != cnx1 ||
+                test_ctx->qclient->cnx_wake_ready_last != cnx2 ||
+                picoquic_get_earliest_cnx_to_wake(test_ctx->qclient, now) != cnx1) {
+                ret = -1;
+            }
+            else {
+                picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx1, now);
+                if (test_ctx->qclient->cnx_wake_ready_first != cnx2 ||
+                    test_ctx->qclient->cnx_wake_ready_last != cnx1 ||
+                    picoquic_get_earliest_cnx_to_wake(test_ctx->qclient, now) != cnx2) {
+                    ret = -1;
+                }
+                else {
+                    picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx1, now + 1000);
+                    if (cnx1->is_wake_ready || !cnx1->is_wake_tree ||
+                        test_ctx->qclient->cnx_wake_ready_first != cnx2 ||
+                        picoquic_get_earliest_cnx_to_wake(test_ctx->qclient, now) != cnx2) {
+                        ret = -1;
+                    }
+                }
+            }
+
+            picoquic_reinsert_by_wake_time(test_ctx->qclient, cnx, now + 4000);
+        }
+
+        if (cnx1 != NULL) {
+            picoquic_delete_cnx(cnx1);
+        }
+        if (cnx2 != NULL) {
+            picoquic_delete_cnx(cnx2);
+        }
+    }
+
+    if (ret == 0) {
         uint64_t wake_time = picoquic_get_next_wake_time(test_ctx->qclient, UINT64_MAX);
 
         if (wake_time > 2 && picoquic_get_earliest_cnx_to_wake(test_ctx->qclient, wake_time / 2) != NULL) {

--- a/picoquictest/qinqtest.c
+++ b/picoquictest/qinqtest.c
@@ -574,11 +574,13 @@ int picoqinq_test_sim_step(struct st_picoqinq_test_ctx_t* test_ctx)
             selected_ctx = i;
             is_stateless = 1;
             next_time = test_ctx->simulated_time;
-        } else if (test_ctx->qctx[i]->cnx_wake_first != NULL) {
-            if (test_ctx->qctx[i]->cnx_wake_first->next_wake_time < next_time) {
+        }
+        else {
+            uint64_t wake_time = picoquic_get_next_wake_time(test_ctx->qctx[i], test_ctx->simulated_time);
+            if (wake_time < next_time) {
                 selected_ctx = i;
                 is_stateless = 0;
-                next_time = test_ctx->qctx[i]->cnx_wake_first->next_wake_time;
+                next_time = wake_time;
             }
         }
     }
@@ -642,19 +644,21 @@ int picoqinq_test_sim_step(struct st_picoqinq_test_ctx_t* test_ctx)
                 picoquic_delete_stateless_packet(sp);
             }
         }
-        else if (test_ctx->qctx[selected_ctx]->cnx_wake_first == NULL) {
-            ret = -1; /* unexpected */
-        }
         else {
-            /* check whether there is something to send */
+            picoquic_cnx_t* cnx = picoquic_get_earliest_cnx_to_wake(test_ctx->qctx[selected_ctx], test_ctx->simulated_time);
+            if (cnx == NULL) {
+                ret = -1; /* unexpected */
+            }
+            else {
+                /* check whether there is something to send */
 
-            ret = picoquic_prepare_packet(test_ctx->qctx[selected_ctx]->cnx_wake_first, test_ctx->simulated_time,
-                packet->bytes, PICOQUIC_MAX_PACKET_SIZE, &packet->length,
-                &packet->addr_to, &packet->addr_from);
-            if (ret != 0)
-            {
-                /* useless test, but makes it easier to add a breakpoint under debugger */
-                ret = -1;
+                ret = picoquic_prepare_packet(cnx, test_ctx->simulated_time,
+                    packet->bytes, PICOQUIC_MAX_PACKET_SIZE, &packet->length,
+                    &packet->addr_to, &packet->addr_from);
+                if (ret != 0) {
+                    /* useless test, but makes it easier to add a breakpoint under debugger */
+                    ret = -1;
+                }
             }
         }
 


### PR DESCRIPTION
The connection wake list currently uses one picosplay tree keyed by next_wake_time. That works for future timers, but it is a poor fit for large batches of connections that are already due.

In a 10K persistent-client server profile, the application main thread stalled around 7,272 live clients with 92.18% of sampled user cycles in picosplay_delete_hint. The hot path was:

  picoquic_prepare_next_packet_ex
  -> picoquic_get_earliest_cnx_to_wake
  -> picosplay_first
  -> picoquic_prepare_packet_ex
  -> picoquic_reinsert_by_wake_time
  -> picosplay_delete_hint

Added a separate ready FIFO for connections whose wake time is due now, kept the existing picosplay tree for future timers, and routed reinsertion based on the new wake time. This preserves timer ordering for future wakeups while making the common many-ready scheduling path O(1) and FIFO-fair. Keep the one-connection case cheap by avoiding the tree in the due-now path.

This ready/future split improves the scheduler microbench without relying on unfair ordering:

  1 connection all-ready: 6.87 ns/op -> 0.24 ns/op
  10K all-ready:         26.51 ns/op -> 1.11 ns/op
  50K mixed10:           37.16 ns/op -> 7.73 ns/op
  100K mixed10:          36.07 ns/op -> 3.56 ns/op

Real profile evidence:

  baseline 10K shaped, stalled at 7,272 live:
    picosplay_delete_hint 92.18% flat / 92.176% folded

  ready-FIFO prototype, 7,280 live:
    picosplay_delete_hint 0.50% flat / 0.269% folded

  later 10K and 41K live captures:
    picosplay_delete_hint stayed at 0.000% in the main app profile

Tests:

  cmake --build ../picoquic-pr-build-shared -j48

  ../picoquic-pr-build-shared/picoquic_ct getter splay stress ready_to_send ready_to_skip ready_to_zfin two_connections keep_alive

  ctest --test-dir ../picoquic-pr-build-shared --output-on-failure

<img width="1200" height="398" alt="01-baseline-stalled-7272" src="https://github.com/user-attachments/assets/e056ba1e-07c6-4198-9d58-f142f22e8e7b" />
<img width="1200" height="798" alt="02-ready-fifo-7280" src="https://github.com/user-attachments/assets/895f6603-3f9d-4819-858f-e1b97ec4e58a" />
<img width="1200" height="494" alt="03-post-scheduler-wall-7388" src="https://github.com/user-attachments/assets/f3a28775-fc5e-4fe3-9559-46bbf02eb039" />
<img width="1200" height="366" alt="04-maxadmit-10001" src="https://github.com/user-attachments/assets/8e8b9489-26ab-449a-a1ab-0ff1f2ed9c95" />
<img width="1200" height="574" alt="05-maxadmit-41013" src="https://github.com/user-attachments/assets/17b7c0e9-1ad0-4c65-ad20-800876a073bb" />
