### PR TITLE
Install picosplay.h with HTTP headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(PICOHTTP_LIBRARY_FILES
     picohttp/wt_baton.c)
 
 set(PICOHTTP_HEADERS
+     picoquic/picosplay.h
      picohttp/h3zero.h
      picohttp/h3zero_common.h
      picohttp/h3zero_uri.h


### PR DESCRIPTION
`h3zero_common.h` is installed as part of `PICOHTTP_HEADERS`, but it tries to include `picosplay.h`, which was only listed as a private core header.

This adds `picosplay.h` to the installed HTTP header set so downstream consumers can include installed HTTP/WebTransport headers such as `pico_webtransport.h` without needing the picoquic source tree in their include path.