### PR TITLE
Replace cascade by BBR-style pushing

### DIFF
--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -818,6 +818,7 @@ static void c4_enter_pushing(
     c4_state->push_alpha = c4_state->alpha_1024_current;
     c4_state->alg_state = c4_pushing;
     c4_state->push_limit = 2 * c4_state->nominal_rate;
+    c4_state->nb_eras_no_increase = 0;
     c4_growth_reset(c4_state);
     c4_era_reset(path_x, c4_state);
 }
@@ -858,8 +859,10 @@ static void c4_on_pushing_era_end(
         c4_era_reset(path_x, c4_state);
     }
     else {
-        /* Move to recovery */
-        c4_enter_recovery(path_x, c4_state, c4_congestion_none);
+        if (c4_state->nb_eras_no_increase > 1) {
+            /* Move to recovery */
+            c4_enter_recovery(path_x, c4_state, c4_congestion_none);
+        }
     }
 }
 

--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -47,7 +47,7 @@
 *            lots of data wait a bit longer, which should improve fairness.
 *            Question: is this "N intervals" or "some amount of data sent"?
 *            the latter is better for the fairness issue.
-* Pushing.   For one RTT. Transmit at higher rate, to probe the network, then
+* probing.   For one RTT. Transmit at higher rate, to probe the network, then
 *            move to "cruising". Higher rate should be 25% higher, to probe
 *            without creating big queues.
 * Slowdown.  Periodic slowdown to 1/2 the nominal CWIN, in order to reset
@@ -59,8 +59,8 @@
 *            initial to recovery -- similar to hystart for now.
 *            recovery to initial -- if measurements show increase in data rate compared to era.
 *            recovery to cruising -- at the end of period.
-*            cruising, pushing to recovery -- if excess delay, loss or ECN
-*            pushing to recovery -- at end of period.
+*            cruising, probing to recovery -- if excess delay, loss or ECN
+*            probing to recovery -- at end of period.
 *            to slowdown..
 * 
 * 
@@ -112,7 +112,7 @@
 #define C4_ALPHA_PREVIOUS_LOW 960 /* 93.75% */
 #define C4_BETA_LOSS_1024 256 /* 25%, 1/4th */
 #define C4_NB_PACKETS_BEFORE_LOSS 20
-#if 0
+#if 1
 #define C4_NB_CRUISE_BEFORE_PUSH 2
 #else
 #define C4_NB_CRUISE_BEFORE_PUSH 4
@@ -126,6 +126,7 @@
 #define C4_PROBE_LEVEL_DEFAULT 1
 
 #define C4_ALPHA_PUSH_12_5 1152 /* 112.5 % */
+#define C4_ALPHA_PUSH_25 1256 /* 125 % */
 #define C4_ALPHA_PUSH_50_0 1536 /* 150.0% % */
 #define C4_ALPHA_PUSH_100_0 2048 /* 150.0% % */
 #define C4_ALPHA_PUSH_200_0 3072 /* 150.0% % */
@@ -143,6 +144,7 @@ typedef enum {
     c4_initial = 0,
     c4_recovery,
     c4_cruising,
+    c4_probing,
     c4_pushing
 } c4_alg_state_t;
 
@@ -174,6 +176,7 @@ typedef struct st_c4_state_t {
     int nb_eras_no_increase;
     uint64_t push_rate_old;
     uint64_t push_alpha;
+    uint64_t push_limit;
 
     uint64_t era_max_rtt;
     uint64_t era_min_rtt;
@@ -207,7 +210,19 @@ static void c4_enter_cruise(
     picoquic_path_t* path_x,
     c4_state_t* c4_state);
 
-static void c4_enter_push(
+static void c4_enter_probing(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state);
+
+static void c4_enter_pushing(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state);
+
+static void c4_on_pushing_rate_measurement(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state);
+
+static void c4_on_pushing_era_end(
     picoquic_path_t* path_x,
     c4_state_t* c4_state);
 
@@ -421,7 +436,7 @@ static void c4_apply_rate_and_cwin(
         }
         target_cwin += PICOQUIC_BYTES_FROM_RATE(delta_rtt_target, pacing_rate);
 
-        if (c4_state->alg_state == c4_pushing) {
+        if (c4_state->alg_state == c4_probing || c4_state->alg_state == c4_pushing) {
             uint64_t delta_alpha = c4_state->alpha_1024_current - 1024;
             uint64_t delta_rate = MULT1024(delta_alpha, c4_state->nominal_rate);
             uint64_t delta_cwin = PICOQUIC_BYTES_FROM_RATE(c4_state->nominal_max_rtt, delta_rate);
@@ -688,7 +703,7 @@ static void c4_enter_recovery(
 /* Exit recovery. We will test whether the previous push was successful.
 * We do that by comparing the nominal cwin to the value before entering
 * push. This "previous value" would be zero if the previous state
-* was not pushing.
+* was not probing.
  */
 
 static void c4_exit_recovery(
@@ -704,6 +719,7 @@ static void c4_exit_recovery(
         c4_state->recent_congestions = 0;
     }
     else {
+        /* TODO: this is obsolete, we should remove the cascade code. */
         if (c4_state->push_was_not_limited) {
             c4_state->probe_level = 1;
             if (c4_state->excess_ce_after_push) {
@@ -738,7 +754,7 @@ static void c4_exit_recovery(
         c4_enter_initial(path_x, c4_state);
     }
     else if (c4_state->probe_level > C4_PROBE_LEVEL_DEFAULT) {
-        c4_enter_push(path_x, c4_state);
+        c4_enter_pushing(path_x, c4_state);
     }
     else {
         c4_enter_cruise(path_x, c4_state);
@@ -779,18 +795,76 @@ static void c4_enter_cruise(
     c4_state->alg_state = c4_cruising;
 }
 
-/* Enter push.
+/* Enter probing. The probe level will be either 3.6125% if reacting to
+* ECN marks, or 6.25% in the default case.
 */
-static void c4_enter_push(
+static void c4_enter_probing(
     picoquic_path_t* path_x,
     c4_state_t* c4_state)
 {
     c4_state->alpha_1024_current = c4_push_rate_by_probe_level[c4_state->probe_level];
     c4_state->push_alpha = c4_state->alpha_1024_current;
     c4_era_reset(path_x, c4_state);
-    c4_state->alg_state = c4_pushing;
+    c4_state->alg_state = c4_probing;
 }
 
+/* Enter pushing.
+* the push rate will always be 25% for now. */
+static void c4_enter_pushing(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state)
+{
+    c4_state->alpha_1024_current = C4_ALPHA_PUSH_25;
+    c4_state->push_alpha = c4_state->alpha_1024_current;
+    c4_state->alg_state = c4_pushing;
+    c4_state->push_limit = 2 * c4_state->nominal_rate;
+    c4_growth_reset(c4_state);
+    c4_era_reset(path_x, c4_state);
+}
+
+/* check the pushing rate.
+* we do this on each rate measurment, and also on the
+* expiry of the current era. 
+* If the rate increased, we reset the era to last another RTT.
+* If the rate did not increase, we wait for the end of the era;
+* if the rate did not increase then, we exit the pushing.
+* (Check: do we need to do like BBR, count 3 RTT?)
+*/
+
+static void c4_on_pushing_rate_measurement(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state)
+{
+    if (c4_growth_evaluate(c4_state)) {
+        if (c4_state->nominal_rate > c4_state->push_limit) {
+            /* Nominal rate has more than doubled, entering initial */
+            c4_enter_initial(path_x, c4_state);
+        }
+        else {
+            /* reset the era */
+            c4_growth_reset(c4_state);
+            c4_era_reset(path_x, c4_state);
+        }
+    }
+}
+
+
+static void c4_on_pushing_era_end(
+    picoquic_path_t* path_x,
+    c4_state_t* c4_state)
+{
+    if (c4_growth_evaluate(c4_state)) {
+        c4_growth_reset(c4_state);
+        c4_era_reset(path_x, c4_state);
+    }
+    else {
+        /* Move to recovery */
+        c4_enter_recovery(path_x, c4_state, c4_congestion_none);
+    }
+}
+
+
+/* handle of RTT */
 void c4_update_min_max_rtt(picoquic_path_t* path_x, c4_state_t* c4_state)
 {
     /* Include the last sample, to deal with order of arrivals between ACK and RTT */
@@ -909,17 +983,23 @@ void c4_handle_ack(picoquic_path_t* path_x, c4_state_t* c4_state, picoquic_per_a
                     c4_era_reset(path_x, c4_state);
                     if (c4_state->nb_cruise_left_before_push <= 0 &&
                         path_x->last_time_acked_data_frame_sent > path_x->last_sender_limited_time) {
-                        c4_enter_push(path_x, c4_state);
+                        c4_enter_probing(path_x, c4_state);
                     }
                     break;
-                case c4_pushing:
+                case c4_probing:
                     c4_enter_recovery(path_x, c4_state, c4_congestion_none);
+                    break;
+                case c4_pushing:
+                    c4_on_pushing_era_end(path_x, c4_state);
                     break;
                 default:
                     c4_era_reset(path_x, c4_state);
                     break;
                 }
             }
+        }
+        else if (c4_state->alg_state == c4_pushing) {
+            c4_on_pushing_rate_measurement(path_x, c4_state);
         }
     }
 }
@@ -990,7 +1070,7 @@ static void c4_notify_congestion(
     }
     else
     {
-        if (c4_state->alg_state != c4_pushing) {
+        if (c4_state->alg_state != c4_probing && c4_state->alg_state != c4_pushing) {
             c4_state->nominal_rate -= MULT1024(beta, c4_state->nominal_rate);
             if (c_mode == c4_congestion_loss) {
                 c4_state->nominal_max_rtt -= MULT1024(beta, c4_state->nominal_max_rtt);

--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -148,13 +148,18 @@ typedef enum {
     c4_pushing
 } c4_alg_state_t;
 
-
 typedef enum {
     c4_congestion_none = 0,
     c4_congestion_delay,
     c4_congestion_ecn,
     c4_congestion_loss
 } c4_congestion_t;
+
+typedef enum {
+    c4_growing_none = 0,
+    c4_growing_slow,
+    c4_growing_fast
+} c4_growing_t;
 
 typedef struct st_c4_state_t {
     c4_alg_state_t alg_state;
@@ -461,22 +466,28 @@ static void c4_apply_rate_and_cwin(
 /* Perform evaluation. Assess whether the previous era resulted
  * in a significant increase or not.
  */
-static int c4_growth_evaluate(c4_state_t* c4_state)
+static c4_growing_t c4_growth_evaluate(c4_state_t* c4_state)
 {
-    int is_growing = 0;
+    c4_growing_t is_growing = c4_growing_none;
     if (c4_state->push_alpha > C4_ALPHA_PUSH_LOW_1024) {
         /* If the value of "push_alpha" was large enough, we can reasonably
          * measure growth. */
         uint64_t target_rate = (3*c4_state->push_rate_old +
             MULT1024(c4_state->push_alpha, c4_state->push_rate_old)) / 4;
-        is_growing = (c4_state->nominal_rate > target_rate);
+        if (c4_state->nominal_rate >= target_rate) {
+            uint64_t higher_rate = (c4_state->push_rate_old +
+                3*MULT1024(c4_state->push_alpha, c4_state->push_rate_old)) / 4;
+            is_growing = (c4_state->nominal_rate > higher_rate) ? c4_growing_fast : c4_growing_slow;
+        }
     }
     else {
         /* If the value was not big enough, we have to make decision
          * based on congestion signals.
          */
-        is_growing = (c4_state->nominal_rate > c4_state->push_rate_old &&
-            !c4_state->congestion_notified);
+        if (c4_state->nominal_rate > c4_state->push_rate_old &&
+            !c4_state->congestion_notified) {
+            is_growing = c4_growing_fast;
+        }
     }
     return is_growing;
 }
@@ -638,8 +649,8 @@ static void c4_initial_handle_ack(picoquic_path_t* path_x, c4_state_t* c4_state,
         * nothing for several RTT, until the client asks for some data.
         * So we test that we have seen at least some data.
         */
-        int is_growing = c4_growth_evaluate(c4_state);
-        if (is_growing) {
+        c4_growing_t is_growing = c4_growth_evaluate(c4_state);
+        if (is_growing != c4_growing_none) {
             c4_state->nb_eras_no_increase = 0;
         }
         else if (c4_state->push_was_not_limited && c4_state->nominal_rate > 0) {
@@ -814,6 +825,7 @@ static void c4_enter_pushing(
     picoquic_path_t* path_x,
     c4_state_t* c4_state)
 {
+    c4_state->alpha_1024_previous = c4_state->alpha_1024_current;
     c4_state->alpha_1024_current = C4_ALPHA_PUSH_25;
     c4_state->push_alpha = c4_state->alpha_1024_current;
     c4_state->alg_state = c4_pushing;
@@ -836,16 +848,12 @@ static void c4_on_pushing_rate_measurement(
     picoquic_path_t* path_x,
     c4_state_t* c4_state)
 {
-    if (c4_growth_evaluate(c4_state)) {
-        if (c4_state->nominal_rate > c4_state->push_limit) {
-            /* Nominal rate has more than doubled, entering initial */
-            c4_enter_initial(path_x, c4_state);
-        }
-        else {
-            /* reset the era */
-            c4_growth_reset(c4_state);
-            c4_era_reset(path_x, c4_state);
-        }
+    c4_growing_t is_growing = c4_growth_evaluate(c4_state);
+    if (is_growing == c4_growing_fast) {
+        /* reset the era */
+        c4_growth_reset(c4_state);
+        c4_era_reset(path_x, c4_state);
+        c4_state->nb_eras_no_increase = 0;
     }
 }
 
@@ -854,12 +862,20 @@ static void c4_on_pushing_era_end(
     picoquic_path_t* path_x,
     c4_state_t* c4_state)
 {
-    if (c4_growth_evaluate(c4_state)) {
+
+    c4_growing_t is_growing = c4_growth_evaluate(c4_state);
+    if (is_growing == c4_growing_fast) {
+        // c4_state->nb_eras_no_increase = 0;
         c4_growth_reset(c4_state);
         c4_era_reset(path_x, c4_state);
     }
     else {
+#if 1
+        if (c4_state->alpha_1024_previous >= C4_ALPHA_PUSH_25) {
+#else
+        c4_state->nb_eras_no_increase++;
         if (c4_state->nb_eras_no_increase > 1) {
+#endif
             /* Move to recovery */
             c4_enter_recovery(path_x, c4_state, c4_congestion_none);
         }


### PR DESCRIPTION
Code changes to replace the "cascade" by a BBR style pushing. his effectively splits the "pushing" state into a "probing" executed frequently, and a "pushing" state only entered if a previous probing detected available bandwidth. The goal is to match or approach BBR performance in "low and up" or "drop and back" style scenarios, without unduly increasing the general aggressiveness of the protocol.

The current implementation uses the 'probe-level" variable used in the cascade code. the first goal was to simply evaluate performance. As shown in the tables below, the performance are generally better than the March 2025 version of C4, and also than the in progress work on building a more aggressive cascade, with only a few exceptions:

* The "low_and_up" performance is much better than March, but still a bit inferior to Cubic.
* The "after_c4" test is degraded, while the "before_c4" test is improved. This should be remedied by further work on the fairness of C4 vs C4 scenarios.
* the test `vs_bbr_lg2` indicates a lack of aggressiveness against an already started BBR connection. This will have to be addressed next. Notice the inverse situation for the test `vs_bbr_lg`.
* about 2% regression in the test `wifi_bad_cubic`, probably due to the lack of aggressiveness.

Overall, this is progress. Next step is to address potential issues in the satellite test, which points to limitations in the way the initial startup works, and perhaps after that addressing the lack of C4-fairness and aggressiveness against Cubic or BBR.


###  average time for simple tests
|  average time for simple tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| alone |  4635796 | 4689608 | 4480854 | 4641428 | 4653960 |
| alone_200 |  1172860 | 1221514 | 1147156 | 1171614 | 1162182 |
| low_and_up |  7927196 | 7507137 | 8062232 | 8211554 | 7760545 |
| drop_and_back |  7892581 | 7627157 | 7627559 | 7569850 | 7696412 |
| blackhole |  5628269 | 5811028 | 5695979 | 5628293 | 5628021 |
| short_long |  17442202 | 42481516 | 21385321 | 17442063 | 17536604 |
| satellite |  7660817 | 7431946 | 6704246 | 7660683 | 7660867 |
###  top 90% time for simple tests
|  top 90% time for simple tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| alone |  4820534 | 4698766 | 4550113 | 4806987 | 4858618 |
| alone_200 |  1202816 | 1221955 | 1157204 | 1201537 | 1185228 |
| low_and_up |  7929954 | 7512390 | 8071884 | 8221162 | 7763802 |
| drop_and_back |  7896792 | 7630836 | 7631530 | 7555974 | 7698264 |
| blackhole |  5629066 | 5814515 | 5699328 | 5629067 | 5628148 |
| short_long |  17444048 | 43393691 | 21553739 | 17443522 | 17538410 |
| satellite |  7661569 | 7432276 | 6704247 | 7660804 | 7661489 |

## compete
Here the statistics for the compete test cases.

###  average time for compete tests
|  average time for compete tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| vs_bbr |  2947904 | 4500214 | 2854018 | 2937361 | 2971282 |
| vs_c4 |  4488332 | 6359313 | 6210560 | 4546127 | 4443842 |
| vs_cubic |  3629542 | 6981768 | 5362805 | 3728446 | 3479269 |
| after_c4 |  5886628 | 6371174 | 7381332 | 4965793 | 5259943 |
| before_c4 |  3118173 | 3416872 | 3060583 | 3189381 | 2718001 |
| vs_c4_lg |  21103919 | 23799132 | 24006267 | 21221828 | 21047335 |
| vs_c4_lg2 |  21157349 | 21070556 | 21765163 | 21127051 | 21109261 |
| vs_bbr_lg |  17270263 | 21100367 | 15576617 | 17652727 | 16667356 |
| vs_bbr_lg2 |  17386558 | 18768931 | 21444750 | 16959119 | 20738935 |
| vs_cubic_lg |  17474440 | 21377231 | 20926495 | 18407002 | 17440089 |
| vs_cubic_lg2 |  17388655 | 15544607 | 20670256 | 17157792 | 16951492 |
###  top 90% time for compete tests
|  top 90% time for compete tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| vs_bbr |  2967298 | 4569513 | 2877826 | 2962621 | 3002911 |
| vs_c4 |  4855984 | 6751477 | 6584737 | 4934840 | 4684679 |
| vs_cubic |  3960012 | 7088423 | 5578599 | 3915744 | 3555684 |
| after_c4 |  6124341 | 6745566 | 7892876 | 5221897 | 6241866 |
| before_c4 |  3254747 | 4686937 | 4155012 | 3365526 | 3056297 |
| vs_c4_lg |  21279884 | 31648515 | 24935797 | 21485943 | 21141990 |
| vs_c4_lg2 |  21223876 | 21142792 | 22220697 | 21308974 | 21175546 |
| vs_bbr_lg |  17375085 | 21129986 | 15850088 | 21023002 | 16926578 |
| vs_bbr_lg2 |  19056546 | 19089158 | 22079621 | 16991365 | 21125373 |
| vs_cubic_lg |  18898262 | 21745262 | 21231416 | 19875932 | 18267834 |
| vs_cubic_lg2 |  17981728 | 15736674 | 20974930 | 18024766 | 17409475 |

## wifi
Here the statistics for the wifi test cases.

###  average time for wifi tests
|  average time for wifi tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| wifi_bad |  4130010 | 5223099 | 4119966 | 3971795 | 4168880 |
| wifi_fade |  5122904 | 5418014 | 5348764 | 5162066 | 5166804 |
| wifi_suspension |  4563058 | 4615830 | 4600584 | 4562957 | 4565884 |
| wifi_bad_bbr |  7329013 | 7786557 | 7142157 | 7099482 | 7093864 |
| wifi_bad_c4 |  9941827 | 10630450 | 9246694 | 9524381 | 8659345 |
| wifi_bad_cubic |  8586908 | 8627229 | 10422755 | 8571719 | 8384000 |
###  top 90% time for wifi tests
|  top 90% time for wifi tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| wifi_bad |  4530866 | 7093808 | 4452795 | 4430002 | 4695229 |
| wifi_fade |  5390592 | 5606363 | 5536004 | 5410636 | 5446254 |
| wifi_suspension |  4564074 | 4616323 | 4600873 | 4563652 | 4574263 |
| wifi_bad_bbr |  11960827 | 12252671 | 12444870 | 11324365 | 10509521 |
| wifi_bad_c4 |  12241445 | 12258102 | 12176350 | 12110705 | 11819738 |
| wifi_bad_cubic |  11120773 | 12343051 | 14094528 | 11025927 | 10683265 |

## ecn
Here the statistics for the ecn test cases.

###  average time for ecn tests
|  average time for ecn tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| ecn |  4491102 | 4670075 | 4459506 | 4490926 | 4494164 |
| ecn_c4 |  11501104 | 15579009 | 15393686 | 11230468 | 11457544 |
| ecn_cubic |  8707132 | 9717152 | 13375504 | 8038435 | 8138028 |
| ecn_bbr |  13306962 | 13319811 | 16962538 | 11981185 | 13106071 |
###  top 90% time for ecn tests
|  top 90% time for ecn tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| ecn |  4491164 | 4670726 | 4457940 | 4491140 | 4494072 |
| ecn_c4 |  12992148 | 16074999 | 16446180 | 13118653 | 12383231 |
| ecn_cubic |  9428474 | 10724486 | 13961162 | 9385551 | 8575740 |
| ecn_bbr |  13581877 | 13384363 | 17570350 | 13066415 | 13360959 |

## media
Here the statistics for the media test cases.

###  average av_latency for media tests
|  average av_latency for media tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| media |  33511 | 33427 | 33512 | 33511 | 33511 |
| media10 |  45214 | 44993 | 47758 | 45366 | 45207 |
| media_600fr |  33624 | 33545 | 33628 | 33625 | 33625 |
| media_short_long |  101035 | 133866 | 100774 | 101035 | 101035 |
| media_wb |  76497 | 86371 | 82441 | 83218 | 80282 |
| media_wf |  82844 | 89679 | 83972 | 81212 | 82690 |
| media_ws |  22850 | 21644 | 22469 | 22864 | 22862 |
| media_ecn |  34409 | 34481 | 34716 | 34404 | 34406 |
###  top 90% max_latency for media tests
|  top 90% max_latency for media tests| c4 | bbr | cubic | c4_cascade | c4_pushing |
| --------- | ---:| ---:| ---:| ---:| ---:|
| media |  43453 | 43453 | 43453 | 43453 | 43453 |
| media10 |  71128 | 71128 | 92163 | 71128 | 71128 |
| media_600fr |  43453 | 43453 | 43453 | 43453 | 43453 |
| media_short_long |  117838 | 334491 | 110856 | 117984 | 117838 |
| media_wb |  267222 | 294755 | 264284 | 274105 | 267162 |
| media_wf |  286732 | 382312 | 319314 | 280633 | 296181 |
| media_ws |  197821 | 195521 | 197821 | 197821 | 197821 |
| media_ecn |  49700 | 50996 | 50996 | 49700 | 49700 |

