### PR TITLE
Update pico_sim to handle repetitions

### DIFF
--- a/p_sim/pico_sim.c
+++ b/p_sim/pico_sim.c
@@ -43,36 +43,30 @@ char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
 {
     int last_dot = -1;
     int last_slash = -1;
-    int spec_len = 0;
     int x = 0;
 
     for (int i = 0; s[i] != 0; i++) {
-        if (s[i] == '/' || s[i] == '\\') {
-            last_slash = i;
-        }
-        else if (s[i] == '.')
+        if (s[i] == '.')
         {
-            last_dot = i;
+            last_dot = x;
+        }
+        if ((x + 1) < (int)l_buf) {
+            buffer[x] = s[x + last_slash];
+            x++;
+        }
+        if (s[i] == '/' || s[i] == '\\') {
+            last_slash = i+1;
+            last_dot = -1;
+            x = 0;
         }
     }
-
-    if (last_slash >= 0) {
-        last_slash += 1;
+    if (last_dot > 0 &&
+        last_dot <= x) {
+        buffer[last_dot] = 0;
     }
     else {
-        last_slash = 0;
+        buffer[x] = 0;
     }
-
-    for (x = 0; (x + 1) < l_buf; x++) {
-        if (s[x + last_slash] == 0 || (x + last_slash) >= last_dot) {
-            break;
-        }
-        else {
-            buffer[x] = s[x + last_slash];
-        }
-    }
-    buffer[x] = 0;
-
     return buffer;
 }
 

--- a/p_sim/pico_sim.c
+++ b/p_sim/pico_sim.c
@@ -39,6 +39,45 @@ void usage(void)
     fprintf(stderr, "  -h       Print this message.\n");
 }
 
+char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
+{
+    int last_dot = -1;
+    int last_slash = -1;
+    int spec_len = 0;
+    int x = 0;
+
+    printf("%s, %d", s, (int)l_buf);
+
+    for (int i = 0; s[i] != 0; i++) {
+        if (s[i] == '/' || s[i] == '\\') {
+            last_slash = i;
+        }
+        else if (s[i] == '.')
+        {
+            last_dot = i;
+        }
+    }
+    printf("Last /: %d, last . : %d\n", last_slash, last_dot);
+    if (last_slash >= 0) {
+        last_slash += 1;
+    }
+    else {
+        last_slash = 0;
+    }
+
+    for (x = 0; (x + 1) < l_buf; x++) {
+        if (s[x + last_slash] == 0 || (x + last_slash) >= last_dot) {
+            break;
+        }
+        else {
+            buffer[x] = s[x + last_slash];
+        }
+    }
+    buffer[x] = 0;
+    printf("x: %d, string: %s\n", x, buffer);
+    return buffer;
+}
+
 int main(int argc, char** argv)
 {
     int ret = 0;
@@ -92,7 +131,9 @@ int main(int argc, char** argv)
             fprintf(stderr, "Error when processing file <%s>\n", spec_file_name);
         }
         else {
-            ret = picoquic_ns_n(&spec, stderr, nb_repeats);
+            char buffer[512];
+            ret = picoquic_ns_n(&spec, stderr, nb_repeats, 
+                get_spec_name(spec_file_name, buffer, sizeof(buffer)));
             fprintf(stderr, "picoquic_ns_n (%s, %d) returns %d\n", spec_file_name, nb_repeats, ret);
         }
         F = picoquic_file_close(F);

--- a/p_sim/pico_sim.c
+++ b/p_sim/pico_sim.c
@@ -46,8 +46,6 @@ char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
     int spec_len = 0;
     int x = 0;
 
-    printf("%s, %d", s, (int)l_buf);
-
     for (int i = 0; s[i] != 0; i++) {
         if (s[i] == '/' || s[i] == '\\') {
             last_slash = i;
@@ -57,7 +55,7 @@ char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
             last_dot = i;
         }
     }
-    printf("Last /: %d, last . : %d\n", last_slash, last_dot);
+
     if (last_slash >= 0) {
         last_slash += 1;
     }
@@ -74,7 +72,7 @@ char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
         }
     }
     buffer[x] = 0;
-    printf("x: %d, string: %s\n", x, buffer);
+
     return buffer;
 }
 
@@ -156,6 +154,7 @@ typedef enum {
     e_data_rate_in_gbps,
     e_latency,
     e_jitter,
+    e_wifi_jitter,
     e_queue_delay_max,
     e_l4s_max,
     e_icid,
@@ -191,6 +190,7 @@ spec_param_t params[] = {
     { e_data_rate_in_gbps, "data_rate_in_gbps", 17 },
     { e_latency, "latency" , 7},
     { e_jitter, "jitter", 6 },
+    { e_wifi_jitter, "wifi_jitter", 11 },
     { e_queue_delay_max, "queue_delay_max", 15 },
     { e_l4s_max, "l4s_max", 7 },
     { e_icid, "icid", 4 },
@@ -316,6 +316,9 @@ int parse_param(picoquic_ns_spec_t* spec, spec_param_enum p_e, char const* line)
             break;
         case e_jitter:
             ret = parse_u64(&spec->jitter, line);
+            break;
+        case e_wifi_jitter:
+            ret = parse_int(&spec->is_wifi_jitter, line);
             break;
         case e_queue_delay_max:
             ret = parse_u64(&spec->queue_delay_max, line);

--- a/p_sim/pico_sim.c
+++ b/p_sim/pico_sim.c
@@ -39,10 +39,10 @@ void usage(void)
     fprintf(stderr, "  -h       Print this message.\n");
 }
 
-char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
+static char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
 {
-    int last_dot = -1;
-    int last_slash = -1;
+    int last_dot = 0;
+    int after_slash = -1;
     int x = 0;
 
     for (int i = 0; s[i] != 0; i++) {
@@ -51,11 +51,11 @@ char const* get_spec_name(char const* s, char * buffer, size_t l_buf)
             last_dot = x;
         }
         if ((x + 1) < (int)l_buf) {
-            buffer[x] = s[x + last_slash];
+            buffer[x] = s[x + after_slash];
             x++;
         }
         if (s[i] == '/' || s[i] == '\\') {
-            last_slash = i+1;
+            after_slash = i+1;
             last_dot = -1;
             x = 0;
         }

--- a/picohttp/picoquic_ns.c
+++ b/picohttp/picoquic_ns.c
@@ -1011,6 +1011,13 @@ int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* sp
     return ret;
 }
 
+void picoquic_ns_make_random(picoquic_ns_ctx_t* cc_ctx)
+{
+    for (int i = 0; i < PICOQUIC_NS_NB_LINKS; i++) {
+        cc_ctx->link[i]->jitter_seed ^= picoquic_crypto_uniform_random(cc_ctx->q_ctx[0], UINT32_MAX);
+    }
+}
+
 int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id, char const * spec_name)
 {
     int ret = 0;
@@ -1025,6 +1032,10 @@ int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id, char con
             fprintf(err_fd, "Cannot allocate simulation context.\n");
         }
         ret = -1;
+    }
+
+    if (ret == 0 && rep_id > 0) {
+        picoquic_ns_make_random(cc_ctx);
     }
     while (ret == 0) {
         int is_active = 0;

--- a/picohttp/picoquic_ns.c
+++ b/picohttp/picoquic_ns.c
@@ -958,9 +958,12 @@ static int picoquic_ns_media_excluded(char const* media_excluded, char const* id
     return is_excluded;
 }
 
-int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* spec, FILE* err_fd)
+int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* spec, uint64_t * delay_average, uint64_t * delay_max, FILE* err_fd)
 {
     int ret = 0;
+
+    *delay_average = 0;
+    *delay_max = 0;
 
     for (size_t i = 0; i < quicperf_ctx->nb_scenarios; i++) {
         if (quicperf_ctx->scenarios[i].media_type != quicperf_media_batch &&
@@ -977,6 +980,9 @@ int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* sp
             else {
                 if (spec->media_latency_average > 0) {
                     double average_delay = ((double)report->sum_delays) / report->nb_frames_received;
+                    if (average_delay > (double)*delay_average) {
+                        *delay_average = (uint64_t)average_delay;
+                    }
                     if (average_delay > (double)spec->media_latency_average) {
                         if (err_fd != NULL) {
                             fprintf(stderr, "Media %zu (%s), latency average %f, expected %"PRIu64"\n",
@@ -987,6 +993,10 @@ int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* sp
                     }
                 }
                 if (spec->media_latency_max > 0 && report->max_delays > spec->media_latency_max) {
+
+                    if (report->max_delays > (double)*delay_max) {
+                        *delay_max = (uint64_t)report->max_delays;
+                    }
                     if (err_fd != NULL) {
                         fprintf(stderr, "Media %zu (%s), latency max %"PRIu64", expected %"PRIu64"\n",
                             i, quicperf_ctx->scenarios[i].id, report->max_delays, spec->media_latency_max);
@@ -1001,11 +1011,14 @@ int picoquic_ns_media_check(quicperf_ctx_t* quicperf_ctx, picoquic_ns_spec_t* sp
     return ret;
 }
 
-int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id)
+int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id, char const * spec_name)
 {
     int ret = 0;
     picoquic_ns_ctx_t* cc_ctx = picoquic_ns_create_ctx(spec, err_fd, rep_id);
     int nb_inactive = 0;
+    uint64_t delay_average = 0;
+    uint64_t delay_max = 0;
+    int is_success = 1;
 
     if (cc_ctx == NULL) {
         if (err_fd != NULL) {
@@ -1071,11 +1084,23 @@ int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id)
             fprintf(err_fd, "Simulated time %" PRIu64 ", expected %" PRIu64 "\n",
                 cc_ctx->simulated_time, spec->main_target_time);
         }
-        ret = -1;
+        is_success = 0;
     }
 
     if (ret == 0 && cc_ctx->client_ctx[0] != NULL) {
-        ret = picoquic_ns_media_check(cc_ctx->client_ctx[0]->quicperf_ctx, spec, err_fd);
+        if (picoquic_ns_media_check(cc_ctx->client_ctx[0]->quicperf_ctx, spec, &delay_average, &delay_max, err_fd) != 0) {
+            is_success = 0;
+        }
+    }
+
+    if (ret == 0) {
+        printf("%s, %d, %" PRIu64 ", %" PRIu64 ", %" PRIu64 ", %s\n",
+            is_success ? "Success" : "Fail", rep_id,
+            cc_ctx->simulated_time, delay_average, delay_max,
+            spec_name);
+        if (!is_success) {
+            ret = -1;
+        }
     }
 
     if (cc_ctx != NULL) {
@@ -1084,11 +1109,11 @@ int picoquic_ns_one(picoquic_ns_spec_t* spec, FILE* err_fd, int rep_id)
     return ret;
 }
 
-int picoquic_ns_n(picoquic_ns_spec_t* spec, FILE* err_fd, int nb_repeats)
+int picoquic_ns_n(picoquic_ns_spec_t* spec, FILE* err_fd, int nb_repeats, char const * spec_name)
 {
     int ret = 0;
     for (int i = 0; ret == 0 && i < nb_repeats; i++) {
-        if ((ret = picoquic_ns_one(spec, err_fd, i)) != 0) {
+        if ((ret = picoquic_ns_one(spec, err_fd, i, spec_name)) != 0) {
             if (err_fd != NULL) {
                 fprintf(err_fd, "Simulation repeat %d fails.\n", i);
                 break;
@@ -1100,5 +1125,5 @@ int picoquic_ns_n(picoquic_ns_spec_t* spec, FILE* err_fd, int nb_repeats)
 
 int picoquic_ns(picoquic_ns_spec_t* spec, FILE* err_fd)
 {
-    return picoquic_ns_n(spec, err_fd, 1);
+    return picoquic_ns_n(spec, err_fd, 1, "");
 }

--- a/picohttp/picoquic_ns.h
+++ b/picohttp/picoquic_ns.h
@@ -98,7 +98,7 @@ typedef struct st_picoquic_ns_spec_t {
 } picoquic_ns_spec_t;
 
 int picoquic_ns(picoquic_ns_spec_t* spec, FILE* err_fd);
-int picoquic_ns_n(picoquic_ns_spec_t* spec, FILE* err_fd, int nb_repeats);
+int picoquic_ns_n(picoquic_ns_spec_t* spec, FILE* err_fd, int nb_repeats, char const * spec_name);
 
 #ifdef __cplusplus
 }

--- a/picoquictest/cc_compete_test.c
+++ b/picoquictest/cc_compete_test.c
@@ -255,7 +255,7 @@ int cc_ns_media_repeat_test(void)
         ret = -1;
     }
     else {
-        ret = picoquic_ns_n(&spec, err_fd, 5);
+        ret = picoquic_ns_n(&spec, err_fd, 5, "media_test");
         picoquic_file_close(err_fd);
     }
     return ret;

--- a/picoquictest/picoquictest.vcxproj
+++ b/picoquictest/picoquictest.vcxproj
@@ -187,7 +187,6 @@
     <ClCompile Include="picolog_test.c" />
     <ClCompile Include="picomask_test.c" />
     <ClCompile Include="picoquic_lb_test.c" />
-    <ClCompile Include="picoquic_ns.c" />
     <ClCompile Include="pn2pn64test.c" />
     <ClCompile Include="qlog_frame_test.c" />
     <ClCompile Include="qlog_test.c" />

--- a/picoquictest/picoquictest.vcxproj.filters
+++ b/picoquictest/picoquictest.vcxproj.filters
@@ -198,9 +198,6 @@
     <ClCompile Include="cc_compete_test.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="picoquic_ns.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="ech_test.c">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
Update the pico_sim application to log independent qlog traces for each repetition of a simulation, and to provide a summary of each execution on the standard output.