### PR TITLE
Proof of concept for ACK rate reduction

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -2887,7 +2887,16 @@ uint64_t picoquic_compute_ack_delay_max(picoquic_cnx_t* cnx, uint64_t rtt, uint6
     if (ack_delay_max < remote_min_ack_delay) {
         ack_delay_max = remote_min_ack_delay;
     }
-
+#if 1
+    if (ack_delay_max < 20000) {
+        if (rtt > 20000) {
+            ack_delay_max = 20000;
+        }
+        else {
+            ack_delay_max = rtt;
+        }
+    }
+#endif
     return ack_delay_max;
 }
 
@@ -2952,9 +2961,11 @@ void picoquic_compute_ack_gap_and_delay(picoquic_cnx_t* cnx, uint64_t rtt, uint6
             }
         }
     }
+#if 0
     if (cnx->path[0]->rtt_min < *ack_delay_max * 4 && *ack_gap > 32) {
         *ack_gap = 32;
     }
+#endif
 }
 
 /* In a multipath environment, a packet can carry acknowledgements for multiple paths.

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -59,7 +59,7 @@ extern "C" {
 #define PICOQUIC_INITIAL_MAX_RETRANSMIT_TIMER 1000000ull /* one second */
 #define PICOQUIC_LARGE_RETRANSMIT_TIMER 2000000ull /* two seconds */
 #define PICOQUIC_MIN_RETRANSMIT_TIMER 50000ull /* 50 ms */
-#define PICOQUIC_ACK_DELAY_MAX 10000ull /* 10 ms */
+#define PICOQUIC_ACK_DELAY_MAX 25000ull /* 10 ms */
 #define PICOQUIC_ACK_DELAY_MAX_DEFAULT 25000ull /* 25 ms, per protocol spec */
 #define PICOQUIC_ACK_DELAY_MIN 1000ull /* 1 ms */
 #define PICOQUIC_ACK_DELAY_MIN_MAX_VALUE 0xFFFFFFull /* max value that can be negotiated by peers */


### PR DESCRIPTION
This PR is just a proof of concept, showing that higher min and max ack delay can drive lower ACK rates. Run this PR if you want to evaluate the performance effect on an application. It does cause a number of regressions that the test suite finds, and is not in any way ready for merging in the main branch.