### PR TITLE
Reinsert on zero length fin add

### DIFF
--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -248,6 +248,7 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
     int ret = 0;
     picoquic_stream_head_t* stream;
     PICOQUIC_THREAD_CHECK(cnx->quic);
+    unsigned int reinsert = 0;
         
     stream = picoquic_find_stream_for_writing(cnx, stream_id, &ret);
     if (ret == 0 && set_fin) {
@@ -258,6 +259,7 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
             }
         } else {
             stream->fin_requested = 1;
+            reinsert = 1;
         }
     }
 
@@ -296,10 +298,13 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
             }
         }
 
-        picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
+        reinsert = 1;
     }
 
     if (ret == 0) {
+        if (reinsert) {
+            picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
+        }
         cnx->nb_bytes_queued += length;
         stream->is_active = 0;
         stream->app_stream_ctx = app_stream_ctx;

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -248,7 +248,6 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
     int ret = 0;
     picoquic_stream_head_t* stream;
     PICOQUIC_THREAD_CHECK(cnx->quic);
-    unsigned int reinsert = 0;
         
     stream = picoquic_find_stream_for_writing(cnx, stream_id, &ret);
     if (ret == 0 && set_fin) {
@@ -259,7 +258,6 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
             }
         } else {
             stream->fin_requested = 1;
-            reinsert = 1;
         }
     }
 
@@ -298,11 +296,10 @@ int picoquic_add_to_stream_with_ctx(picoquic_cnx_t* cnx, uint64_t stream_id,
             }
         }
 
-        reinsert = 1;
     }
 
     if (ret == 0) {
-        if (reinsert) {
+        if (length > 0 || set_fin) {
             picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
         }
         cnx->nb_bytes_queued += length;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -339,6 +339,7 @@ static const picoquic_test_def_t test_table[] = {
     { "reset_stream_at_limit_test", reset_stream_at_limit_test },
     { "reset_stream_at_loss", reset_stream_at_loss_test },
     { "stream_state_local_reuse", stream_state_local_reuse_test },
+    { "add_to_stream_fin_only_wakes_cnx", add_to_stream_fin_only_wakes_cnx_test },
     { "initial_pto", initial_pto_test },
     { "initial_pto_srv", initial_pto_srv_test },
     { "ready_to_send", ready_to_send_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -277,6 +277,7 @@ int reset_stream_at_basic_test(void);
 int reset_stream_at_limit_test(void);
 int reset_stream_at_loss_test(void);
 int stream_state_local_reuse_test(void);
+int add_to_stream_fin_only_wakes_cnx_test(void);
 int initial_pto_test(void);
 int initial_pto_srv_test(void);
 int ready_to_send_test(void);

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -472,6 +472,47 @@ int stream_state_local_reuse_test(void)
 }
 
 /*
+ * Zero length fin add should wake cnx.
+ */
+int add_to_stream_fin_only_wakes_cnx_test(void)
+{
+    picoquic_quic_t* quic = NULL;
+    picoquic_cnx_t* cnx = NULL;
+    uint64_t simulated_time = 0;
+    int ret = 0;
+    const uint64_t future_wake_time = 60ull * 1000000ull;
+
+    if (picoquic_test_set_minimal_cnx_with_time(&quic, &cnx, &simulated_time) != 0 || quic == NULL || cnx == NULL) {
+        ret = -1;
+    }
+    else {
+        cnx->client_mode = 1;
+        uint64_t stream_id = picoquic_get_next_local_stream_id(cnx, 0);
+
+        /* Park the connection in the future wake tree */
+        picoquic_reinsert_by_wake_time(quic, cnx, future_wake_time);
+        if (cnx->is_wake_ready || !cnx->is_wake_tree) {
+            ret = -1;
+        }
+        else if (picoquic_add_to_stream(cnx, stream_id, NULL, 0, 1) != 0) {
+            ret = -1;
+        }
+        else {
+            picoquic_stream_head_t* stream = picoquic_find_stream(cnx, stream_id);
+            if (stream == NULL || !stream->fin_requested) {
+                ret = -1;
+            }
+            else if (!cnx->is_wake_ready || cnx->is_wake_tree) {
+                ret = -1;
+            }
+        }
+    }
+
+    picoquic_test_delete_minimal_cnx(&quic, &cnx);
+    return ret;
+}
+
+/*
  * Test creation and deletion of streams.
  */
 int check_stream_splay_node_sanity(picosplay_node_t *x, void *floor, void *ceil, picosplay_comparator comp) {


### PR DESCRIPTION
This is more of a question and a potential solution than a normal PR. 

In our application we typically close a stream after the last bytes that will be sent have already been sent, and so we close using add with a 0 length data and fin set to true.

One of our tests ensuring timely stream close has been quite flaky, and on investigating it seems like a 0 length does not today cause the stream context to be reinserted with a new wake time, so a fin might linger longer than expected(?). For us I think this is really only a test related issue, but it seems like we may want to reinsert when the fin is set even if it's a zero length byte array? 