### PR TITLE
Correct parity for stream IDs

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4713,14 +4713,14 @@ int picoquic_check_max_streams_frame_needs_repeat(picoquic_cnx_t* cnx, const uin
     else {
         if (bytes[0] == picoquic_frame_type_max_streams_bidir) {
             if (max_stream_rank <= cnx->max_stream_id_bidir_rank_acked ||
-                cnx->max_stream_id_bidir_local > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 0)) {
+                cnx->max_stream_id_bidir_local > STREAM_ID_FROM_RANK(max_stream_rank, !cnx->client_mode, 0)) {
                 /* Streams bidir already increased or already acked  */
                 *no_need_to_repeat = 1;
             }
         }
         else {
             if (max_stream_rank <= cnx->max_stream_id_unidir_rank_acked ||
-                cnx->max_stream_id_unidir_local > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 1)) {
+                cnx->max_stream_id_unidir_local > STREAM_ID_FROM_RANK(max_stream_rank, !cnx->client_mode, 1)) {
                 /* Streams unidir already increased or acked */
                 *no_need_to_repeat = 1;
             }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3797,10 +3797,10 @@ picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
         /* Initialize local flow control variables to advertised values */
         cnx->maxdata_local = ((uint64_t)cnx->local_parameters.initial_max_data);
         cnx->max_stream_id_bidir_local = STREAM_ID_FROM_RANK(
-            cnx->local_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
+            cnx->local_parameters.initial_max_stream_id_bidir, !cnx->client_mode, 0);
         cnx->max_stream_id_bidir_local_computed = STREAM_TYPE_FROM_ID(cnx->max_stream_id_bidir_local);
         cnx->max_stream_id_unidir_local = STREAM_ID_FROM_RANK(
-            cnx->local_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+            cnx->local_parameters.initial_max_stream_id_unidir, !cnx->client_mode, 1);
         cnx->max_stream_id_unidir_local_computed = STREAM_TYPE_FROM_ID(cnx->max_stream_id_unidir_local);
        
         /* Initialize padding policy to default for context */
@@ -4088,9 +4088,9 @@ void picoquic_set_transport_parameters(picoquic_cnx_t * cnx, picoquic_tp_t const
 
     cnx->maxdata_local = ((uint64_t)cnx->local_parameters.initial_max_data);
     cnx->max_stream_id_bidir_local = STREAM_ID_FROM_RANK(
-        cnx->local_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
+        cnx->local_parameters.initial_max_stream_id_bidir, !cnx->client_mode, 0);
     cnx->max_stream_id_unidir_local = STREAM_ID_FROM_RANK(
-        cnx->local_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+        cnx->local_parameters.initial_max_stream_id_unidir, !cnx->client_mode, 1);
 }
 
 picoquic_tp_t const* picoquic_get_transport_parameters(picoquic_cnx_t* cnx, int get_local)


### PR DESCRIPTION
Hi @huitema, I've been looking into some `STREAM_LIMIT_ERROR` issues we were hitting, and it led me to find something I wanted to get some verification on - I am not a QUIC expert by any means. I made a PR just so the code is easier to reference. 

I'm not sure if the local/peer parity of the stream ID from rank call is backwards when setting the `max_stream_id_unidir_local`, potentially causing an off by one error and rejecting the very last stream that should be accepted.

My understanding is that `max_stream_id_unidir_local` is our limit as sent to the peer, and thus is the max stream ID we will accept from the peer. However, we calculate that passing `cnx->client_mode` to `STREAM_ID_FROM_RANK` (what is our stream ID for that rank), when I think we should be using `!cnx->client_ mode` (what is their stream ID for that rank)? 

The actual check (which is correct) looks like:

```
else if (is_remote && stream_id > (IS_BIDIR_STREAM_ID(stream_id) ? cnx->max_stream_id_bidir_local : cnx->max_stream_id_unidir_local)){
        /* Protocol error, stream ID too high */
        picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR, 0);
    }    
```

i.e compare the incoming stream ID to `max_stream_id_bidir_local`.

I think the result here is that we may reject a valid stream ID at the very top end of the limit. For example, a limit of 512 would mean the acceptable peer initiated unidirectional stream ID `2047` would be rejected because the check would compare it to the largest locally initiated stream ID: `2046`?