### PR TITLE
[codex] Test installed h3zero common header

### DIFF
--- a/ci/embedding-test/install_test/main_http.c
+++ b/ci/embedding-test/install_test/main_http.c
@@ -1,4 +1,4 @@
-#include <h3zero.h>
+#include <h3zero_common.h>
 #include <stdio.h>
 
 int main(void)


### PR DESCRIPTION
## Summary

- Exercise the installed `h3zero_common.h` header in the embedding install smoke test.
- Keep coverage on the header dependency that requires installed `picosplay.h` to be present beside the HTTP headers.

## Root Cause

`h3zero_common.h` includes `picosplay.h`, but the existing installed-package HTTP smoke test only included `h3zero.h`. That meant an install tree missing the transitive sibling header could pass the embedding test while downstream consumers failed at compile time.

## Validation

- `git diff --check -- ci/embedding-test/install_test/main_http.c`
- Staged install-style header compile: `cc -I "$tmp/include" -x c -fsyntax-only ci/embedding-test/install_test/main_http.c`
- Attempted `CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu) ci/embedding-test/run.sh "$(pwd)"`; local run failed before the changed install test due to AppleClang/Homebrew architecture mismatch (`x86_64` build vs `arm64` OpenSSL/Brotli).
- Retried with `-DCMAKE_OSX_ARCHITECTURES=arm64`; the run built picoquic but hung in Apple `ld` with 0%% CPU for several minutes and was stopped.
