### PR TITLE
Debug simulation and check mark active handling

### DIFF
--- a/picohttp/picoquic_ns.c
+++ b/picohttp/picoquic_ns.c
@@ -937,7 +937,7 @@ static int picoquic_ns_media_excluded(char const* media_excluded, char const* id
 {
     int is_excluded = 0;
     size_t id_len = strlen(id);
-    while (*media_excluded != 0){
+    while (media_excluded != NULL && *media_excluded != 0){
         size_t to_next_comma = 0;
 
         while (*media_excluded == ' ' || *media_excluded == '\t') {

--- a/picohttp/quicperf.c
+++ b/picohttp/quicperf.c
@@ -1304,16 +1304,20 @@ int quicperf_prepare_to_send_media(picoquic_cnx_t* cnx, quicperf_ctx_t* ctx, qui
         available = (size_t)(send_limit - stream_ctx->frame_bytes_sent);
         stream_ctx->nb_frames_sent++;
 
+        /* Check whether this is the last frame for the stream */
         if (stream_ctx->nb_frames_sent >= stream_ctx->nb_frames) {
+            /* If this is the last frame, prepare to close the stream. */
             is_fin = 1;
             stream_ctx->is_activated = 0;
         }
         else {
+            /* If this is not the last frame, check whether the sender should wait before sending the next frame. */
             uint64_t current_time = picoquic_get_quic_time(picoquic_get_quic_ctx(cnx));
             if (stream_ctx->frequency > 0) {
                 stream_ctx->next_frame_time = stream_ctx->start_time + (stream_ctx->nb_frames_sent * 1000000) / stream_ctx->frequency;
             }
-            if (current_time < stream_ctx->next_frame_time){
+            if (current_time < stream_ctx->next_frame_time) {
+                /* the next frame cannot be sent immediately. Mark the stream as inactive/ */
                 stream_ctx->is_activated = 0;
                 if (ctx->stream_wakeup_time == 0 || ctx->stream_wakeup_time > stream_ctx->next_frame_time) {
                     ctx->stream_wakeup_time = stream_ctx->next_frame_time;
@@ -1324,6 +1328,9 @@ int quicperf_prepare_to_send_media(picoquic_cnx_t* cnx, quicperf_ctx_t* ctx, qui
         }
     }
 
+    /* The number of bytes available is the minimum of the number of remaining bytes
+     * for the frame and the length of the callback buffer.
+     */
     buffer = picoquic_provide_stream_data_buffer(context, available, is_fin, stream_ctx->is_activated);
     if (buffer != NULL) {
         size_t byte_index = 0;
@@ -1445,7 +1452,7 @@ int quicperf_server_timer(picoquic_cnx_t* cnx, quicperf_ctx_t* ctx, uint64_t cur
                         ret = picoquic_mark_active_stream(cnx, stream_ctx->stream_id, 1, stream_ctx);
                         stream_ctx->is_activated = 1;
                     }
-                    if (stream_ctx->next_frame_time < next_wakeup_time) {
+                    else {
                         next_wakeup_time = stream_ctx->next_frame_time;
                     }
                 }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -1869,6 +1869,9 @@ uint8_t * picoquic_format_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head
                         if (is_still_active != NULL) {
                             *is_still_active = stream_data_context.is_still_active;
                         }
+                        if (!stream->is_active) {
+                            picoquic_update_output_stream(cnx, stream);
+                        }
                     }
                 }
             }

--- a/picoquictest/cc_compete_test.c
+++ b/picoquictest/cc_compete_test.c
@@ -206,7 +206,7 @@ int cc_ns_media_test(void)
     spec.qlog_dir = ".";
     spec.qperf_log = "./ns_qperflog.csv";
     spec.media_stats_start = 200000;
-    spec.media_latency_average = 30500;
+    spec.media_latency_average = 35000;
     spec.media_latency_max = 50000;
     spec.media_excluded = "vhigh, vmid,  vlast";
 
@@ -245,7 +245,7 @@ int cc_ns_media_repeat_test(void)
     spec.qlog_dir = ".";
     spec.qperf_log = "./ns_qperflog.csv";
     spec.media_stats_start = 200000;
-    spec.media_latency_average = 30500;
+    spec.media_latency_average = 35000;
     spec.media_latency_max = 50000;
     spec.media_excluded = "vhigh, vmid,  vlast";
 

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -634,7 +634,7 @@ int quicperf_multi_test(void)
         250, /* nb_frames_received_min */
         250, /* nb_frames_received_max */
         20000, /* average_delay_min */
-        26000, /* average_delay_max */
+        28000, /* average_delay_max */
         100000, /* max_delay */
         20000, /* min_delay */
         },


### PR DESCRIPTION
Check the handling of media streams in the quicperf code. Found out that in some case the transition between active and inactive state was too loose. Fixed that.

Checked that streams that are marked inactive in the "prepare to send" callback are removed from the output list.

The changes in the handling of medias makes the simulation closer to the media over QUIC applications. It also results in small changes in timing in the multi media simulations. The expected values for three different media tests had to be updated.