### PR TITLE
tls session resumption key rotation

### DIFF
--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -665,6 +665,10 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
 
 void picoquic_free(picoquic_quic_t* quic);
 
+/* Server state keys protect TLS tickets and tokens. key[0] selects slot 0/1; last set is active. */
+int picoquic_set_server_state_key(picoquic_quic_t* quic,
+    const uint8_t* server_state_key, size_t server_state_key_length);
+
 /* Preference for low memory options.
  * setting this flag instructs picoquic to chose implementations of algorithms 
  * that use less memory while maintaining reasonable performance. For example,

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -665,9 +665,9 @@ picoquic_quic_t* picoquic_create(uint32_t max_nb_connections,
 
 void picoquic_free(picoquic_quic_t* quic);
 
-/* Server state keys protect TLS tickets and tokens. key[0] selects slot 0/1; last set is active. */
-int picoquic_set_server_state_key(picoquic_quic_t* quic,
-    const uint8_t* server_state_key, size_t server_state_key_length);
+/* Ticket keys protect TLS tickets and tokens. key[0] selects slot 0/1; last set is active. */
+int picoquic_set_ticket_key(picoquic_quic_t* quic,
+    const uint8_t* ticket_key, size_t ticket_key_length);
 
 /* Preference for low memory options.
  * setting this flag instructs picoquic to chose implementations of algorithms 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -573,11 +573,10 @@ typedef int (*picoquic_performance_log_fn)(picoquic_quic_t* quic, picoquic_cnx_t
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.
  */
-typedef struct st_picoquic_server_state_key_t {
+typedef struct st_picoquic_ticket_key_state_t {
     void* aead_encrypt_ctx;
     void* aead_decrypt_ctx;
-    size_t checksum_length;
-} picoquic_server_state_key_t;
+} picoquic_ticket_key_state_t;
 
 typedef struct st_picoquic_quic_t {
     void* tls_master_ctx;
@@ -683,8 +682,8 @@ typedef struct st_picoquic_quic_t {
     picoquic_connection_id_cb_fn cnx_id_callback_fn;
     void* cnx_id_callback_ctx;
 
-    picoquic_server_state_key_t server_state_key[2];
-    unsigned int server_state_key_active_slot : 1;
+    picoquic_ticket_key_state_t ticket_key_state[2];
+    unsigned int ticket_key_state_active_slot : 1;
     void ** retry_integrity_sign_ctx;
     void ** retry_integrity_verify_ctx;
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -684,7 +684,7 @@ typedef struct st_picoquic_quic_t {
     void* cnx_id_callback_ctx;
 
     picoquic_server_state_key_t server_state_key[2];
-    uint8_t server_state_key_active_slot;
+    uint8_t server_state_key_active_slot : 1;
     void ** retry_integrity_sign_ctx;
     void ** retry_integrity_verify_ctx;
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -684,7 +684,7 @@ typedef struct st_picoquic_quic_t {
     void* cnx_id_callback_ctx;
 
     picoquic_server_state_key_t server_state_key[2];
-    uint8_t server_state_key_active_slot : 1;
+    unsigned int server_state_key_active_slot : 1;
     void ** retry_integrity_sign_ctx;
     void ** retry_integrity_verify_ctx;
 

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -573,6 +573,12 @@ typedef int (*picoquic_performance_log_fn)(picoquic_quic_t* quic, picoquic_cnx_t
 /* QUIC context, defining the tables of connections,
  * open sockets, etc.
  */
+typedef struct st_picoquic_server_state_key_t {
+    void* aead_encrypt_ctx;
+    void* aead_decrypt_ctx;
+    size_t checksum_length;
+} picoquic_server_state_key_t;
+
 typedef struct st_picoquic_quic_t {
     void* tls_master_ctx;
     picoquic_stream_data_cb_fn default_callback_fn;
@@ -677,8 +683,8 @@ typedef struct st_picoquic_quic_t {
     picoquic_connection_id_cb_fn cnx_id_callback_fn;
     void* cnx_id_callback_ctx;
 
-    void* aead_encrypt_ticket_ctx;
-    void* aead_decrypt_ticket_ctx;
+    picoquic_server_state_key_t server_state_key[2];
+    uint8_t server_state_key_active_slot;
     void ** retry_integrity_sign_ctx;
     void ** retry_integrity_verify_ctx;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1078,7 +1078,7 @@ void picoquic_free(picoquic_quic_t* quic)
         picoquic_delete_retry_protection_contexts(quic);
 
         for (int i = 0; i < 2; i++) {
-            picoquic_dispose_server_state_key(&quic->server_state_key[i]);
+            picoquic_dispose_ticket_key_state(&quic->ticket_key_state[i]);
         }
 
         if (quic->default_alpn != NULL) {

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1077,14 +1077,8 @@ void picoquic_free(picoquic_quic_t* quic)
         /* Delete TLS and AEAD cntexts */
         picoquic_delete_retry_protection_contexts(quic);
 
-        if (quic->aead_encrypt_ticket_ctx != NULL) {
-            picoquic_aead_free(quic->aead_encrypt_ticket_ctx);
-            quic->aead_encrypt_ticket_ctx = NULL;
-        }
-
-        if (quic->aead_decrypt_ticket_ctx != NULL) {
-            picoquic_aead_free(quic->aead_decrypt_ticket_ctx);
-            quic->aead_decrypt_ticket_ctx = NULL;
+        for (int i = 0; i < 2; i++) {
+            picoquic_dispose_server_state_key(&quic->server_state_key[i]);
         }
 
         if (quic->default_alpn != NULL) {

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -3073,8 +3073,7 @@ void picoquic_tls_set_use_exporter(picoquic_quic_t* quic, int use_exporter) {
  * - 64 bit random sequence number.
  * - Encrypted value of the token.
  * - AEAD checksum.
- * The most significant bit of the random number is set to 1 (0x80) for a "new token",
- * and to zero for a "retry token".
+ * The top bit identifies server state key slot 0 or 1; the next bit marks NEW_TOKEN.
  * When invoking AEAD, the sequence number is used to update the IV, and the IP address
  * is passed as "authenticated" data. The 64 bit random number alleviates the concern of
  * reusing the same AEAD key twice. The authenticated data ensures that if the token is
@@ -3089,8 +3088,9 @@ static int picoquic_server_encrypt_retry_token(picoquic_quic_t * quic, const str
     uint64_t sequence;
     uint8_t* auth_data;
     size_t auth_data_length;
+    picoquic_server_state_key_t* key = &quic->server_state_key[quic->server_state_key_active_slot];
 
-    if (text_length + 1u + 16u > token_max) {
+    if (!picoquic_server_state_key_is_set(key) || text_length + 8u + key->checksum_length > token_max) {
         ret = -1;
         *token_length = 0;
     }
@@ -3104,17 +3104,17 @@ static int picoquic_server_encrypt_retry_token(picoquic_quic_t * quic, const str
             auth_data = (uint8_t*)&((struct sockaddr_in6*)addr_peer)->sin6_addr;
             auth_data_length = 16;
         }
-        picoquic_crypto_random(quic, token, 8);
+        sequence = picoquic_server_state_random_sequence(quic->server_state_key_active_slot);
         if (is_new_token) {
-            token[0] |= 0x80;
+            sequence |= PICOQUIC_TOKEN_TYPE_NEW;
         }
         else {
-            token[0] &= 0x7F;
+            sequence &= ~PICOQUIC_TOKEN_TYPE_NEW;
         }
-        sequence = PICOPARSE_64(token);
+        picoformat_64(token, sequence);
 
-        *token_length = (size_t)8u + picoquic_aead_encrypt_generic(token + 8, text, text_length,
-            sequence, auth_data, auth_data_length, quic->aead_encrypt_ticket_ctx);
+        *token_length = 8u + picoquic_aead_encrypt_generic(token + 8, text, text_length,
+            sequence, auth_data, auth_data_length, key->aead_encrypt_ctx);
     }
 
     return ret;
@@ -3142,13 +3142,19 @@ int picoquic_server_decrypt_retry_token(picoquic_quic_t* quic, const struct sock
         ret = -1;
     }
     else {
-        *is_new_token = ((token[0] & 0x80) == 0) ? 0: 1;
         sequence = PICOPARSE_64(token);
+        *is_new_token = ((sequence & PICOQUIC_TOKEN_TYPE_NEW) == 0) ? 0: 1;
 
-        *text_length = picoquic_aead_decrypt_generic(text, token+8, token_length-8,
-            sequence, auth_data, auth_data_length, quic->aead_decrypt_ticket_ctx);
-        if (*text_length >= token_length - 8) {
+        picoquic_server_state_key_t* key = &quic->server_state_key[PICOQUIC_SERVER_STATE_KEY_SLOT(sequence)];
+        if (!picoquic_server_state_key_is_set(key) || token_length < 8 + key->checksum_length) {
             ret = -1;
+        }
+        else {
+            *text_length = picoquic_aead_decrypt_generic(text, token+8, token_length-8,
+                sequence, auth_data, auth_data_length, key->aead_decrypt_ctx);
+            if (*text_length >= token_length - 8) {
+                ret = -1;
+            }
         }
     }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1237,7 +1237,7 @@ static int picoquic_server_state_key_is_set(picoquic_server_state_key_t* key)
     return key->aead_encrypt_ctx != NULL && key->aead_decrypt_ctx != NULL;
 }
 
-static uint64_t picoquic_server_state_random_sequence(uint8_t key_slot)
+static uint64_t picoquic_server_state_random_sequence(unsigned int key_slot)
 {
     uint64_t sequence;
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -909,7 +909,7 @@ void picoquic_log_crypto_errors(picoquic_cnx_t* cnx, int ret)
 }
 
 
-static int picoquic_server_setup_server_state_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length);
 
@@ -1990,7 +1990,7 @@ int picoquic_master_tlscontext(picoquic_quic_t* quic,
         }
 
         if (ret == 0) {
-            ret = picoquic_server_setup_server_state_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
+            ret = picoquic_setup_server_state_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
         }
 
         if (ret == 0) {
@@ -2611,7 +2611,7 @@ void * picoquic_setup_test_aead_context(int is_encrypt, const uint8_t * secret, 
     return v_aead;
 }
 
-static int picoquic_server_setup_server_state_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length)
 {
@@ -2669,7 +2669,7 @@ int picoquic_set_server_state_key(picoquic_quic_t* quic,
     else {
         PICOQUIC_THREAD_CHECK(quic);
 
-        ret = picoquic_server_setup_server_state_aead_contexts(quic, NULL,
+        ret = picoquic_setup_server_state_aead_contexts(quic, NULL,
             server_state_key, server_state_key_length);
     }
 

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -909,7 +909,7 @@ void picoquic_log_crypto_errors(picoquic_cnx_t* cnx, int ret)
 }
 
 
-static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_setup_ticket_key_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length);
 
@@ -1230,25 +1230,20 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
  */
 
 #define PICOQUIC_TOKEN_TYPE_NEW 0x4000000000000000ull
-#define PICOQUIC_SERVER_STATE_KEY_SLOT(sequence) ((uint8_t)((sequence) >> 63))
+#define PICOQUIC_TICKET_KEY_SLOT(sequence) ((uint8_t)((sequence) >> 63))
+#define PICOQUIC_AEAD_TAG_SIZE(aead_context) (((ptls_aead_context_t*)(aead_context))->algo->tag_size)
 
-static int picoquic_server_state_key_is_set(picoquic_server_state_key_t* key)
+static int picoquic_ticket_key_state_is_set(picoquic_ticket_key_state_t* key)
 {
     return key->aead_encrypt_ctx != NULL && key->aead_decrypt_ctx != NULL;
 }
 
-static uint64_t picoquic_server_state_random_sequence(unsigned int key_slot)
+static uint64_t picoquic_ticket_key_random_sequence(unsigned int key_slot)
 {
-    uint64_t sequence;
-
-    do {
-        sequence = picoquic_public_random_64();
-    } while (PICOQUIC_SERVER_STATE_KEY_SLOT(sequence) != key_slot);
-
-    return sequence;
+    return (picoquic_public_random_64() & 0x7fffffffffffffffull) | (((uint64_t)key_slot & 1) << 63);
 }
 
-void picoquic_dispose_server_state_key(picoquic_server_state_key_t* key)
+void picoquic_dispose_ticket_key_state(picoquic_ticket_key_state_t* key)
 {
     if (key->aead_encrypt_ctx != NULL) {
         picoquic_aead_free(key->aead_encrypt_ctx);
@@ -1256,7 +1251,7 @@ void picoquic_dispose_server_state_key(picoquic_server_state_key_t* key)
     if (key->aead_decrypt_ctx != NULL) {
         picoquic_aead_free(key->aead_decrypt_ctx);
     }
-    memset(key, 0, sizeof(picoquic_server_state_key_t));
+    memset(key, 0, sizeof(picoquic_ticket_key_state_t));
 }
 
 int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_ticket_ctx,
@@ -1295,14 +1290,14 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
     picoformat_64(param_bytes, quic->default_tp.initial_max_stream_id_unidir);
 
     if (is_encrypt != 0) {
-        picoquic_server_state_key_t* key = &quic->server_state_key[quic->server_state_key_active_slot];
+        picoquic_ticket_key_state_t* key = &quic->ticket_key_state[quic->ticket_key_state_active_slot];
         /* Encoding*/
-        if (!picoquic_server_state_key_is_set(key)) {
+        if (!picoquic_ticket_key_state_is_set(key)) {
             ret = -1;
-        } else if ((ret = ptls_buffer_reserve(dst, 8 + 4 + src.len + key->checksum_length)) == 0) {
+        } else if ((ret = ptls_buffer_reserve(dst, 8 + 4 + src.len + PICOQUIC_AEAD_TAG_SIZE(key->aead_encrypt_ctx))) == 0) {
             /* Create and store the ticket sequence number */
             uint32_t version_number = picoquic_supported_versions[quic->cnx_in_progress->version_index].version;
-            uint64_t seq_num = picoquic_server_state_random_sequence(quic->server_state_key_active_slot);
+            uint64_t seq_num = picoquic_ticket_key_random_sequence(quic->ticket_key_state_active_slot);
             size_t start_off;
             size_t data_length;
 
@@ -1323,14 +1318,14 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             quic->cnx_in_progress->issued_ticket_id = seq_num;
         }
     } else {
-        picoquic_server_state_key_t* key = NULL;
+        picoquic_ticket_key_state_t* key = NULL;
         /* Decoding*/
         if (src.len >= 8) {
-            key = &quic->server_state_key[PICOQUIC_SERVER_STATE_KEY_SLOT(PICOPARSE_64(src.base))];
+            key = &quic->ticket_key_state[PICOQUIC_TICKET_KEY_SLOT(PICOPARSE_64(src.base))];
         }
-        if (key == NULL || !picoquic_server_state_key_is_set(key)) {
+        if (key == NULL || !picoquic_ticket_key_state_is_set(key)) {
             ret = -1;
-        } else if (src.len < 8 + 4 + key->checksum_length) {
+        } else if (src.len < 8 + 4 + PICOQUIC_AEAD_TAG_SIZE(key->aead_decrypt_ctx)) {
             ret = -1;
         } else if ((ret = ptls_buffer_reserve(dst, src.len)) == 0) {
             /* Decode the ticket sequence number */
@@ -1990,7 +1985,7 @@ int picoquic_master_tlscontext(picoquic_quic_t* quic,
         }
 
         if (ret == 0) {
-            ret = picoquic_setup_server_state_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
+            ret = picoquic_setup_ticket_key_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
         }
 
         if (ret == 0) {
@@ -2592,12 +2587,7 @@ void picoquic_cipher_free(void* cipher_context)
 
 size_t picoquic_aead_get_checksum_length(void* aead_context)
 {
-    size_t tag_size = ((ptls_aead_context_t*)aead_context)->algo->tag_size;
-    /* TODO: remove this temporary fix to deal with Feb 2019 change in picotls */
-    if (tag_size > 16) {
-        tag_size = 16;
-    }
-    return tag_size;
+    return PICOQUIC_AEAD_TAG_SIZE(aead_context);
 }
 
 /* Setting of encryption contexts for test */
@@ -2611,14 +2601,14 @@ void * picoquic_setup_test_aead_context(int is_encrypt, const uint8_t * secret, 
     return v_aead;
 }
 
-static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_setup_ticket_key_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length)
 {
     int ret = 0;
     uint8_t temp_secret[256]; /* secret_max */
     ptls_cipher_suite_t *cipher = picoquic_get_aes128gcm_sha256(0);
-    picoquic_server_state_key_t new_key = { 0 };
+    picoquic_ticket_key_state_t new_key = { 0 };
     uint8_t key_slot = 0;
 
     if (quic == NULL || ((secret == NULL || secret_length == 0) && tls_ctx == NULL)) {
@@ -2642,14 +2632,13 @@ static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
         }
 
         if (ret != 0) {
-            picoquic_dispose_server_state_key(&new_key);
+            picoquic_dispose_ticket_key_state(&new_key);
         }
         else {
-            new_key.checksum_length = picoquic_aead_get_checksum_length(new_key.aead_encrypt_ctx);
-            picoquic_dispose_server_state_key(&quic->server_state_key[key_slot]);
-            quic->server_state_key[key_slot] = new_key;
-            memset(&new_key, 0, sizeof(picoquic_server_state_key_t));
-            quic->server_state_key_active_slot = key_slot;
+            picoquic_dispose_ticket_key_state(&quic->ticket_key_state[key_slot]);
+            quic->ticket_key_state[key_slot] = new_key;
+            memset(&new_key, 0, sizeof(picoquic_ticket_key_state_t));
+            quic->ticket_key_state_active_slot = key_slot;
         }
 
         /* erase the temporary secret */
@@ -2658,19 +2647,19 @@ static int picoquic_setup_server_state_aead_contexts(picoquic_quic_t* quic,
     return ret;
 }
 
-int picoquic_set_server_state_key(picoquic_quic_t* quic,
-    const uint8_t* server_state_key, size_t server_state_key_length)
+int picoquic_set_ticket_key(picoquic_quic_t* quic,
+    const uint8_t* ticket_key, size_t ticket_key_length)
 {
     int ret = 0;
 
-    if (quic == NULL || server_state_key == NULL || server_state_key_length == 0) {
+    if (quic == NULL || ticket_key == NULL || ticket_key_length == 0) {
         ret = -1;
     }
     else {
         PICOQUIC_THREAD_CHECK(quic);
 
-        ret = picoquic_setup_server_state_aead_contexts(quic, NULL,
-            server_state_key, server_state_key_length);
+        ret = picoquic_setup_ticket_key_aead_contexts(quic, NULL,
+            ticket_key, ticket_key_length);
     }
 
     return ret;
@@ -3073,7 +3062,7 @@ void picoquic_tls_set_use_exporter(picoquic_quic_t* quic, int use_exporter) {
  * - 64 bit random sequence number.
  * - Encrypted value of the token.
  * - AEAD checksum.
- * The top bit identifies server state key slot 0 or 1; the next bit marks NEW_TOKEN.
+ * The top bit identifies ticket key slot 0 or 1; the next bit marks NEW_TOKEN.
  * When invoking AEAD, the sequence number is used to update the IV, and the IP address
  * is passed as "authenticated" data. The 64 bit random number alleviates the concern of
  * reusing the same AEAD key twice. The authenticated data ensures that if the token is
@@ -3088,9 +3077,10 @@ static int picoquic_server_encrypt_retry_token(picoquic_quic_t * quic, const str
     uint64_t sequence;
     uint8_t* auth_data;
     size_t auth_data_length;
-    picoquic_server_state_key_t* key = &quic->server_state_key[quic->server_state_key_active_slot];
+    picoquic_ticket_key_state_t* key = &quic->ticket_key_state[quic->ticket_key_state_active_slot];
 
-    if (!picoquic_server_state_key_is_set(key) || text_length + 8u + key->checksum_length > token_max) {
+    if (!picoquic_ticket_key_state_is_set(key) ||
+        text_length + 8u + PICOQUIC_AEAD_TAG_SIZE(key->aead_encrypt_ctx) > token_max) {
         ret = -1;
         *token_length = 0;
     }
@@ -3104,7 +3094,7 @@ static int picoquic_server_encrypt_retry_token(picoquic_quic_t * quic, const str
             auth_data = (uint8_t*)&((struct sockaddr_in6*)addr_peer)->sin6_addr;
             auth_data_length = 16;
         }
-        sequence = picoquic_server_state_random_sequence(quic->server_state_key_active_slot);
+        sequence = picoquic_ticket_key_random_sequence(quic->ticket_key_state_active_slot);
         if (is_new_token) {
             sequence |= PICOQUIC_TOKEN_TYPE_NEW;
         }
@@ -3145,8 +3135,9 @@ int picoquic_server_decrypt_retry_token(picoquic_quic_t* quic, const struct sock
         sequence = PICOPARSE_64(token);
         *is_new_token = ((sequence & PICOQUIC_TOKEN_TYPE_NEW) == 0) ? 0: 1;
 
-        picoquic_server_state_key_t* key = &quic->server_state_key[PICOQUIC_SERVER_STATE_KEY_SLOT(sequence)];
-        if (!picoquic_server_state_key_is_set(key) || token_length < 8 + key->checksum_length) {
+        picoquic_ticket_key_state_t* key = &quic->ticket_key_state[PICOQUIC_TICKET_KEY_SLOT(sequence)];
+        if (!picoquic_ticket_key_state_is_set(key) ||
+            token_length < 8 + PICOQUIC_AEAD_TAG_SIZE(key->aead_decrypt_ctx)) {
             ret = -1;
         }
         else {

--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -909,7 +909,7 @@ void picoquic_log_crypto_errors(picoquic_cnx_t* cnx, int ret)
 }
 
 
-int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_server_setup_server_state_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length);
 
@@ -1229,6 +1229,36 @@ int picoquic_client_hello_call_back(ptls_on_client_hello_t* on_hello_cb_ctx,
  * Should return 0 if the ticket is good, etc.
  */
 
+#define PICOQUIC_TOKEN_TYPE_NEW 0x4000000000000000ull
+#define PICOQUIC_SERVER_STATE_KEY_SLOT(sequence) ((uint8_t)((sequence) >> 63))
+
+static int picoquic_server_state_key_is_set(picoquic_server_state_key_t* key)
+{
+    return key->aead_encrypt_ctx != NULL && key->aead_decrypt_ctx != NULL;
+}
+
+static uint64_t picoquic_server_state_random_sequence(uint8_t key_slot)
+{
+    uint64_t sequence;
+
+    do {
+        sequence = picoquic_public_random_64();
+    } while (PICOQUIC_SERVER_STATE_KEY_SLOT(sequence) != key_slot);
+
+    return sequence;
+}
+
+void picoquic_dispose_server_state_key(picoquic_server_state_key_t* key)
+{
+    if (key->aead_encrypt_ctx != NULL) {
+        picoquic_aead_free(key->aead_encrypt_ctx);
+    }
+    if (key->aead_decrypt_ctx != NULL) {
+        picoquic_aead_free(key->aead_decrypt_ctx);
+    }
+    memset(key, 0, sizeof(picoquic_server_state_key_t));
+}
+
 int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_ticket_ctx,
     ptls_t* UNUSED(tls), int is_encrypt, ptls_buffer_t* dst, ptls_iovec_t src)
 {
@@ -1265,14 +1295,14 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
     picoformat_64(param_bytes, quic->default_tp.initial_max_stream_id_unidir);
 
     if (is_encrypt != 0) {
-        ptls_aead_context_t* aead_enc = (ptls_aead_context_t*)quic->aead_encrypt_ticket_ctx;
+        picoquic_server_state_key_t* key = &quic->server_state_key[quic->server_state_key_active_slot];
         /* Encoding*/
-        if (aead_enc == NULL) {
+        if (!picoquic_server_state_key_is_set(key)) {
             ret = -1;
-        } else if ((ret = ptls_buffer_reserve(dst, 8 + 4 + src.len + aead_enc->algo->tag_size)) == 0) {
+        } else if ((ret = ptls_buffer_reserve(dst, 8 + 4 + src.len + key->checksum_length)) == 0) {
             /* Create and store the ticket sequence number */
             uint32_t version_number = picoquic_supported_versions[quic->cnx_in_progress->version_index].version;
-            uint64_t seq_num = picoquic_public_random_64();
+            uint64_t seq_num = picoquic_server_state_random_sequence(quic->server_state_key_active_slot);
             size_t start_off;
             size_t data_length;
 
@@ -1286,26 +1316,32 @@ int picoquic_server_encrypt_ticket_call_back(ptls_encrypt_ticket_t* encrypt_tick
             picoformat_32(dst->base + dst->off + data_length, version_number);
             data_length += 4;
             /* Run AEAD encryption */
-            dst->off += ptls_aead_encrypt(aead_enc, dst->base + dst->off,
-                dst->base + start_off, data_length, seq_num, param_verif, sizeof(param_verif));
+            dst->off += picoquic_aead_encrypt_generic(dst->base + dst->off,
+                dst->base + start_off, data_length, seq_num, param_verif,
+                sizeof(param_verif), key->aead_encrypt_ctx);
             /* Remember issued ticket ID in connection context */
             quic->cnx_in_progress->issued_ticket_id = seq_num;
         }
     } else {
-        ptls_aead_context_t* aead_dec = (ptls_aead_context_t*)quic->aead_decrypt_ticket_ctx;
+        picoquic_server_state_key_t* key = NULL;
         /* Decoding*/
-        if (aead_dec == NULL) {
+        if (src.len >= 8) {
+            key = &quic->server_state_key[PICOQUIC_SERVER_STATE_KEY_SLOT(PICOPARSE_64(src.base))];
+        }
+        if (key == NULL || !picoquic_server_state_key_is_set(key)) {
             ret = -1;
-        } else if (src.len < 8 + 4 + aead_dec->algo->tag_size) {
+        } else if (src.len < 8 + 4 + key->checksum_length) {
             ret = -1;
         } else if ((ret = ptls_buffer_reserve(dst, src.len)) == 0) {
             /* Decode the ticket sequence number */
             uint64_t seq_num = PICOPARSE_64(src.base);
+            size_t cipher_length = src.len - 8;
             /* Decrypt */
-            size_t decrypted = ptls_aead_decrypt(aead_dec, dst->base + dst->off,
-                src.base + 8, src.len - 8, seq_num, param_verif, sizeof(param_verif));
+            size_t decrypted = picoquic_aead_decrypt_generic(dst->base + dst->off,
+                src.base + 8, cipher_length, seq_num, param_verif,
+                sizeof(param_verif), key->aead_decrypt_ctx);
 
-            if (decrypted > src.len - 8) {
+            if (decrypted < 4 || decrypted > cipher_length) {
                 /* decryption error */
                 ret = -1;
                 picoquic_log_app_message(quic->cnx_in_progress, "%s",
@@ -1954,7 +1990,7 @@ int picoquic_master_tlscontext(picoquic_quic_t* quic,
         }
 
         if (ret == 0) {
-            ret = picoquic_server_setup_ticket_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
+            ret = picoquic_server_setup_server_state_aead_contexts(quic, ctx, ticket_key, ticket_key_length);
         }
 
         if (ret == 0) {
@@ -2575,15 +2611,19 @@ void * picoquic_setup_test_aead_context(int is_encrypt, const uint8_t * secret, 
     return v_aead;
 }
 
-int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t* quic,
+static int picoquic_server_setup_server_state_aead_contexts(picoquic_quic_t* quic,
     ptls_context_t* tls_ctx,
     const uint8_t* secret, size_t secret_length)
 {
     int ret = 0;
     uint8_t temp_secret[256]; /* secret_max */
     ptls_cipher_suite_t *cipher = picoquic_get_aes128gcm_sha256(0);
+    picoquic_server_state_key_t new_key = { 0 };
+    uint8_t key_slot = 0;
 
-    if (cipher->hash->digest_size > sizeof(temp_secret)) {
+    if (quic == NULL || ((secret == NULL || secret_length == 0) && tls_ctx == NULL)) {
+        ret = -1;
+    } else if (cipher->hash->digest_size > sizeof(temp_secret)) {
         ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
     } else {
         if (secret != NULL && secret_length > 0) {
@@ -2593,15 +2633,46 @@ int picoquic_server_setup_ticket_aead_contexts(picoquic_quic_t* quic,
             tls_ctx->random_bytes(temp_secret, cipher->hash->digest_size);
         }
 
-        /* Create the AEAD contexts */
-        ret = picoquic_set_aead_from_secret(&quic->aead_encrypt_ticket_ctx, cipher, 1, temp_secret, "random label");
         if (ret == 0) {
-            ret = picoquic_set_aead_from_secret(&quic->aead_decrypt_ticket_ctx, cipher, 0, temp_secret, "random label");
+            key_slot = temp_secret[0] >> 7;
+            ret = picoquic_set_aead_from_secret(&new_key.aead_encrypt_ctx, cipher, 1, temp_secret, "random label");
+        }
+        if (ret == 0) {
+            ret = picoquic_set_aead_from_secret(&new_key.aead_decrypt_ctx, cipher, 0, temp_secret, "random label");
+        }
+
+        if (ret != 0) {
+            picoquic_dispose_server_state_key(&new_key);
+        }
+        else {
+            new_key.checksum_length = picoquic_aead_get_checksum_length(new_key.aead_encrypt_ctx);
+            picoquic_dispose_server_state_key(&quic->server_state_key[key_slot]);
+            quic->server_state_key[key_slot] = new_key;
+            memset(&new_key, 0, sizeof(picoquic_server_state_key_t));
+            quic->server_state_key_active_slot = key_slot;
         }
 
         /* erase the temporary secret */
         ptls_clear_memory(temp_secret, cipher->hash->digest_size);
     }
+    return ret;
+}
+
+int picoquic_set_server_state_key(picoquic_quic_t* quic,
+    const uint8_t* server_state_key, size_t server_state_key_length)
+{
+    int ret = 0;
+
+    if (quic == NULL || server_state_key == NULL || server_state_key_length == 0) {
+        ret = -1;
+    }
+    else {
+        PICOQUIC_THREAD_CHECK(quic);
+
+        ret = picoquic_server_setup_server_state_aead_contexts(quic, NULL,
+            server_state_key, server_state_key_length);
+    }
+
     return ret;
 }
 

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -135,6 +135,8 @@ void picoquic_tls_set_verify_certificate_callback(picoquic_quic_t* quic,
 
 void picoquic_dispose_verify_certificate_callback(picoquic_quic_t* quic);
 
+void picoquic_dispose_server_state_key(picoquic_server_state_key_t* key);
+
 void picoquic_tls_set_client_authentication(picoquic_quic_t* quic, int client_authentication);
 
 int picoquic_tls_client_authentication_activated(picoquic_quic_t* quic);

--- a/picoquic/tls_api.h
+++ b/picoquic/tls_api.h
@@ -135,7 +135,7 @@ void picoquic_tls_set_verify_certificate_callback(picoquic_quic_t* quic,
 
 void picoquic_dispose_verify_certificate_callback(picoquic_quic_t* quic);
 
-void picoquic_dispose_server_state_key(picoquic_server_state_key_t* key);
+void picoquic_dispose_ticket_key_state(picoquic_ticket_key_state_t* key);
 
 void picoquic_tls_set_client_authentication(picoquic_quic_t* quic, int client_authentication);
 

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -204,7 +204,7 @@ static const picoquic_test_def_t test_table[] = {
     { "token_store", token_store_test },
     { "token_reuse_api", token_reuse_api_test },
     { "session_resume", session_resume_test },
-    { "server_state_key_rotation", server_state_key_rotation_test },
+    { "ticket_key_rotation", ticket_key_rotation_test },
     { "zero_rtt", zero_rtt_test },
     { "zero_rtt_loss", zero_rtt_loss_test },
     { "stop_sending", stop_sending_test },

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -204,6 +204,7 @@ static const picoquic_test_def_t test_table[] = {
     { "token_store", token_store_test },
     { "token_reuse_api", token_reuse_api_test },
     { "session_resume", session_resume_test },
+    { "server_state_key_rotation", server_state_key_rotation_test },
     { "zero_rtt", zero_rtt_test },
     { "zero_rtt_loss", zero_rtt_loss_test },
     { "stop_sending", stop_sending_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -124,7 +124,7 @@ int ticket_seed_test(void);
 int ticket_seed_from_bdp_frame_test(void);
 int token_store_test(void);
 int session_resume_test(void);
-int server_state_key_rotation_test(void);
+int ticket_key_rotation_test(void);
 int zero_rtt_test(void);
 int zero_rtt_loss_test(void);
 int stop_sending_test(void);

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -124,6 +124,7 @@ int ticket_seed_test(void);
 int ticket_seed_from_bdp_frame_test(void);
 int token_store_test(void);
 int session_resume_test(void);
+int server_state_key_rotation_test(void);
 int zero_rtt_test(void);
 int zero_rtt_loss_test(void);
 int stop_sending_test(void);

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -55,6 +55,10 @@ static const uint8_t test_ticket_badcrypt_key[32] = {
     255, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 };
+
+#define PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(sequence) (uint8_t)((sequence) >> 63)
+
+static const uint8_t test_server_state_replace_key[32] = { 1 };
 /*
  * Generic call back function.
  */
@@ -4368,6 +4372,61 @@ int session_resume_test(void)
             tls_api_delete_ctx(test_ctx);
             test_ctx = NULL;
         }
+    }
+
+    return ret;
+}
+
+static char const* server_state_key_rotation_file_name = "server_state_key_rotation_tickets.bin";
+
+int server_state_key_rotation_test(void)
+{
+    uint64_t simulated_time = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    int ret = picoquic_save_tickets(NULL, simulated_time, server_state_key_rotation_file_name);
+
+    for (int i = 0; ret == 0 && i < 3; i++) {
+        uint64_t loss_mask = 0;
+        ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN,
+            &simulated_time, server_state_key_rotation_file_name, NULL, 0, 0, 0);
+
+        if (ret == 0 && i > 0) {
+            ret = picoquic_set_server_state_key(test_ctx->qserver,
+                (i == 1) ? test_ticket_encrypt_key : test_server_state_replace_key,
+                sizeof(test_ticket_encrypt_key));
+        }
+        if (ret == 0) {
+            ret = picoquic_set_server_state_key(test_ctx->qserver,
+                (i == 0) ? test_ticket_encrypt_key : test_ticket_badcrypt_key,
+                sizeof(test_ticket_encrypt_key));
+        }
+        if (ret == 0) {
+            ret = tls_api_connection_loop(test_ctx, &loss_mask, 0, &simulated_time);
+        }
+        if (ret == 0 && i > 0 &&
+            ((picoquic_tls_is_psk_handshake(test_ctx->cnx_server) != (i == 1)) ||
+                (picoquic_tls_is_psk_handshake(test_ctx->cnx_client) != (i == 1)))) {
+            ret = -1;
+        }
+        if (ret == 0) {
+            ret = (i == 0) ? session_resume_wait_for_ticket(test_ctx, &simulated_time) :
+                tls_api_synch_to_empty_loop(test_ctx, &simulated_time, 2048, 0, 1);
+        }
+        if (ret == 0 && PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(test_ctx->cnx_server->issued_ticket_id) != (uint8_t)(i == 0 ? 0 : 1)) {
+            ret = -1;
+        }
+        if (ret == 0) {
+            ret = tls_api_attempt_to_close(test_ctx, &simulated_time);
+        }
+        if (ret == 0 && i == 0) {
+            ret = picoquic_save_tickets(test_ctx->qclient->p_first_ticket, simulated_time,
+                server_state_key_rotation_file_name);
+        }
+        if (test_ctx != NULL) {
+            tls_api_delete_ctx(test_ctx);
+            test_ctx = NULL;
+        }
+        simulated_time += 1000;
     }
 
     return ret;

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -3926,10 +3926,17 @@ int tls_retry_token_valid_test(void)
     /* Test of an invalid token: valid token with changed bytes */
 
     for (int token_mode = 0; ret == 0 && token_mode < 2; token_mode++) {
-        if (picoquic_prepare_retry_token(quic, addr[0], time_base * 1000000 + time_delta[1], odcid[token_mode],
+        if (picoquic_set_server_state_key(quic,
+            test_ticket_encrypt_key, sizeof(test_ticket_encrypt_key)) != 0) {
+            ret = -1;
+        }
+        else if (picoquic_prepare_retry_token(quic, addr[0], time_base * 1000000 + time_delta[1], odcid[token_mode],
             cid[token_mode], pn[1],
             token_buffer, sizeof(token_buffer), &token_size) != 0) {
             ret = PICOQUIC_ERROR_MEMORY;
+        }
+        else if (PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(PICOPARSE_64(token_buffer)) != 0) {
+            ret = -1;
         }
 
         if (ret == 0) {
@@ -4006,6 +4013,35 @@ int tls_retry_token_valid_test(void)
                     DBG_PRINTF("%s", "Bad length check fails\n");
                     ret = -1;
                 }
+            }
+        }
+
+        if (ret == 0 && picoquic_set_server_state_key(quic,
+            test_ticket_badcrypt_key, sizeof(test_ticket_badcrypt_key)) != 0) {
+            ret = -1;
+        }
+        if (ret == 0) {
+            verified = picoquic_verify_retry_token(quic, addr[0], time_base * 1000000 + time_delta[0],
+                &is_new_token, &odcid_found, cid[0], pn[2], token_buffer, token_size, 0);
+            if (verified != 0) {
+                ret = -1;
+            }
+            else if (is_new_token != (odcid[token_mode]->id_len == 0)) {
+                ret = -1;
+            }
+        }
+
+        if (ret == 0) {
+            if (picoquic_prepare_retry_token(quic, addr[0], time_base * 1000000 + time_delta[1], odcid[token_mode],
+                cid[token_mode], pn[1], token_buffer, sizeof(token_buffer), &token_size) != 0) {
+                ret = PICOQUIC_ERROR_MEMORY;
+            }
+            else if (PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(PICOPARSE_64(token_buffer)) != 1) {
+                ret = -1;
+            }
+            else if (picoquic_verify_retry_token(quic, addr[0], time_base * 1000000 + time_delta[0],
+                &is_new_token, &odcid_found, cid[0], pn[2], token_buffer, token_size, 0) != 0) {
+                ret = -1;
             }
         }
     }

--- a/picoquictest/tls_api_test.c
+++ b/picoquictest/tls_api_test.c
@@ -56,9 +56,9 @@ static const uint8_t test_ticket_badcrypt_key[32] = {
     16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
 };
 
-#define PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(sequence) (uint8_t)((sequence) >> 63)
+#define PICOQUIC_TEST_TICKET_KEY_SLOT(sequence) (uint8_t)((sequence) >> 63)
 
-static const uint8_t test_server_state_replace_key[32] = { 1 };
+static const uint8_t test_ticket_key_replace_key[32] = { 1 };
 /*
  * Generic call back function.
  */
@@ -3926,7 +3926,7 @@ int tls_retry_token_valid_test(void)
     /* Test of an invalid token: valid token with changed bytes */
 
     for (int token_mode = 0; ret == 0 && token_mode < 2; token_mode++) {
-        if (picoquic_set_server_state_key(quic,
+        if (picoquic_set_ticket_key(quic,
             test_ticket_encrypt_key, sizeof(test_ticket_encrypt_key)) != 0) {
             ret = -1;
         }
@@ -3935,7 +3935,7 @@ int tls_retry_token_valid_test(void)
             token_buffer, sizeof(token_buffer), &token_size) != 0) {
             ret = PICOQUIC_ERROR_MEMORY;
         }
-        else if (PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(PICOPARSE_64(token_buffer)) != 0) {
+        else if (PICOQUIC_TEST_TICKET_KEY_SLOT(PICOPARSE_64(token_buffer)) != 0) {
             ret = -1;
         }
 
@@ -4016,7 +4016,7 @@ int tls_retry_token_valid_test(void)
             }
         }
 
-        if (ret == 0 && picoquic_set_server_state_key(quic,
+        if (ret == 0 && picoquic_set_ticket_key(quic,
             test_ticket_badcrypt_key, sizeof(test_ticket_badcrypt_key)) != 0) {
             ret = -1;
         }
@@ -4036,7 +4036,7 @@ int tls_retry_token_valid_test(void)
                 cid[token_mode], pn[1], token_buffer, sizeof(token_buffer), &token_size) != 0) {
                 ret = PICOQUIC_ERROR_MEMORY;
             }
-            else if (PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(PICOPARSE_64(token_buffer)) != 1) {
+            else if (PICOQUIC_TEST_TICKET_KEY_SLOT(PICOPARSE_64(token_buffer)) != 1) {
                 ret = -1;
             }
             else if (picoquic_verify_retry_token(quic, addr[0], time_base * 1000000 + time_delta[0],
@@ -4413,26 +4413,26 @@ int session_resume_test(void)
     return ret;
 }
 
-static char const* server_state_key_rotation_file_name = "server_state_key_rotation_tickets.bin";
+static char const* ticket_key_rotation_file_name = "ticket_key_rotation_tickets.bin";
 
-int server_state_key_rotation_test(void)
+int ticket_key_rotation_test(void)
 {
     uint64_t simulated_time = 0;
     picoquic_test_tls_api_ctx_t* test_ctx = NULL;
-    int ret = picoquic_save_tickets(NULL, simulated_time, server_state_key_rotation_file_name);
+    int ret = picoquic_save_tickets(NULL, simulated_time, ticket_key_rotation_file_name);
 
     for (int i = 0; ret == 0 && i < 3; i++) {
         uint64_t loss_mask = 0;
         ret = tls_api_init_ctx(&test_ctx, 0, PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN,
-            &simulated_time, server_state_key_rotation_file_name, NULL, 0, 0, 0);
+            &simulated_time, ticket_key_rotation_file_name, NULL, 0, 0, 0);
 
         if (ret == 0 && i > 0) {
-            ret = picoquic_set_server_state_key(test_ctx->qserver,
-                (i == 1) ? test_ticket_encrypt_key : test_server_state_replace_key,
+            ret = picoquic_set_ticket_key(test_ctx->qserver,
+                (i == 1) ? test_ticket_encrypt_key : test_ticket_key_replace_key,
                 sizeof(test_ticket_encrypt_key));
         }
         if (ret == 0) {
-            ret = picoquic_set_server_state_key(test_ctx->qserver,
+            ret = picoquic_set_ticket_key(test_ctx->qserver,
                 (i == 0) ? test_ticket_encrypt_key : test_ticket_badcrypt_key,
                 sizeof(test_ticket_encrypt_key));
         }
@@ -4448,7 +4448,7 @@ int server_state_key_rotation_test(void)
             ret = (i == 0) ? session_resume_wait_for_ticket(test_ctx, &simulated_time) :
                 tls_api_synch_to_empty_loop(test_ctx, &simulated_time, 2048, 0, 1);
         }
-        if (ret == 0 && PICOQUIC_TEST_SERVER_STATE_KEY_SLOT(test_ctx->cnx_server->issued_ticket_id) != (uint8_t)(i == 0 ? 0 : 1)) {
+        if (ret == 0 && PICOQUIC_TEST_TICKET_KEY_SLOT(test_ctx->cnx_server->issued_ticket_id) != (uint8_t)(i == 0 ? 0 : 1)) {
             ret = -1;
         }
         if (ret == 0) {
@@ -4456,7 +4456,7 @@ int server_state_key_rotation_test(void)
         }
         if (ret == 0 && i == 0) {
             ret = picoquic_save_tickets(test_ctx->qclient->p_first_ticket, simulated_time,
-                server_state_key_rotation_file_name);
+                ticket_key_rotation_file_name);
         }
         if (test_ctx != NULL) {
             tls_api_delete_ctx(test_ctx);


### PR DESCRIPTION
good security hygiene to cycle these keys on some regular basis, and might not want to force expire every existing ticket that has been issued.

RFCs talk about lifetimes of 7 days: https://www.rfc-editor.org/rfc/rfc9325.html#section-3.4-4.2
cloudflare cycles keys every hour: https://blog.cloudflare.com/tls-1-3-overview-and-q-and-a/