### PR TITLE
Test reverse chain of output queue and fix it

### DIFF
--- a/picoquic/streams.c
+++ b/picoquic/streams.c
@@ -628,7 +628,7 @@ void picoquic_insert_output_stream(picoquic_cnx_t* cnx, picoquic_stream_head_t* 
 {
     if (stream->is_output_stream == 0)
     {
-        /* To not insert if the stream cannot be written to */
+        /* Do not insert if the stream cannot be written to */
         if (IS_CLIENT_STREAM_ID(stream->stream_id) == cnx->client_mode) {
             if (stream->stream_id > ((IS_BIDIR_STREAM_ID(stream->stream_id)) ? cnx->max_stream_id_bidir_remote : cnx->max_stream_id_unidir_remote)) {
                 return;
@@ -1017,14 +1017,16 @@ void picoquic_reorder_output_stream_after_send(picoquic_cnx_t* cnx, picoquic_str
         picoquic_remove_output_stream(cnx, stream);
     }
     else if ((stream->stream_priority & 1) == 0 && stream->last_time_data_sent != old_time_sent) {
-        /* TODO: should consider update in place */
-        picoquic_stream_head_t* previous = stream->previous_output_stream;
+        /* Find the next position. */
+        picoquic_stream_head_t* new_previous = stream->previous_output_stream;
         picoquic_stream_head_t* next = stream->next_output_stream;
+
         while (next != NULL && picoquic_compare_stream_priority(stream, next) > 0) {
-            previous = next;
+            new_previous = next;
             next = next->next_output_stream;
         }
-        if (previous != stream->previous_output_stream) {
+        /* Reinsert after "previous", but only if it has changed */
+        if (new_previous != stream->previous_output_stream) {
             /* Remove from current position */
             if (stream->previous_output_stream == NULL) {
                 cnx->output_streams.first_output_stream = stream->next_output_stream;
@@ -1038,10 +1040,17 @@ void picoquic_reorder_output_stream_after_send(picoquic_cnx_t* cnx, picoquic_str
             else {
                 stream->next_output_stream->previous_output_stream = stream->previous_output_stream;
             }
-            /* Insert after previous -- by construction, previous cannot be NULL */
-            stream->previous_output_stream = previous;
-            stream->next_output_stream = previous->next_output_stream;
-            previous->next_output_stream = stream;
+            /* Insert after new previous, which by construction cannot be null */
+            if (new_previous->next_output_stream == NULL) {
+                stream->next_output_stream = NULL;
+                cnx->output_streams.last_output_stream = stream;
+            }
+            else {
+                stream->next_output_stream = new_previous->next_output_stream;
+                new_previous->next_output_stream->previous_output_stream = stream;
+            }
+            new_previous->next_output_stream = stream;
+            stream->previous_output_stream = new_previous;
         }
     }
 }

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -1033,8 +1033,7 @@ int stream_output_test(void)
                 simulated_time += 100;
                 /* Do a series of simulated send in which we send data from the first
                 * stream, causing it to be reordered */
-                for (int i = 0; ret == 0 && i < nb_streams; i++) {
-                    uint64_t stream_id = ordered_list[0];
+                for (size_t i = 0; ret == 0 && i < nb_streams; i++) {
                     stream = picoquic_find_ready_stream_path(cnx, NULL, 0);
                     if (stream == NULL || stream->stream_id != ordered_list[0]) {
                         /* this is unexpected */

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -20,6 +20,7 @@
 */
 
 #include <string.h>
+#include <stdlib.h>
 #include "picoquic_internal.h"
 #include "picoquictest_internal.h"
 
@@ -714,6 +715,7 @@ static int stream_output_test_list(picoquic_cnx_t * cnx, size_t nb_output, uint6
     int ret = 0;
     picoquic_stream_head_t * stream;
     size_t nb_found = 0;
+    size_t nb_back = 0;
 
     /* test order and value of output list */
     stream = cnx->output_streams.first_output_stream;
@@ -726,7 +728,7 @@ static int stream_output_test_list(picoquic_cnx_t * cnx, size_t nb_output, uint6
             break;
         }
         else if (nb_found >= nb_output) {
-            if (nb_found < nb_output) {
+            if (nb_found > nb_output) {
                 DBG_PRINTF("Stream[%d] is not NULL\n", (int)nb_found);
                 ret = -1;
             }
@@ -740,6 +742,33 @@ static int stream_output_test_list(picoquic_cnx_t * cnx, size_t nb_output, uint6
             nb_found++;
         }
     }
+    /* Test in the reverse direction */
+    stream = cnx->output_streams.last_output_stream;
+    while (ret == 0) {
+        if (stream == NULL) {
+            if (nb_back < nb_output) {
+                DBG_PRINTF("Stream[%d] is NULL\n", (int)nb_back);
+                ret = -1;
+            }
+            break;
+        }
+        else if (nb_back >= nb_output) {
+            if (nb_back > nb_output) {
+                DBG_PRINTF("Back Stream[%d] is not NULL\n", (int)nb_back);
+                ret = -1;
+            }
+        }
+        else if (stream->stream_id != output[nb_output - nb_back - 1]) {
+            DBG_PRINTF("Stream[%d].stream_id = %d, expected %d\n", (int)nb_found, (int)stream->stream_id, (int)output[nb_output - nb_back]);
+            ret = -1;
+        }
+        else {
+            stream = stream->previous_output_stream;
+            nb_back++;
+        }
+    }
+
+
 
     return ret;
 }
@@ -939,8 +968,6 @@ int stream_output_test(void)
                 }
             }
 
-
-
             /* Reset the priorities to an odd number, and set the last time sent. */
             if (ret == 0) {
                 simulated_time = 1000;
@@ -977,6 +1004,50 @@ int stream_output_test(void)
 
                         picoquic_reorder_output_stream_after_send(cnx, stream, old_time_sent);
                         ret = stream_output_test_list(cnx, sizeof(output4) / sizeof(uint64_t), output4);
+                    }
+                }
+            }
+
+            if (ret == 0) {
+                /* systematic test of reordering with even priorities */
+                size_t nb_streams = 0;
+                uint64_t ordered_list[16];
+                simulated_time = 3000;
+                /* reset priorities for all streams and compute the original order */
+                for (int i = 0; i < 7; i++) {
+                    stream = picoquic_find_stream(cnx, values[i]);
+                    if (stream == NULL) {
+                        ret = -1;
+                    }
+                    else {
+                        /* force the stream to be marked inactive, so as to reset its ranking in the output list*/
+                        picoquic_mark_active_stream(cnx, values[i], 0, NULL);
+                        /* reset priorities and mark active so as to add to output list */
+                        stream->last_time_data_sent = simulated_time + i;
+                        picoquic_set_stream_priority(cnx, values[i], 8);
+                        picoquic_mark_active_stream(cnx, values[i], 1, NULL);
+                        ordered_list[nb_streams] = stream->stream_id;
+                        nb_streams++;
+                    }
+                }
+                simulated_time += 100;
+                /* Do a series of simulated send in which we send data from the first
+                * stream, causing it to be reordered */
+                for (int i = 0; ret == 0 && i < nb_streams; i++) {
+                    uint64_t stream_id = ordered_list[0];
+                    stream = picoquic_find_ready_stream_path(cnx, NULL, 0);
+                    if (stream == NULL || stream->stream_id != ordered_list[0]) {
+                        /* this is unexpected */
+                        ret = -1;
+                    }
+                    else {
+                        uint64_t old_time_sent = stream->last_time_data_sent;
+                        simulated_time += 100;
+                        stream->last_time_data_sent = simulated_time;
+                        memmove(&ordered_list[0], &ordered_list[1], sizeof(uint64_t) * (nb_streams - 1));
+                        ordered_list[nb_streams - 1] = stream->stream_id;
+                        picoquic_reorder_output_stream_after_send(cnx, stream, old_time_sent);
+                        ret = stream_output_test_list(cnx, nb_streams, ordered_list);
                     }
                 }
             }


### PR DESCRIPTION
Close #2162 

Issue #2162 is due to erroneous management of the pointers for the double linked "output queue". The existing test `stream_output` was not stressing the function `picoquic_reorder_output_stream_after_send` and was not testing that the reverse chain was correct after manipulation. Improving the test surfaced the issue, and verifies the fix.