### PR TITLE
Per-stream retirement callback (stream_released) + h3zero forwarding

### DIFF
--- a/picohttp/h3zero_common.c
+++ b/picohttp/h3zero_common.c
@@ -1967,6 +1967,25 @@ int h3zero_callback(picoquic_cnx_t* cnx,
 			* after the limits for unidir streams are known */
 			ret = h3zero_protocol_init_safe(cnx, ctx);
 			break;
+		case picoquic_callback_stream_released:
+			/* picoquic patch 0003 fires this per-stream when fully
+			 * retired. Forward to the registered path callback as
+			 * picohttp_callback_free so the app can release per-
+			 * stream context mid-session, then delete h3zero's own
+			 * stream_ctx. Without this, apps can only clean at
+			 * session close (picosplay_empty_tree). */
+			if (stream_ctx == NULL) {
+				stream_ctx = h3zero_find_stream(ctx, stream_id);
+			}
+			if (stream_ctx != NULL) {
+				if (stream_ctx->path_callback != NULL) {
+					(void)stream_ctx->path_callback(cnx, NULL, 0,
+						picohttp_callback_free,
+						stream_ctx, stream_ctx->path_callback_ctx);
+				}
+				h3zero_delete_stream(cnx, ctx, stream_ctx);
+			}
+			break;
 		default:
 			/* unexpected -- just ignore. */
 			break;

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -124,6 +124,15 @@ int picoquic_delete_stream_if_closed(picoquic_cnx_t* cnx, picoquic_stream_head_t
     if (stream->is_closed && (
         (!IS_BIDIR_STREAM_ID(stream->stream_id) && !IS_LOCAL_STREAM_ID(stream->stream_id, cnx->client_mode)) ||
         picoquic_is_stream_acked(stream))) {
+        /* Notify application that the stream is fully retired and any
+         * per-stream app context tied to this stream_id can be freed.
+         * Fired only if the app took ownership (non-NULL ctx). Return
+         * value ignored: stream is about to be deleted regardless. */
+        if (stream->app_stream_ctx != NULL && cnx->callback_fn != NULL) {
+            (void)cnx->callback_fn(cnx, stream->stream_id, NULL, 0,
+                picoquic_callback_stream_released,
+                cnx->callback_ctx, stream->app_stream_ctx);
+        }
         picoquic_delete_stream(cnx, stream);
     }
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -355,7 +355,10 @@ typedef enum {
     picoquic_callback_path_quality_changed, /* Some path quality parameters have changed */
     picoquic_callback_path_address_observed, /* The peer has reported an address for the path */
     picoquic_callback_app_wakeup, /* wakeup timer set by application has expired */
-    picoquic_callback_next_path_allowed /* There are enough path_id and connection ID available for the next path */
+    picoquic_callback_next_path_allowed, /* There are enough path_id and connection ID available for the next path */
+    picoquic_callback_stream_released /* Stream fully retired: bytes=NULL, len=0,
+                                       * stream_ctx = the app_stream_ctx the app set;
+                                       * picoquic will not call back with this stream_ctx again. */
 } picoquic_call_back_event_t;
 
 typedef struct st_picoquic_tp_preferred_address_t {

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -1409,6 +1409,16 @@ void picoquic_unlink_app_stream_ctx(picoquic_cnx_t* cnx, uint64_t stream_id);
 int picoquic_mark_active_stream(picoquic_cnx_t* cnx,
     uint64_t stream_id, int is_active, void* v_stream_ctx);
 
+/* Mark stream as active without touching app_stream_ctx. Use when the
+ * caller has no opinion on the ctx (e.g. a layered stack where a lower
+ * layer like h3zero already set app_stream_ctx, and a higher layer
+ * uses prepare_to_send for byte transfer and only needs to wake the
+ * worker). picoquic_set_app_stream_ctx / picoquic_unlink_app_stream_ctx
+ * remain the explicit set / clear APIs.
+ */
+int picoquic_mark_active_stream_v2(picoquic_cnx_t* cnx,
+    uint64_t stream_id, int is_active);
+
 /* Handling of stream packetisation and head-of-line blocking:
 * 
 * When preparing a packet, if a stream is available, picoquic will fill the

--- a/picoquic/streams.c
+++ b/picoquic/streams.c
@@ -246,6 +246,36 @@ int picoquic_mark_active_stream(picoquic_cnx_t* cnx,
     return ret;
 }
 
+int picoquic_mark_active_stream_v2(picoquic_cnx_t* cnx,
+    uint64_t stream_id, int is_active)
+{
+    int ret = 0;
+    picoquic_stream_head_t* stream;
+    PICOQUIC_THREAD_CHECK(cnx->quic);
+
+    stream = picoquic_find_stream_for_writing(cnx, stream_id, &ret);
+    if (ret == 0) {
+        if (is_active) {
+            if (!stream->fin_requested &&
+                (!stream->reset_requested || picoquic_check_sack_list(&stream->sack_list, 0, stream->reliable_size) == 0) &&
+                cnx->callback_fn != NULL) {
+                if (!stream->is_active) {
+                    stream->is_active = 1;
+                    picoquic_reinsert_by_wake_time(cnx->quic, cnx, picoquic_get_quic_time(cnx->quic));
+                }
+            }
+            else {
+                ret = PICOQUIC_ERROR_CANNOT_SET_ACTIVE_STREAM;
+            }
+        }
+        else {
+            stream->is_active = 0;
+        }
+    }
+
+    return ret;
+}
+
 int picoquic_set_stream_not_coalesced(picoquic_cnx_t* cnx, uint64_t stream_id, int is_not_coalesced)
 {
     int ret = 0;


### PR DESCRIPTION
Apps with per-stream context have no way to know when picoquic has fully retired a stream. `picoquic_unlink_app_stream_ctx` only nulls the pointer; it doesn't tell the app *when*. `picoquic_is_stream_acked` is internal to frames.c. Best the app can do today is bulk-free at `picoquic_callback_close` — accumulating state for the full connection lifetime, pathological for workloads with high mid-session stream churn.

Two commits:

**1. Add `picoquic_callback_stream_released` + h3zero forwarding**

Fires from `picoquic_delete_stream_if_closed` just before the stream is deleted, when `app_stream_ctx` is non-NULL. Pure receivers (FIN/RESET received), senders, and bidi all get notified at the right moment — when picoquic is confident no further callback will reference this `stream_ctx`. Callback return value is ignored: the stream is about to be deleted regardless.

`h3zero_callback` forwards the new event as `picohttp_callback_free` to the registered path callback, then deletes its own `stream_ctx` (mirrors the connection-close `picosplay_empty_tree` path). Without this, apps registered via path callbacks can only release per-stream state at session close.

**2. `picoquic_mark_active_stream`: NULL ctx means "do not change"**

Layered stacks hit a clobber path: h3zero (or picowt) sets `app_stream_ctx` at stream-create time, then a higher layer that uses prepare_to_send calls `picoquic_mark_active_stream(.., NULL)` to wake the worker (no ctx opinion). `mark_active_stream`'s unconditional assignment wipes h3zero's pointer. The new `stream_released` callback then fires with `app_stream_ctx == NULL` and the layered stack never learns about the retirement.

Treating NULL as "do not change" fixes the clobber. `picoquic_unlink_app_stream_ctx` remains the explicit-clear API. Documented behaviour of `mark_active_stream` (picoquic.h:1373) does not specify NULL semantics, so this is not a documented-behaviour change.

Does NOT modify `picoquic_add_to_stream_with_ctx` (same clobber pattern). Its NULL-via-wrapper `picoquic_add_to_stream` IS documented at picoquic.h:1500 to "erase the app_stream_ctx value" — that one stays.

**Note for quicperf:** `picohttp/quicperf.c:1000` calls `mark_active_stream(.., 0, NULL)` as an explicit deactivate-and-clear-ctx before delete. After this change `app_stream_ctx` is preserved, leaving a dangling pointer to the about-to-be-freed `quicperf_stream_ctx_t`. quicperf should add a `picoquic_unlink_app_stream_ctx` alongside. Not bundled here so the policy change stays single-purpose; happy to add it to this PR on request.

**Alternate approach:** keep `mark_active_stream` semantics, push the lookup burden to apps — they call `h3zero_find_stream` before `mark_active` and pass the resulting `stream_ctx`. Per-callback O(log N) splay-tree cost; ~0.05% CPU on a 2.5 Gbps WT workload, so negligible. Doable but every layered-stack app would have to repeat the same workaround.

**Tested:** `picoquic_ct` 515/515 + `picohttp_ct` 82/82 pass on this branch.