### PR TITLE
Make packet loop send batch configurable

### DIFF
--- a/doc/parallel.md
+++ b/doc/parallel.md
@@ -79,6 +79,7 @@ typedef struct st_picoquic_packet_loop_param_t {
     int prefer_extra_socket;
     int simulate_eio;
     size_t send_length_max;
+    size_t send_batch_max;
 } picoquic_packet_loop_param_t;
 ```
 

--- a/doc/socket_loop.md
+++ b/doc/socket_loop.md
@@ -85,7 +85,7 @@ The `param` argument contains data to parameterize the packet loop:
   `picoquic_prepare_next_packet_ex`. This is used in debugging,
   to verify that the `UDP_GSO` implementation is functional.
 
-* `send_batch_max`: if specified, the maximum number of packets sent in
+`send_batch_max`: if specified, the maximum number of calls to `sendmsg()` in
   one packet loop iteration. If left to 0, the packet loop uses
   `PICOQUIC_PACKET_LOOP_SEND_MAX`.
 

--- a/doc/socket_loop.md
+++ b/doc/socket_loop.md
@@ -85,6 +85,9 @@ The `param` argument contains data to parameterize the packet loop:
   `picoquic_prepare_next_packet_ex`. This is used in debugging,
   to verify that the `UDP_GSO` implementation is functional.
 
+* `send_batch_max`: if specified, the maximum number of packets sent in
+  one packet loop iteration. If left to 0, the packet loop uses
+  `PICOQUIC_PACKET_LOOP_SEND_MAX`.
 
 In addition, the packet loop exposes a network level callback API, to handle
 network level events that are not directly linked to the QUIC connections.

--- a/picoquic/picoquic_packet_loop.h
+++ b/picoquic/picoquic_packet_loop.h
@@ -33,7 +33,9 @@ extern "C" {
 
 #define PICOQUIC_PACKET_LOOP_SOCKETS_MAX 4
 #define PICOQUIC_PACKET_LOOP_RECV_MAX 10
+#ifndef PICOQUIC_PACKET_LOOP_SEND_MAX
 #define PICOQUIC_PACKET_LOOP_SEND_MAX 10
+#endif
 #define PICOQUIC_PACKET_LOOP_SEND_DELAY_MAX 2500
 
 typedef struct st_picoquic_socket_ctx_t {
@@ -204,6 +206,7 @@ typedef struct st_picoquic_packet_loop_param_t {
     int prefer_extra_socket;
     int simulate_eio;
     size_t send_length_max;
+    size_t send_batch_max; /* 0: use PICOQUIC_PACKET_LOOP_SEND_MAX */
 } picoquic_packet_loop_param_t;
 
 int picoquic_packet_loop_v2(picoquic_quic_t* quic,
@@ -491,4 +494,3 @@ void picoquic_packet_loop_abandon_socket(
 }
 #endif
 #endif /* PICOQUIC_PACKET_LOOP_H */
-

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -2396,6 +2396,8 @@ void* picoquic_packet_loop_v3(void* v_ctx)
     size_t send_length = 0;
     size_t send_msg_size = 0;
     size_t send_buffer_size = param->socket_buffer_size;
+    size_t send_batch_max = (param->send_batch_max == 0) ?
+        PICOQUIC_PACKET_LOOP_SEND_MAX : param->send_batch_max;
     size_t* send_msg_ptr = NULL;
     int bytes_recv;
     picoquic_connection_id_t log_cid;
@@ -2698,7 +2700,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
             * packets may be adding in the receive queue.
              */
             /* TODO: isolate the UDP sending logic in a function. */
-            while (ret == 0 && nb_packets_sent < PICOQUIC_PACKET_LOOP_SEND_MAX) {
+            while (ret == 0 && nb_packets_sent < send_batch_max) {
                 struct sockaddr_storage peer_addr;
                 struct sockaddr_storage local_addr = { 0 };
                 int if_index = 0;


### PR DESCRIPTION
Make the packet loop send batch configurable.

Today `PICOQUIC_PACKET_LOOP_SEND_MAX` is hardcoded to 10 packets per loop iteration. This keeps the
default unchanged, but adds two opt-in ways for users with send-heavy workloads to tune it:

- allow compile-time override with `#ifndef PICOQUIC_PACKET_LOOP_SEND_MAX`
- add `send_batch_max` to `picoquic_packet_loop_param_t`, where `0` preserves the existing default

The sockloop.c packet loop uses `send_batch_max` when set. Windows remains covered by the compile-time macro.

Some server workloads have many packets ready to send every loop turn. In those cases, a hardcoded 10-
packet batch can force extra packet-loop iterations and poll/syscall churn.

This PR does not change picoquic’s default behavior. Callers must opt in.