### PR TITLE
Simplify the code managing stream ID limits

### DIFF
--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -41,7 +41,7 @@ picoquic_stream_head_t* picoquic_create_missing_streams(picoquic_cnx_t* cnx, uin
         /* TODO: not an error if lower than next stream, would be just an old stream. */
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR, 0);
     }
-    else if (is_remote && stream_id > (IS_BIDIR_STREAM_ID(stream_id) ? cnx->max_stream_id_bidir_local : cnx->max_stream_id_unidir_local)){
+    else if (is_remote && STREAM_RANK_FROM_ID(stream_id) > (IS_BIDIR_STREAM_ID(stream_id) ? cnx->max_streams_bidir_local : cnx->max_streams_unidir_local)){
         /* Protocol error, stream ID too high */
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR, 0);
     } 
@@ -1624,12 +1624,12 @@ uint8_t * picoquic_format_stream_blocked_frame(picoquic_cnx_t* cnx, uint8_t* byt
 
     if (IS_BIDIR_STREAM_ID(stream->stream_id)) {
         f_type = picoquic_frame_type_streams_blocked_bidir;
-        stream_limit = STREAM_RANK_FROM_ID(cnx->max_stream_id_bidir_remote);
+        stream_limit = cnx->max_streams_bidir_remote;
         should_not_send = cnx->stream_blocked_bidir_sent;
     }
     else {
         f_type = picoquic_frame_type_streams_blocked_unidir;
-        stream_limit = STREAM_RANK_FROM_ID(cnx->max_stream_id_unidir_remote);
+        stream_limit = cnx->max_streams_unidir_remote;
         should_not_send = cnx->stream_blocked_unidir_sent;
     }
     if (!should_not_send) {
@@ -1661,7 +1661,7 @@ uint8_t * picoquic_format_one_blocked_frame(picoquic_cnx_t* cnx, uint8_t* bytes,
         /* if the stream is not active yet, verify that it fits under
             * the max stream id limit, which depends of the type of stream */
         if (IS_CLIENT_STREAM_ID(stream->stream_id) == cnx->client_mode &&
-            stream->stream_id > ((IS_BIDIR_STREAM_ID(stream->stream_id)) ? cnx->max_stream_id_bidir_remote : cnx->max_stream_id_unidir_remote)) {
+            STREAM_RANK_FROM_ID(stream->stream_id) > ((IS_BIDIR_STREAM_ID(stream->stream_id)) ? cnx->max_streams_bidir_remote : cnx->max_streams_unidir_remote)) {
             if (!(IS_BIDIR_STREAM_ID(stream->stream_id) ? cnx->stream_blocked_bidir_sent : cnx->stream_blocked_unidir_sent))
             {
                 /* Prepare a stream blocked frame */
@@ -1792,7 +1792,7 @@ uint8_t * picoquic_format_stream_frame(picoquic_cnx_t* cnx, picoquic_stream_head
 
     /* Check parity */
     if (IS_CLIENT_STREAM_ID(stream->stream_id) == cnx->client_mode) {
-        if (stream->stream_id > ((IS_BIDIR_STREAM_ID(stream->stream_id)) ? cnx->max_stream_id_bidir_remote : cnx->max_stream_id_unidir_remote)) {
+        if (STREAM_RANK_FROM_ID(stream->stream_id) > ((IS_BIDIR_STREAM_ID(stream->stream_id)) ? cnx->max_streams_bidir_remote : cnx->max_streams_unidir_remote)) {
             /* Attempting to send data on a forbidden stream is a protocol error */
             return NULL;
         }
@@ -3387,7 +3387,7 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                 /* Malformed frame, do not retransmit */
                 *no_need_to_repeat = 1;
             }
-            else if (cnx->max_stream_id_bidir_remote > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 0)) {
+            else if (cnx->max_streams_bidir_remote > max_stream_rank) {
                 /* Streams bidir already increased */
                 *no_need_to_repeat = 1;
             }
@@ -3401,7 +3401,7 @@ int picoquic_check_frame_needs_repeat(picoquic_cnx_t* cnx, const uint8_t* bytes,
                 /* Malformed frame, do not retransmit */
                 *no_need_to_repeat = 1;
             }
-            else if (cnx->max_stream_id_unidir_remote > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 1)) {
+            else if (cnx->max_streams_unidir_remote > max_stream_rank) {
                 /* Streams unidir already increased */
                 *no_need_to_repeat = 1;
             }
@@ -4576,13 +4576,13 @@ uint8_t * picoquic_format_max_streams_frame_if_needed(picoquic_cnx_t* cnx,
 {
     uint8_t* bytes0 = bytes;
 
-    if (cnx->max_stream_id_bidir_local_computed + 
-        2*cnx->local_parameters.initial_max_stream_id_bidir > cnx->max_stream_id_bidir_local) {
-        uint64_t new_bidir_local = cnx->max_stream_id_bidir_local +
-            4 * cnx->local_parameters.initial_max_stream_id_bidir;
+    if (2*cnx->max_streams_bidir_local_computed + 
+        cnx->local_parameters.initial_max_stream_id_bidir > 2*cnx->max_streams_bidir_local) {
+        uint64_t new_bidir_local = cnx->max_streams_bidir_local +
+            cnx->local_parameters.initial_max_stream_id_bidir;
         if ((bytes = picoquic_frames_uint8_encode(bytes, bytes_max, picoquic_frame_type_max_streams_bidir)) != NULL &&
-            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, STREAM_RANK_FROM_ID(new_bidir_local))) != NULL) {
-            cnx->max_stream_id_bidir_local = new_bidir_local;
+            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, new_bidir_local)) != NULL) {
+            cnx->max_streams_bidir_local = new_bidir_local;
             *is_pure_ack = 0;
             bytes0 = bytes;
         } else {
@@ -4591,13 +4591,13 @@ uint8_t * picoquic_format_max_streams_frame_if_needed(picoquic_cnx_t* cnx,
         }
     }
     
-    if (cnx->max_stream_id_unidir_local_computed +
-        2*cnx->local_parameters.initial_max_stream_id_unidir > cnx->max_stream_id_unidir_local) {
-        uint64_t new_unidir_local = cnx->max_stream_id_unidir_local + 4*cnx->local_parameters.initial_max_stream_id_unidir;
+    if (2*cnx->max_streams_unidir_local_computed +
+        cnx->local_parameters.initial_max_stream_id_unidir > 2*cnx->max_streams_unidir_local) {
+        uint64_t new_unidir_local = cnx->max_streams_unidir_local + cnx->local_parameters.initial_max_stream_id_unidir;
 
         if ((bytes = picoquic_frames_uint8_encode(bytes, bytes_max, picoquic_frame_type_max_streams_unidir)) != NULL &&
-            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, STREAM_RANK_FROM_ID(new_unidir_local))) != NULL) {
-            cnx->max_stream_id_unidir_local = new_unidir_local;
+            (bytes = picoquic_frames_varint_encode(bytes, bytes_max, new_unidir_local)) != NULL) {
+            cnx->max_streams_unidir_local = new_unidir_local;
             *is_pure_ack = 0;
         }
         else {
@@ -4620,12 +4620,12 @@ void picoquic_update_max_stream_ID_local(picoquic_cnx_t* cnx, picoquic_stream_he
                 {
                     /* Sending is complete */
                     stream->max_stream_updated = 1;
-                    cnx->max_stream_id_bidir_local_computed += 4;
+                    cnx->max_streams_bidir_local_computed += 1;
                 }
             } else {
                 /* No need to check receive complete on uni directional streams */
                 stream->max_stream_updated = 1;
-                cnx->max_stream_id_unidir_local_computed += 4;
+                cnx->max_streams_unidir_local_computed += 1;
             }
         }
     }
@@ -4638,32 +4638,28 @@ const uint8_t* picoquic_decode_max_streams_frame(picoquic_cnx_t* cnx, const uint
     if ((bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &max_stream_rank)) == NULL) {
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
     }
+    else if (max_stream_rank >= (1ull << 60)) {
+        (void)picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
+        bytes = NULL;
+    }
     else {
-        uint64_t max_stream_id;
         if (max_streams_frame_type == picoquic_frame_type_max_streams_bidir) {
             /* Bidir */
-            max_stream_id = STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 0);
-            if (max_stream_id > cnx->max_stream_id_bidir_remote) {
-                uint64_t old_limit = cnx->max_stream_id_bidir_remote;
-                cnx->max_stream_id_bidir_remote = max_stream_id;
-                picoquic_add_output_streams(cnx, old_limit, max_stream_id, 1);
+            if (max_stream_rank > cnx->max_streams_bidir_remote) {
+                uint64_t old_limit = cnx->max_streams_bidir_remote;
+                cnx->max_streams_bidir_remote = max_stream_rank;
+                picoquic_add_output_streams(cnx, old_limit, max_stream_rank, 1);
                 cnx->stream_blocked_bidir_sent = 0;
             }
         }
         else {
             /* Unidir */
-            max_stream_id = STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 1);
-            if (max_stream_id > cnx->max_stream_id_unidir_remote) {
-                uint64_t old_limit = cnx->max_stream_id_unidir_remote;
-                cnx->max_stream_id_unidir_remote = max_stream_id;
-                picoquic_add_output_streams(cnx, old_limit, max_stream_id, 0);
+            if (max_stream_rank > cnx->max_streams_unidir_remote) {
+                uint64_t old_limit = cnx->max_streams_unidir_remote;
+                cnx->max_streams_unidir_remote = max_stream_rank;
+                picoquic_add_output_streams(cnx, old_limit, max_stream_rank, 0);
                 cnx->stream_blocked_unidir_sent = 0;
             }
-        }
-
-        if (max_stream_id >= (1ull << 62)) {
-            (void)picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
-            bytes = NULL;
         }
     }
 
@@ -4681,13 +4677,13 @@ int picoquic_process_ack_of_max_streams_frame(picoquic_cnx_t* cnx, const uint8_t
     if ((bytes_next = picoquic_frames_varint_decode(bytes + 1, bytes_max, &max_stream_rank)) != NULL) {
         *consumed = bytes_next - bytes;
         if (bytes[0] == picoquic_frame_type_max_streams_bidir) {
-            if (max_stream_rank > cnx->max_stream_id_bidir_rank_acked) {
-                cnx->max_stream_id_bidir_rank_acked = max_stream_rank;
+            if (max_stream_rank > cnx->max_streams_bidir_acked) {
+                cnx->max_streams_bidir_acked = max_stream_rank;
             }
         }
         else {
-            if (max_stream_rank > cnx->max_stream_id_unidir_rank_acked) {
-                cnx->max_stream_id_unidir_rank_acked = max_stream_rank;
+            if (max_stream_rank > cnx->max_streams_unidir_acked) {
+                cnx->max_streams_unidir_acked = max_stream_rank;
             }
         }
     }
@@ -4712,15 +4708,15 @@ int picoquic_check_max_streams_frame_needs_repeat(picoquic_cnx_t* cnx, const uin
     }
     else {
         if (bytes[0] == picoquic_frame_type_max_streams_bidir) {
-            if (max_stream_rank <= cnx->max_stream_id_bidir_rank_acked ||
-                cnx->max_stream_id_bidir_local > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 0)) {
+            if (max_stream_rank <= cnx->max_streams_bidir_acked ||
+                cnx->max_streams_bidir_local > max_stream_rank) {
                 /* Streams bidir already increased or already acked  */
                 *no_need_to_repeat = 1;
             }
         }
         else {
-            if (max_stream_rank <= cnx->max_stream_id_unidir_rank_acked ||
-                cnx->max_stream_id_unidir_local > STREAM_ID_FROM_RANK(max_stream_rank, cnx->client_mode, 1)) {
+            if (max_stream_rank <= cnx->max_streams_unidir_acked ||
+                cnx->max_streams_unidir_local > max_stream_rank) {
                 /* Streams unidir already increased or acked */
                 *no_need_to_repeat = 1;
             }
@@ -5050,9 +5046,8 @@ const uint8_t* picoquic_decode_streams_blocked_frame(picoquic_cnx_t* cnx, const 
             frame_id);
     }
     else {
-        uint64_t max_stream_id = (frame_id == picoquic_frame_type_streams_blocked_unidir) ?
-            cnx->max_stream_id_unidir_local : cnx->max_stream_id_bidir_local;
-        uint64_t local_limit = STREAM_RANK_FROM_ID(max_stream_id);
+        uint64_t local_limit= (frame_id == picoquic_frame_type_streams_blocked_unidir) ?
+            cnx->max_streams_unidir_local : cnx->max_streams_bidir_local;
         if (stream_limit > local_limit) {
             picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_STREAM_LIMIT_ERROR, frame_id);
         }

--- a/picoquic/frames.c
+++ b/picoquic/frames.c
@@ -4638,7 +4638,7 @@ const uint8_t* picoquic_decode_max_streams_frame(picoquic_cnx_t* cnx, const uint
     if ((bytes = picoquic_frames_varint_decode(bytes + 1, bytes_max, &max_stream_rank)) == NULL) {
         picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
     }
-    else if (max_stream_rank >= (1ull << 60)) {
+    else if (max_stream_rank > (1ull << 60)) {
         (void)picoquic_connection_error(cnx, PICOQUIC_TRANSPORT_FRAME_FORMAT_ERROR, max_streams_frame_type);
         bytes = NULL;
     }

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -797,7 +797,7 @@ typedef struct st_picoquic_stream_head_t {
 #define IS_CLIENT_STREAM_ID(id) (unsigned int)(((id) & 1) == 0)
 #define IS_BIDIR_STREAM_ID(id)  (unsigned int)(((id) & 2) == 0)
 #define IS_LOCAL_STREAM_ID(id, client_mode)  (unsigned int)(((id)^(client_mode)) & 1)
-#define STREAM_ID_FROM_RANK(rank, client_mode, is_unidir) ((((uint64_t)(rank)-(uint64_t)1)<<2)|(((uint64_t)is_unidir)<<1)|((uint64_t)(client_mode^1)))
+#define STREAM_ID_FROM_RANK(rank, is_client_stream, is_unidir) ((((uint64_t)(rank)-(uint64_t)1)<<2)|(((uint64_t)is_unidir)<<1)|((uint64_t)(is_client_stream^1)))
 #define STREAM_RANK_FROM_ID(id) ((id + 4)>>2)
 #define STREAM_TYPE_FROM_ID(id) ((id)&3)
 #define NEXT_STREAM_ID_FOR_TYPE(id) ((id)+4)

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1462,14 +1462,14 @@ typedef struct st_picoquic_cnx_t {
     uint64_t maxdata_remote; /* Highest value received from the peer */
     uint64_t max_stream_data_local;
     uint64_t max_stream_data_remote;
-    uint64_t max_stream_id_bidir_local; /* Highest value sent to the peer */
-    uint64_t max_stream_id_bidir_rank_acked; /* Highest rank value acked by the peer */
-    uint64_t max_stream_id_bidir_local_computed; /* Value computed from stream FIN but not yet sent */
-    uint64_t max_stream_id_bidir_remote; /* Highest value received from the peer */
-    uint64_t max_stream_id_unidir_local; /* Highest value sent to the peer */
-    uint64_t max_stream_id_unidir_rank_acked; /* Highest rank value acked by the peer */
-    uint64_t max_stream_id_unidir_local_computed;  /* Value computed from stream FIN but not yet sent */
-    uint64_t max_stream_id_unidir_remote; /* Highest value received from the peer */
+    uint64_t max_streams_bidir_local; /* Highest value sent to the peer */
+    uint64_t max_streams_bidir_acked; /* Highest rank value acked by the peer */
+    uint64_t max_streams_bidir_local_computed; /* Value computed from stream FIN but not yet sent */
+    uint64_t max_streams_bidir_remote; /* Highest value received from the peer */
+    uint64_t max_streams_unidir_local; /* Highest value sent to the peer */
+    uint64_t max_streams_unidir_acked; /* Highest rank value acked by the peer */
+    uint64_t max_streams_unidir_local_computed;  /* Value computed from stream FIN but not yet sent */
+    uint64_t max_streams_unidir_remote; /* Highest value received from the peer */
 
     /* Queue for frames waiting to be sent */
     picoquic_misc_frame_header_t* first_misc_frame;

--- a/picoquic/qmux.c
+++ b/picoquic/qmux.c
@@ -1235,10 +1235,10 @@ int picoqmux_start_client_cnx(picoquic_cnx_t* cnx)
          * and remote parameters may have been initialized to the initial value
          * of the previous session. Apply these new parameters. */
         cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
-        cnx->max_stream_id_bidir_remote =
-            STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
-        cnx->max_stream_id_unidir_remote =
-            STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+        cnx->max_streams_bidir_remote =
+            cnx->remote_parameters.initial_max_stream_id_bidir;
+        cnx->max_streams_unidir_remote =
+            cnx->remote_parameters.initial_max_stream_id_unidir;
         cnx->max_stream_data_remote = cnx->remote_parameters.initial_max_data;
         cnx->max_stream_data_local = cnx->local_parameters.initial_max_stream_data_bidi_local;
 

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -3796,12 +3796,12 @@ picoquic_cnx_t* picoquic_create_cnx_internal(picoquic_quic_t* quic,
  
         /* Initialize local flow control variables to advertised values */
         cnx->maxdata_local = ((uint64_t)cnx->local_parameters.initial_max_data);
-        cnx->max_stream_id_bidir_local = STREAM_ID_FROM_RANK(
-            cnx->local_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
-        cnx->max_stream_id_bidir_local_computed = STREAM_TYPE_FROM_ID(cnx->max_stream_id_bidir_local);
-        cnx->max_stream_id_unidir_local = STREAM_ID_FROM_RANK(
-            cnx->local_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
-        cnx->max_stream_id_unidir_local_computed = STREAM_TYPE_FROM_ID(cnx->max_stream_id_unidir_local);
+        cnx->max_streams_bidir_local = 
+            cnx->local_parameters.initial_max_stream_id_bidir;
+        cnx->max_streams_bidir_local_computed = 0;
+        cnx->max_streams_unidir_local =
+            cnx->local_parameters.initial_max_stream_id_unidir;
+        cnx->max_streams_unidir_local_computed = 0;
        
         /* Initialize padding policy to default for context */
         cnx->padding_multiple = quic->padding_multiple_default;
@@ -4061,10 +4061,10 @@ int picoquic_start_client_cnx(picoquic_cnx_t * cnx)
      * and remote parameters may have been initialized to the initial value
      * of the previous session. Apply these new parameters. */
     cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
-    cnx->max_stream_id_bidir_remote =
-        STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
-    cnx->max_stream_id_unidir_remote = 
-        STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+    cnx->max_streams_bidir_remote =
+        cnx->remote_parameters.initial_max_stream_id_bidir;
+    cnx->max_streams_unidir_remote = 
+        cnx->remote_parameters.initial_max_stream_id_unidir;
     cnx->max_stream_data_remote = cnx->remote_parameters.initial_max_data;
     cnx->max_stream_data_local = cnx->local_parameters.initial_max_stream_data_bidi_local;
 
@@ -4087,10 +4087,10 @@ void picoquic_set_transport_parameters(picoquic_cnx_t * cnx, picoquic_tp_t const
     /* Initialize local flow control variables to advertised values */
 
     cnx->maxdata_local = ((uint64_t)cnx->local_parameters.initial_max_data);
-    cnx->max_stream_id_bidir_local = STREAM_ID_FROM_RANK(
-        cnx->local_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
-    cnx->max_stream_id_unidir_local = STREAM_ID_FROM_RANK(
-        cnx->local_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+    cnx->max_streams_bidir_local = 
+        cnx->local_parameters.initial_max_stream_id_bidir;
+    cnx->max_streams_unidir_local =
+        cnx->local_parameters.initial_max_stream_id_unidir;
 }
 
 picoquic_tp_t const* picoquic_get_transport_parameters(picoquic_cnx_t* cnx, int get_local)

--- a/picoquic/streams.c
+++ b/picoquic/streams.c
@@ -645,8 +645,8 @@ void picoquic_insert_output_stream(picoquic_cnx_t* cnx, picoquic_stream_head_t* 
         /* Do not insert if the stream cannot be written to */
         if (IS_CLIENT_STREAM_ID(stream->stream_id) == cnx->client_mode) {
             uint64_t remote_limit = (IS_BIDIR_STREAM_ID(stream->stream_id)) ?
-                cnx->max_stream_id_bidir_remote : cnx->max_stream_id_unidir_remote;
-            if (stream->stream_id > remote_limit) {
+                cnx->max_streams_bidir_remote : cnx->max_streams_unidir_remote;
+            if (STREAM_RANK_FROM_ID(stream->stream_id) > remote_limit) {
                 /* The application marked this stream active (or queued data on it),
                  * but the peer has not yet granted enough stream credit: the stream
                  * ID is beyond the current MAX_STREAMS(_UNI) limit. The stream will
@@ -801,8 +801,8 @@ int picoquic_find_ready_stream_has_data(picoquic_cnx_t* cnx, picoquic_stream_hea
             if (stream->sent_offset == 0) {
                 if (IS_CLIENT_STREAM_ID(stream->stream_id) == cnx->client_mode) {
                     uint64_t remote_limit = (IS_BIDIR_STREAM_ID(stream->stream_id)) ?
-                        cnx->max_stream_id_bidir_remote : cnx->max_stream_id_unidir_remote;
-                    if (stream->stream_id > remote_limit) {
+                        cnx->max_streams_bidir_remote : cnx->max_streams_unidir_remote;
+                    if (STREAM_RANK_FROM_ID(stream->stream_id) > remote_limit) {
                         /* This is the path actually taken when an application calls
                          * picoquic_mark_active_stream() on a stream ID beyond the
                          * peer's currently granted MAX_STREAMS(_UNI) limit: the
@@ -845,13 +845,14 @@ void picoquic_update_output_stream(picoquic_cnx_t* cnx, picoquic_stream_head_t* 
 
 void picoquic_add_output_streams(picoquic_cnx_t* cnx, uint64_t old_limit, uint64_t new_limit, unsigned int is_bidir)
 {
-    uint64_t old_rank = STREAM_RANK_FROM_ID(old_limit);
+    uint64_t old_rank = old_limit;
     uint64_t first_new_id = STREAM_ID_FROM_RANK(old_rank + 1ull, cnx->client_mode, !is_bidir);
     picoquic_stream_head_t* stream = picoquic_find_stream(cnx, first_new_id);
 
     while (stream) {
-        if (stream->stream_id > old_limit) {
-            if (stream->stream_id > new_limit) {
+        uint64_t new_rank = STREAM_RANK_FROM_ID(stream->stream_id);
+        if (new_rank > old_limit) {
+            if (new_rank > new_limit) {
                 break;
             }
             if (IS_LOCAL_STREAM_ID(stream->stream_id, cnx->client_mode) && IS_BIDIR_STREAM_ID(stream->stream_id) == is_bidir) {
@@ -879,13 +880,13 @@ picoquic_stream_head_t* picoquic_create_stream(picoquic_cnx_t* cnx, uint64_t str
             if (IS_BIDIR_STREAM_ID(stream_id)) {
                 stream->maxdata_local = cnx->local_parameters.initial_max_stream_data_bidi_local;
                 stream->maxdata_remote = cnx->remote_parameters.initial_max_stream_data_bidi_remote;
-                is_output_stream = stream->stream_id <= cnx->max_stream_id_bidir_remote;
+                is_output_stream = (STREAM_RANK_FROM_ID(stream->stream_id) <= cnx->max_streams_bidir_remote);
 
             }
             else {
                 stream->maxdata_local = 0;
                 stream->maxdata_remote = cnx->remote_parameters.initial_max_stream_data_uni;
-                is_output_stream = stream->stream_id <= cnx->max_stream_id_unidir_remote;
+                is_output_stream = (STREAM_RANK_FROM_ID(stream->stream_id) <= cnx->max_streams_unidir_remote);
             }
         }
         else {

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -638,7 +638,7 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     uint64_t old_limit = cnx->max_streams_bidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_bidir =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
-                    if (cnx->remote_parameters.initial_max_stream_id_bidir >= (1ull << 60)) {
+                    if (cnx->remote_parameters.initial_max_stream_id_bidir > (1ull << 60)) {
                         ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max streams bidir");
                     }
                     else {

--- a/picoquic/transport.c
+++ b/picoquic/transport.c
@@ -533,12 +533,12 @@ void picoquic_clear_transport_extensions(picoquic_cnx_t* cnx)
     cnx->remote_parameters.initial_max_data = 0;
     cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
     cnx->remote_parameters.initial_max_stream_id_bidir = 0;
-    cnx->max_stream_id_bidir_remote = 0;
+    cnx->max_streams_bidir_remote = 0;
     cnx->remote_parameters.max_idle_timeout = 0;
     cnx->remote_parameters.max_packet_size = 1500;
     cnx->remote_parameters.ack_delay_exponent = 3;
     cnx->remote_parameters.initial_max_stream_id_unidir = 0;
-    cnx->max_stream_id_unidir_remote = 0;
+    cnx->max_streams_unidir_remote = 0;
     cnx->remote_parameters.migration_disabled = 0;
     cnx->remote_parameters.max_ack_delay = PICOQUIC_ACK_DELAY_MAX_DEFAULT;
     cnx->remote_parameters.max_datagram_frame_size = 0;
@@ -635,17 +635,16 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     cnx->maxdata_remote = cnx->remote_parameters.initial_max_data;
                     break;
                 case picoquic_tp_initial_max_streams_bidi: {
-                    uint64_t old_limit = cnx->max_stream_id_bidir_remote;
+                    uint64_t old_limit = cnx->max_streams_bidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_bidir =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                     if (cnx->remote_parameters.initial_max_stream_id_bidir >= (1ull << 60)) {
                         ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max streams bidir");
                     }
                     else {
-                        cnx->max_stream_id_bidir_remote = STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_bidir,
-                            cnx->client_mode, 0);
+                        cnx->max_streams_bidir_remote = cnx->remote_parameters.initial_max_stream_id_bidir;
                         cnx->max_stream_data_remote = cnx->remote_parameters.initial_max_stream_data_bidi_remote;
-                        picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_bidir_remote, 1);
+                        picoquic_add_output_streams(cnx, old_limit, cnx->max_streams_bidir_remote, 1);
                     }
                     break;
                 }
@@ -701,16 +700,15 @@ int picoquic_receive_transport_extensions(picoquic_cnx_t* cnx, int extension_mod
                     }
                     break;
                 case picoquic_tp_initial_max_streams_uni: {
-                    uint64_t old_limit = cnx->max_stream_id_unidir_remote;
+                    uint64_t old_limit = cnx->max_streams_unidir_remote;
                     cnx->remote_parameters.initial_max_stream_id_unidir =
                         picoquic_transport_param_varint_decode(cnx, bytes + byte_index, extension_length, &ret);
                     if (cnx->remote_parameters.initial_max_stream_id_unidir >= (1ull << 60)) {
                         ret = picoquic_connection_error_ex(cnx, PICOQUIC_TRANSPORT_PARAMETER_ERROR, 0, "Max streams unidir");
                     }
                     else {
-                        cnx->max_stream_id_unidir_remote = STREAM_ID_FROM_RANK(cnx->remote_parameters.initial_max_stream_id_unidir,
-                            cnx->client_mode, 1);
-                        picoquic_add_output_streams(cnx, old_limit, cnx->max_stream_id_unidir_remote, 0);
+                        cnx->max_streams_unidir_remote = cnx->remote_parameters.initial_max_stream_id_unidir;
+                        picoquic_add_output_streams(cnx, old_limit, cnx->max_streams_unidir_remote, 0);
                     }
                     break;
                 }

--- a/picoquicfirst/picoquicdemo.c
+++ b/picoquicfirst/picoquicdemo.c
@@ -981,8 +981,8 @@ int quic_client(const char* ip_address_text, int server_port,
                 picoquic_set_desired_version(cnx_client, config->desired_version);
             }
 
-            fprintf(stdout, "Max stream id bidir remote before start = %d (%d)\n",
-                (int)cnx_client->max_stream_id_bidir_remote,
+            fprintf(stdout, "Max streams bidir remote before start = %d (%d)\n",
+                (int)cnx_client->max_streams_bidir_remote,
                 (int)cnx_client->remote_parameters.initial_max_stream_id_bidir);
 
             if (config->ech_target != NULL) {
@@ -999,8 +999,8 @@ int quic_client(const char* ip_address_text, int server_port,
                     picoquic_supported_versions[cnx_client->version_index].version,
                     (unsigned long long)picoquic_val64_connection_id(picoquic_get_logging_cnxid(cnx_client)));
 
-                fprintf(stdout, "Max stream id bidir remote after start = %d (%d)\n",
-                    (int)cnx_client->max_stream_id_bidir_remote,
+                fprintf(stdout, "Max streams bidir remote after start = %d (%d)\n",
+                    (int)cnx_client->max_streams_bidir_remote,
                     (int)cnx_client->remote_parameters.initial_max_stream_id_bidir);
             }
 
@@ -1008,8 +1008,8 @@ int quic_client(const char* ip_address_text, int server_port,
                 if (picoquic_is_0rtt_available(cnx_client) && (config->proposed_version & 0x0a0a0a0a) != 0x0a0a0a0a) {
                     loop_cb.zero_rtt_available = 1;
 
-                    fprintf(stdout, "Max stream id bidir remote after 0rtt = %d (%d)\n",
-                        (int)cnx_client->max_stream_id_bidir_remote,
+                    fprintf(stdout, "Max streams bidir remote after 0rtt = %d (%d)\n",
+                        (int)cnx_client->max_streams_bidir_remote,
                         (int)cnx_client->remote_parameters.initial_max_stream_id_bidir);
 
                     /* Queue a simple frame to perform 0-RTT test */

--- a/picoquictest/qmux_test.c
+++ b/picoquictest/qmux_test.c
@@ -115,6 +115,11 @@ void qmux_test_simulate_remote(picoquic_cnx_t* cnx) {
     cnx->remote_parameters.initial_max_stream_data_bidi_local = 0x10000;
     cnx->remote_parameters.initial_max_stream_data_bidi_remote = 0x10000;
     cnx->remote_parameters.initial_max_stream_id_bidir = 100;
+    cnx->remote_parameters.initial_max_stream_id_unidir = 100;
+    cnx->max_streams_bidir_local = cnx->local_parameters.initial_max_stream_id_bidir;
+    cnx->max_streams_bidir_remote = cnx->remote_parameters.initial_max_stream_id_bidir;
+    cnx->max_streams_unidir_local = cnx->local_parameters.initial_max_stream_id_unidir;
+    cnx->max_streams_unidir_remote = cnx->remote_parameters.initial_max_stream_id_unidir;
 }
 
 int qmux_send_test(void)

--- a/picoquictest/skip_frame_test.c
+++ b/picoquictest/skip_frame_test.c
@@ -3400,10 +3400,10 @@ int send_stream_blocked_test_one(const struct st_stream_blocked_test_t * test)
             cnx->remote_parameters.initial_max_stream_id_unidir = 64;
         }
 
-        cnx->max_stream_id_bidir_remote = STREAM_ID_FROM_RANK(
-            cnx->remote_parameters.initial_max_stream_id_bidir, cnx->client_mode, 0);
-        cnx->max_stream_id_unidir_remote = STREAM_ID_FROM_RANK(
-            cnx->remote_parameters.initial_max_stream_id_unidir, cnx->client_mode, 1);
+        cnx->max_streams_bidir_remote = 
+            cnx->remote_parameters.initial_max_stream_id_bidir;
+        cnx->max_streams_unidir_remote = 
+            cnx->remote_parameters.initial_max_stream_id_unidir;
 
         if (test->is_data_blocked) {
             cnx->remote_parameters.initial_max_stream_data_bidi_local = 0;

--- a/picoquictest/stream0_frame_test.c
+++ b/picoquictest/stream0_frame_test.c
@@ -910,8 +910,8 @@ int stream_output_test(void)
             cnx->remote_parameters.initial_max_stream_data_bidi_remote = PICOQUIC_DEFAULT_0RTT_WINDOW;
             cnx->remote_parameters.initial_max_stream_data_uni = PICOQUIC_DEFAULT_0RTT_WINDOW;
             cnx->remote_parameters.initial_max_stream_data_bidi_local = PICOQUIC_DEFAULT_0RTT_WINDOW;
-            cnx->max_stream_id_bidir_remote = (cnx->client_mode) ? 4 : 0;
-            cnx->max_stream_id_unidir_remote = (cnx->client_mode) ? 10 : 0;
+            cnx->max_streams_bidir_remote = (cnx->client_mode) ? 2 : 0;
+            cnx->max_streams_unidir_remote = (cnx->client_mode) ? 3 : 0;
 
             cnx->high_priority_stream_id = 1;
 
@@ -925,9 +925,9 @@ int stream_output_test(void)
 
             if (ret == 0) {
                 /* Relax the max stream id value and test order again */
-                uint64_t old_limit = cnx->max_stream_id_bidir_remote;
-                cnx->max_stream_id_bidir_remote = 8;
-                picoquic_add_output_streams(cnx, old_limit, 8, 1);
+                uint64_t old_limit = cnx->max_streams_bidir_remote;
+                cnx->max_streams_bidir_remote = 3;
+                picoquic_add_output_streams(cnx, old_limit, 3, 1);
                 ret = stream_output_test_list(cnx, sizeof(output2) / sizeof(uint64_t), output2);
             }
 


### PR DESCRIPTION
This is an alternative to PR #2181, "correct parity for stream ID". The problem underlying that PR is that the code managing stream ID limits has to juggle variations of macros like STREAM_RANK_FROM_ID or STREAM_ID_FROM_RANK, and that the last one had a misleading signature, so we end up with mistakes. The root cause is a discrepancy between the code and the standard, because of the way the code was first written. RFC 9000 says "Only streams with a stream ID less than (max_streams * 4 + first_stream_id_of_type) can be opened; see [Table 1](https://www.rfc-editor.org/rfc/rfc9000.html#stream-id-types). Initial limits are set in the transport parameters; see [Section 18.2](https://www.rfc-editor.org/rfc/rfc9000.html#transport-parameter-definitions). Subsequent limits are advertised using MAX_STREAMS frames; see [Section 19.11](https://www.rfc-editor.org/rfc/rfc9000.html#frame-max-streams). Separate limits apply to unidirectional and bidirectional streams."

That means the limits set in transport parameters and in MAX_STREAMS frames are expressed as what we call "rank" in the code. That's a change from the early drafts, in which the limits were expressed as stream IDs (i.e., 4* rank + first). But to keep using stream ids, which requires adding complex macros and tests. The PR reverses that. It replaces old parameters like "cnx->max_stream_id_bidir_local", expressed as stream ID, by the new parameters like "cnx->max_streams_bidir_local", expressed as number of streams. As a result, the code becomes easier to read, and less error prone.

The bugs targeted by PR #2181 were due to misuse of the "client_mode" argument when computing stream limits using STREAM_ID_FROM_RANK. We fix that macro to make clear that the second argument is a stream ID type (created by client vs. server) and not a connection type (client vs server). We fix the issue by eliminating the use of the macro altogether.