### PR TITLE
Add public picoquic_set_unified_log_fns() API for custom log backends

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ set(PICOQUIC_CORE_HEADERS_PRIVATE
     picoquic/picoquic_logger.h
     picoquic/picoquic_set_binlog.h
     picoquic/picoquic_set_textlog.h
+    picoquic/picoquic_set_unified_log_fns.h
     picoquic/picoquic_unified_log.h
     picoquic/picosplay.h
     picoquic/tls_api.h

--- a/picoquic/picoquic_set_unified_log_fns.h
+++ b/picoquic/picoquic_set_unified_log_fns.h
@@ -1,0 +1,83 @@
+/*
+* Author: OpenMOQ contributors
+* Copyright (c) 2026, OpenMOQ contributors
+* All rights reserved.
+*
+* Permission to use, copy, modify, and distribute this software for any
+* purpose with or without fee is hereby granted, provided that the above
+* copyright notice and this permission notice appear in all copies.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+* USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef PICOQUIC_SET_UNIFIED_LOG_FNS_H
+#define PICOQUIC_SET_UNIFIED_LOG_FNS_H
+
+#include "picoquic.h"
+#include "picoquic_unified_log.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Selector for picoquic_set_unified_log_fns().
+ *
+ * Picoquic stores three independent slots for unified-log callbacks and
+ * dispatches events to every populated slot; clearing one (passing NULL fns)
+ * does not affect the others. The built-in backends populate them as follows:
+ *
+ *   PICOQUIC_LOG_SLOT_TEXT — populated by picoquic_set_textlog()
+ *   PICOQUIC_LOG_SLOT_BIN  — populated by picoquic_set_binlog()
+ *   PICOQUIC_LOG_SLOT_QLOG — populated by picoquic_set_qlog()
+ *
+ * A custom backend (e.g. a C++ wrapper routing into a native logging
+ * framework) typically takes the TEXT slot, since its purpose
+ * ("human-readable per-event log") matches.
+ */
+typedef enum {
+    PICOQUIC_LOG_SLOT_TEXT = 0,
+    PICOQUIC_LOG_SLOT_BIN  = 1,
+    PICOQUIC_LOG_SLOT_QLOG = 2
+} picoquic_log_slot_t;
+
+/* Install a custom unified-log callback struct on the picoquic context.
+ *
+ * Mirrors what picoquic_set_textlog / set_binlog / set_qlog do for their
+ * built-in backends; intended for external consumers who want to implement
+ * their own picoquic_unified_logging_t (for example, to route events into
+ * a native logging framework such as folly XLOG, glog, or spdlog) without
+ * reaching into picoquic_internal.h.
+ *
+ * The caller retains ownership of fns. picoquic stores the pointer as-is
+ * and does not copy or free it, so fns must remain valid for the lifetime
+ * of the picoquic context — process-lifetime static storage is the typical
+ * pattern (mirroring the built-in textlog_functions / binlog_functions /
+ * qlog_fns structs).
+ *
+ * Pass fns == NULL to clear the slot (e.g. to disable a previously
+ * installed custom backend without affecting the others).
+ *
+ * @param quic the picoquic context (must be non-null)
+ * @param slot which slot to populate (TEXT, BIN, or QLOG)
+ * @param fns  pointer to the unified logging struct, or NULL to clear
+ * @return 0 on success, -1 on invalid arguments
+ */
+int picoquic_set_unified_log_fns(
+    picoquic_quic_t* quic,
+    picoquic_log_slot_t slot,
+    picoquic_unified_logging_t* fns);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PICOQUIC_SET_UNIFIED_LOG_FNS_H */

--- a/picoquic/unified_log.c
+++ b/picoquic/unified_log.c
@@ -28,6 +28,7 @@
 #include <sys/time.h>
 #endif
 #include "picoquic_unified_log.h"
+#include "picoquic_set_unified_log_fns.h"
 
 /* Close the quic level resource associated with logs */
 void picoquic_log_close_logs(picoquic_quic_t* quic)
@@ -342,4 +343,38 @@ void picoquic_log_cc_dump(picoquic_cnx_t* cnx, uint64_t current_time)
             path_x->is_cc_data_updated = 0;
         }
     }
+}
+
+/* ------------------------------------------------------------------
+ * Public setter for installing custom unified-log callback structs
+ * (see picoquic_set_unified_log_fns.h). Allows external consumers to
+ * provide their own picoquic_unified_logging_t implementation without
+ * reaching into picoquic_internal.h.
+ *
+ * The caller retains ownership of fns; picoquic stores the pointer
+ * as-is and does not copy or free it. Pass fns == NULL to clear a
+ * slot.
+ * ------------------------------------------------------------------ */
+int picoquic_set_unified_log_fns(
+    picoquic_quic_t* quic,
+    picoquic_log_slot_t slot,
+    picoquic_unified_logging_t* fns)
+{
+    if (quic == NULL) {
+        return -1;
+    }
+    switch (slot) {
+    case PICOQUIC_LOG_SLOT_TEXT:
+        quic->text_log_fns = fns;
+        break;
+    case PICOQUIC_LOG_SLOT_BIN:
+        quic->bin_log_fns = fns;
+        break;
+    case PICOQUIC_LOG_SLOT_QLOG:
+        quic->qlog_fns = fns;
+        break;
+    default:
+        return -1;
+    }
+    return 0;
 }


### PR DESCRIPTION
## Summary

Adds a public setter so consumers can install their own `picoquic_unified_logging_t` implementation without including `picoquic_internal.h`. Mirrors the existing `picoquic_set_textlog` / `picoquic_set_binlog` / `picoquic_set_qlog` convention (same `_set_` verb naming, same per-slot model).

```c
typedef enum {
    PICOQUIC_LOG_SLOT_TEXT = 0,   /* same slot as picoquic_set_textlog */
    PICOQUIC_LOG_SLOT_BIN  = 1,   /* same slot as picoquic_set_binlog  */
    PICOQUIC_LOG_SLOT_QLOG = 2    /* same slot as picoquic_set_qlog    */
} picoquic_log_slot_t;

int picoquic_set_unified_log_fns(picoquic_quic_t* quic,
                                  picoquic_log_slot_t slot,
                                  picoquic_unified_logging_t* fns);
```

Returns 0 on success, -1 on invalid args. Pass `fns == NULL` to clear the slot. Caller retains ownership of fns; picoquic stores the pointer as-is and does not copy or free it — typical pattern is a process-lifetime static struct, matching the existing built-in backends.

## Motivation

picoquic already exposes the `picoquic_unified_logging_t` struct via the public `picoquic_unified_log.h` header — what was missing was a way to *attach* a custom one. Today, anyone implementing a 4th backend (text/bin/qlog being the three built-in) has to either use one of the file-based setters (forcing file I/O) or `#include "picoquic_internal.h"` to write the slot field directly. The latter is fragile and breaks if picoquic ever reorganizes internal state.

## Use cases that benefit

Real-world consumers wanting to route picoquic's per-event signals (per-packet, per-cnx lifecycle, drops, losses, CC dumps, ALPN negotiation, etc.) somewhere other than a file:

- **Native-framework log routing** — folly XLOG, glog, spdlog, log4cxx, custom in-house systems. Lets picoquic events show up in the application's normal log stream, controllable via the application's standard logging knobs (severity, category, sinks). This is the use case driving us specifically (we're plugging picoquic into folly's category-based logging so QUIC-internal events sit alongside our HTTP/3 + application-layer logs under a uniform `--logging=quic.picoquic=...` config).
- **Real-time monitoring without file I/O** — emit structured events to an in-process aggregator, OTEL/Prometheus exporter, or message bus directly from the callbacks (no intermediate file).
- **Test harnesses** — install a capture callback in tests to assert specific events were emitted, without polluting the filesystem or parsing log files.
- **Embedded/constrained environments** — devices where file I/O is undesirable but per-event logging via a custom transport (UART, network, ring buffer) is fine.

Each of these today has to choose between "use one of the three file backends" (and live with the file I/O semantics) or "include `picoquic_internal.h`" (and live with the fragility). This setter gives them a clean third option using picoquic's own pluggable unified-log abstraction — the design is already there, just lacking the public entry point.

## Backwards compatibility

Purely additive — no existing functions or types changed. The new `picoquic_log_slot_t` enum and `picoquic_set_unified_log_fns()` function are new public surface; everything else is untouched. Existing consumers of `picoquic_set_textlog` / `picoquic_set_binlog` / `picoquic_set_qlog` are unaffected.

## Files

| | |
|---|---|
| `picoquic/picoquic_set_unified_log_fns.h` (new) | Public header — enum + setter declaration |
| `picoquic/unified_log.c` | `+#include` of the new header at the top; +setter implementation at the bottom (~25 lines, a switch over the slot enum that assigns the matching `quic->*_log_fns` field) |
| `CMakeLists.txt` | Add the new header to `PICOQUIC_CORE_HEADERS` (installed alongside `picoquic_set_textlog.h` / `picoquic_set_binlog.h`) |

## Test plan

- [ ] picoquic-core builds; new header installed alongside the existing setter headers.
- [ ] Smoke test: install a minimal `picoquic_unified_logging_t` via the new setter into the TEXT slot, run a tiny QUIC handshake, verify the 14 callbacks fire as expected.
- [ ] `fns == NULL` clears the slot cleanly (subsequent events skip the slot per `unified_log.c`'s existing null-checks).
- [ ] Invalid slot value returns -1 without modifying state.

Happy to extend the test plan or restructure as you prefer — let me know what would be most useful for review.