### PR TITLE
Open stream flow control even if max data limit set

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -2480,6 +2480,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(flow_control_open_max)
+        {
+            int ret = flow_control_open_max_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(bbr)
         {
             int ret = bbr_test();

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -122,7 +122,7 @@ int picoquic_open_flow_control(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t
     size_t consumed = 0;
     PICOQUIC_THREAD_CHECK(cnx->quic);
 
-    if (cnx->cnx_state == picoquic_state_ready && cnx->quic->max_data_limit == 0){
+    if (cnx->cnx_state == picoquic_state_ready){
         /* Only send the update in ready state, so that the misc frame is not picked by the
          * wrong transport context.
          * TODO: find way to queue the update so it is only sent as 0RTT or 1RTT packet.
@@ -139,13 +139,23 @@ int picoquic_open_flow_control(picoquic_cnx_t* cnx, uint64_t stream_id, uint64_t
 
             if (max_required > stream->maxdata_local) {
                 uint8_t* bytes_next = picoquic_format_max_stream_data_frame(cnx, stream, buffer + consumed, bytes_max, &more_data, &is_pure_ack, max_required);
-                bytes_next = picoquic_format_max_data_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack, expected_data_size);
-                if ((length = bytes_next - buffer) > 0) {
+                /* If the application has not set an explicit flow control limit, we also increase the "max_data" */
+                if (cnx->quic->max_data_limit == 0 && bytes_next != NULL) {
+                    bytes_next = picoquic_format_max_data_frame(cnx, bytes_next, bytes_max, &more_data, &is_pure_ack, expected_data_size);
+                }
+                if (bytes_next == NULL) {
+                    ret = PICOQUIC_ERROR_UNEXPECTED_ERROR;
+                }
+                else if ((length = bytes_next - buffer) > 0) {
                     ret = picoquic_queue_misc_frame(cnx, buffer, length, is_pure_ack,
                         picoquic_packet_context_application);
                 }
             }
         }
+    }
+    else {
+        /* Error: we can only use this API if the connection state is "ready" */
+        ret = PICOQUIC_ERROR_UNEXPECTED_STATE;
     }
 
     return ret;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -392,6 +392,7 @@ static const picoquic_test_def_t test_table[] = {
     { "fastcc", fastcc_test },
     { "fastcc_jitter", fastcc_jitter_test },
     { "flow_control", flow_control_test },
+    { "flow_control_open_max", flow_control_open_max_test },
     { "bbr", bbr_test },
     { "bbr_jitter", bbr_jitter_test },
     { "bbr_long", bbr_long_test },

--- a/picoquictest/flow_control_test.c
+++ b/picoquictest/flow_control_test.c
@@ -369,3 +369,70 @@ int flow_control_test(void)
 
 	return fctest_one(&spec);
 }
+
+/*
+ * Minimal reproducer for picoquic_open_flow_control() becoming a silent no-op
+ * after picoquic_set_max_data_control() enables bounded connection flow control.
+ */
+
+int flow_control_open_max_test(void)
+{
+	int ret = 0;
+	struct sockaddr_in peer;
+	picoquic_quic_t* quic = NULL;
+
+	memset(&peer, 0, sizeof(peer));
+	peer.sin_family = AF_INET;
+	peer.sin_port = htons(4433);
+	peer.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+	quic = picoquic_create(
+		1, NULL, NULL, NULL, "repro", NULL, NULL, NULL, NULL, NULL,
+		0, NULL, NULL, NULL, 0);
+
+	if (quic == NULL) {
+		DBG_PRINTF("%s", "picoquic_create failed");
+		ret = -1;
+	}
+	else {
+		picoquic_set_max_data_control(quic, 65536);
+		picoquic_cnx_t* cnx = picoquic_create_cnx(
+			quic, picoquic_null_connection_id, picoquic_null_connection_id,
+			(const struct sockaddr*)&peer, 0, 0, "server.example", "repro", 1);
+		if (cnx == NULL) {
+			DBG_PRINTF("%s", "picoquic_create_cnx failed");
+			ret = -1;
+		}
+		else {
+			picoquic_stream_head_t* stream = NULL;
+			cnx->cnx_state = picoquic_state_ready;
+			if ((stream = picoquic_create_stream(cnx, 0)) == NULL) {
+				DBG_PRINTF("%s", "picoquic_create_stream failed");
+				ret = -1;
+			}
+			else {
+				const picoquic_misc_frame_header_t* frame = NULL;
+
+				stream->consumed_offset = 1024;
+				stream->maxdata_local = 1024;
+
+				if ((ret = picoquic_open_flow_control(cnx, 0, 1024)) != 0) {
+					DBG_PRINTF("picoquic_open_flow_control returned %d", ret);
+				}
+				else if ((frame = cnx->first_misc_frame) == NULL) {
+					DBG_PRINTF("%s", "BUG: returned success but queued no MAX_STREAM_DATA frame");
+					ret = -1;
+				}
+				else {
+					const uint8_t* encoded = (const uint8_t*)(frame)+sizeof(picoquic_misc_frame_header_t);
+					if (frame->length == 0 || encoded[0] != picoquic_frame_type_max_stream_data) {
+						DBG_PRINTF("%s", "BUG: returned success but first queued frame is not MAX_STREAM_DATA");
+						ret = -1;
+					}
+				}
+			}
+		}
+		picoquic_free(quic);
+	}
+	return ret;
+}

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -432,6 +432,7 @@ int queue_network_input_test(void);
 int fastcc_test(void);
 int fastcc_jitter_test(void);
 int flow_control_test(void);
+int flow_control_open_max_test(void);
 int bbr_test(void);
 int bbr_jitter_test(void);
 int bbr_long_test(void);


### PR DESCRIPTION
The previous design would refuse any attempt to open the per stream data limit if the application had set a global flow control limit. We decouple the tests. If the global limit is set, the api `picoquic_open_flow_control` still opens the per stream flow control, but leaves the global control unchanged.