### PR TITLE
Release capsule before closing baton connection.

### DIFF
--- a/picohttp/wt_baton.c
+++ b/picohttp/wt_baton.c
@@ -348,6 +348,8 @@ int wt_baton_stream_data(picoquic_cnx_t* cnx,
                 stream_ctx->ps.stream_state.is_fin_received = 1;
                 baton_ctx->baton_state = wt_baton_state_closed;
                 if (baton_ctx->is_client) {
+                    /* Most baton memory is allocated on the stack, but not the capsule! */
+                    picowt_release_capsule(&baton_ctx->capsule);
                     ret = picoquic_close(cnx, 0);
                 }
                 else {


### PR DESCRIPTION
In some racy conditions, we observed a memory leak when running the "baton_reset" test. This leak was due to receiving a capsule in "half closed" state, falsifying the belief that the capsule buffer was already freed. Freeing it before closing the connection fixes the 37 bytes leak.