### PR TITLE
sockloop: drop system <linux/io_uring.h> include

### DIFF
--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -82,7 +82,6 @@
 #include <netinet/in.h>
 
 #if defined(PICOQUIC_WITH_IO_URING)
-#include <linux/io_uring.h>
 #include <liburing.h>
 #else
 #ifndef PICOQUIC_USES_SELECT


### PR DESCRIPTION
`sockloop.c` includes `<linux/io_uring.h>` from `linux-libc-dev` immediately before `<liburing.h>`. They share include guard `LINUX_IO_URING_H`; whichever wins, the other is silently skipped.

On hosts with older `linux-libc-dev` (Ubuntu 22.04 ships 5.15-era uapi), the kernel header wins and the newer types/enums in `liburing.h` inline functions (`struct io_uring_buf_ring`, `IORING_OP_MSG_RING`, `IORING_FILE_INDEX_ALLOC`, `IORING_OP_SOCKET`, `IORING_SETUP_CQE32`, ...) are undefined — dozens of compile errors.

`liburing.h` pulls in its bundled `liburing/io_uring.h` which is a strict superset of the kernel uapi. Dropping the explicit system include lets the bundled header define the guard with full definitions and removes the distro-uapi dependency.

Tested: builds clean on Ubuntu 22.04 with `linux-libc-dev` older than the bundled `liburing`.