### PR TITLE
Fix Header Protection interop failure with mbedtls backend

### DIFF
--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -518,7 +518,7 @@ static ptls_cipher_algorithm_t* picoquic_get_header_protection_cipher(ptls_ciphe
         else
 #endif
         {
-            hp_cipher = cipher->aead->ctr_cipher;
+            hp_cipher = cipher->aead->ecb_cipher;
         }
     }
 
@@ -1536,7 +1536,9 @@ static int picoquic_set_pn_enc_from_secret(void ** v_pn_enc, ptls_cipher_suite_t
     else if ((ret = ptls_hkdf_expand_label(cipher->hash, pnekey,
         hp_cipher->key_size, ptls_iovec_init(secret, cipher->hash->digest_size),
         PICOQUIC_LABEL_HP, ptls_iovec_init(NULL, 0), prefix_label)) == 0) {
-        if ((*v_pn_enc = ptls_cipher_new(hp_cipher, is_enc, pnekey)) == NULL) {
+        /* RFC 9001 Section 5.4.3: Header Protection always uses AES-ECB encrypt,
+         * regardless of the packet direction (send or receive). */
+        if ((*v_pn_enc = ptls_cipher_new(hp_cipher, 1, pnekey)) == NULL) {
             ret = PTLS_ERROR_NO_MEMORY;
         }
     }
@@ -2803,13 +2805,19 @@ void * picoquic_hp_enc_create_for_test(int cipher_suite_id, const uint8_t * hp_k
 
 size_t picoquic_pn_iv_size(void *pn_enc)
 {
-    return ((ptls_cipher_context_t *)pn_enc)->algo->iv_size;
+    /* AES-ECB has no IV; return AES block size (the HP sample length). */
+    (void)pn_enc;
+    return 16;
 }
 
 void picoquic_pn_encrypt(void *pn_enc, const void * iv, void *output, const void *input, size_t len)
 {
-    ptls_cipher_init((ptls_cipher_context_t *) pn_enc, iv);
-    ptls_cipher_encrypt((ptls_cipher_context_t *) pn_enc, output, input, len);
+    /* RFC 9001 Section 5.4.3: mask = AES-ECB(hp_key, sample).
+     * The "iv" parameter carries the 16-byte sample to encrypt. */
+    (void)input;
+    uint8_t mask[16];
+    ptls_cipher_encrypt((ptls_cipher_context_t *)pn_enc, mask, iv, 16);
+    memcpy(output, mask, len);
 }
 
 /* Utility functions, so applications do not have to load picotls.h */


### PR DESCRIPTION
## Summary

The Header Protection (HP) mask derivation uses `ctr_cipher` (AES-CTR) to compute `mask = AES(hp_key, sample)`. This relies on the assumption that `AES-CTR(key, IV=sample, zeros)` produces the same output as `AES-ECB(key, sample)`.

This assumption holds for OpenSSL (which treats the full 16-byte IV as the counter block), but **fails with mbedtls** which partitions the IV differently. The result is that a picoquic client using the mbedtls backend cannot complete the QUIC handshake with non-picoquic servers (e.g. ngtcp2), because:

1. The HP mask is computed incorrectly (CTR vs ECB mismatch)
2. The receive-direction HP context is created with `is_enc=0`, but AES-ECB decrypt ≠ encrypt, so inbound header deprotection silently fails

## Fix

1. Use `ecb_cipher` instead of `ctr_cipher` in `picoquic_get_header_protection_cipher()` — this directly implements RFC 9001 Section 5.4.3 which defines HP as a single AES-ECB block encrypt of the sample
2. Always pass `is_enc=1` when creating the HP cipher context (HP is always encrypt, regardless of packet direction)
3. Adapt `picoquic_pn_encrypt()` to directly ECB-encrypt the 16-byte sample
4. Return constant 16 from `picoquic_pn_iv_size()` (AES block size, since ECB has no IV)

## Notes

- This change is functionally equivalent for OpenSSL backend (AES-ECB and AES-CTR-with-full-IV produce the same output)
- Fixes interoperability with ngtcp2 server when picoquic uses mbedtls
- Tested: picoquic client (ESP32-C3, mbedtls) ↔ ngtcp2 server (picotls+mbedtls) — handshake completes and 1-RTT application data exchanges successfully