### PR TITLE
Fix HP cipher context created with wrong direction on receive path

### DIFF
--- a/picoquic/tls_api.c
+++ b/picoquic/tls_api.c
@@ -1524,6 +1524,7 @@ static int picoquic_set_pn_enc_from_secret(void ** v_pn_enc, ptls_cipher_suite_t
     uint8_t pnekey[PTLS_MAX_SECRET_SIZE];
     ptls_cipher_algorithm_t* hp_cipher = picoquic_get_header_protection_cipher(cipher);
     int ret = 0;
+    (void)is_enc;
 
     if (*v_pn_enc != NULL) {
         ptls_cipher_free((ptls_cipher_context_t *)*v_pn_enc);
@@ -1536,7 +1537,9 @@ static int picoquic_set_pn_enc_from_secret(void ** v_pn_enc, ptls_cipher_suite_t
     else if ((ret = ptls_hkdf_expand_label(cipher->hash, pnekey,
         hp_cipher->key_size, ptls_iovec_init(secret, cipher->hash->digest_size),
         PICOQUIC_LABEL_HP, ptls_iovec_init(NULL, 0), prefix_label)) == 0) {
-        if ((*v_pn_enc = ptls_cipher_new(hp_cipher, is_enc, pnekey)) == NULL) {
+        /* RFC 9001 Section 5.4.3: Header Protection always uses AES-ECB encrypt,
+         * regardless of the packet direction (send or receive). */
+        if ((*v_pn_enc = ptls_cipher_new(hp_cipher, 1, pnekey)) == NULL) {
             ret = PTLS_ERROR_NO_MEMORY;
         }
     }


### PR DESCRIPTION
## Summary

The Header Protection (HP) cipher context in `picoquic_set_pn_enc_from_secret()` is created with the directional `is_enc` flag passed through from the AEAD setup. For the receive path (`is_enc=0`), this causes the PSA key to be imported with `PSA_KEY_USAGE_DECRYPT` and the cipher operation to use `psa_cipher_decrypt_setup()`.

While AES-CTR is mathematically symmetric, some PSA/mbedtls implementations on constrained platforms produce different internal cipher state when initialized in decrypt mode vs encrypt mode, leading to incorrect HP masks for inbound packets. This causes interoperability failures when a picoquic client using the mbedtls backend communicates with non-picoquic servers (e.g. ngtcp2).

## Fix

RFC 9001 Section 5.4.3 defines Header Protection as always applying the cipher in the **encrypt** direction, regardless of whether the packet is being protected (sent) or deprotected (received). Fix by hardcoding `is_enc=1` when creating the HP cipher context.

## Testing

- picoquic client (mbedtls, ESP32-C3/NuttX) ↔ ngtcp2 server (picotls+mbedtls): handshake now completes and 1-RTT application data exchanges successfully
- The change is a no-op for backends where CTR encrypt == decrypt (OpenSSL, minicrypto), so existing behavior is preserved