### PR TITLE
Test an fix a last path abandoned issue.

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -3331,6 +3331,12 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(multipath_abandon_last) {
+            int ret = multipath_abandon_last_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(multipath_back0) {
             int ret = multipath_back0_test();
 

--- a/picoquic/picoquic.h
+++ b/picoquic/picoquic.h
@@ -115,6 +115,7 @@ extern "C" {
 #define PICOQUIC_ERROR_PACKET_TOO_BIG (PICOQUIC_ERROR_CLASS + 71)
 #define PICOQUIC_ERROR_OFFSET_TOO_BIG (PICOQUIC_ERROR_CLASS + 72)
 #define PICOQUIC_NO_ERROR_SCONE_ADVICE (PICOQUIC_ERROR_CLASS + 73)
+#define PICOQUIC_ERROR_PATH_LAST_REMAINING (PICOQUIC_ERROR_CLASS + 74)
 /*
  * Protocol errors defined in the QUIC spec
  */
@@ -1054,10 +1055,15 @@ void picoquic_set_rejected_version(picoquic_cnx_t* cnx, uint32_t rejected_versio
  * the new path will come in addition to the set of existing paths; if not,
  * the new path when validated will replace the default path.
  * The "abandon path" should only be used if multipath is enabled, and if more than
- * one path is available -- otherwise, just close the connection. If the command
- * is accepted, the peer will be informed of the need to close the path, and the
- * path will be demoted after a short delay. 
- * 
+ * one path is still available for use -- otherwise, just close the connection, or
+ * probe a new path before abandoning this one. If the command is accepted, the
+ * peer will be informed of the need to close the path, and the path will be
+ * demoted after a short delay. Calling picoquic_abandon_path() on the last path
+ * that is not already marked for demotion returns PICOQUIC_ERROR_PATH_LAST_REMAINING
+ * instead of demoting it, since that would eventually leave the connection with no
+ * path to send on. The peer abandoning its last path is not affected by this check;
+ * it simply results in the connection being closed.
+ *
  * Like all user-level networking API, the "probe new path" API assumes that the
  * port numbers in the socket addresses structures are expressed in network order.
  * 
@@ -1092,7 +1098,12 @@ void picoquic_set_rejected_version(picoquic_cnx_t* cnx, uint32_t rejected_versio
  *   PICOQUIC_ERROR_PATH_LIMIT_EXCEEDED: The application is trying to create more
  *   simultaneous paths than allowed. It will need to close one of the existing paths
  *   before creating a new one.
- * 
+ *
+ *   PICOQUIC_ERROR_PATH_LAST_REMAINING: returned by picoquic_abandon_path(). The
+ *   target path is the last one not already marked for demotion, so abandoning it
+ *   would leave the connection with no path to send on. The application should
+ *   close the connection instead, or probe a new path before abandoning this one.
+ *
  * The errors PICOQUIC_ERROR_PATH_ID_BLOCKED, PICOQUIC_ERROR_PATH_CID_BLOCKED.
  * PICOQUIC_ERROR_PATH_NOT_READY and PICOQUIC_ERROR_PATH_LIMIT_EXCEEDED are transient.
  * The application can use the `picoquic_check_new_path_allowed` API to check whether

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -2669,16 +2669,34 @@ int picoquic_abandon_path(picoquic_cnx_t* cnx, uint64_t unique_path_id,
         int path_index = picoquic_get_path_id_from_unique(cnx, unique_path_id);
 
         if (path_index >= 0) {
-            /* Check whether this is the last path */
-            if (cnx->nb_paths <= 1) {
-                /* That would mean deleting the last path. Don't do that */
-                ret = -1;
-            }
-            else if (!cnx->path[path_index]->path_is_demoted) {
-                /* if demotion is not already in progress, demote the path,
-                * and if the path can be properly identified, post a path abandon frame.
-                */
-                picoquic_demote_path(cnx, path_index, current_time, reason);
+            if (!cnx->path[path_index]->path_is_demoted) {
+                /* Check whether this is the last path not already marked for
+                 * demotion. A path that was abandoned earlier is still counted
+                 * in nb_paths until its demotion timer expires, so checking
+                 * nb_paths alone is not enough: it would let an application
+                 * abandon every path in turn, eventually leaving none.
+                 */
+                int nb_active = 0;
+
+                for (int i = 0; i < cnx->nb_paths; i++) {
+                    if (!cnx->path[i]->path_is_demoted) {
+                        nb_active++;
+                    }
+                }
+
+                if (nb_active <= 1) {
+                    /* That would mean leaving no path available. Don't do
+                     * that: the application should close the connection
+                     * instead, or probe a new path before abandoning this one.
+                     */
+                    ret = PICOQUIC_ERROR_PATH_LAST_REMAINING;
+                }
+                else {
+                    /* Demote the path, and if it can be properly identified,
+                     * post a path abandon frame.
+                     */
+                    picoquic_demote_path(cnx, path_index, current_time, reason);
+                }
             }
         }
         else {

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -637,6 +637,7 @@ static const picoquic_test_def_t test_table[] = {
     { "multipath_socket_error", multipath_socket_error_test },
     { "multipath_socket0_error", multipath_socket0_error_test },
     { "multipath_abandon", multipath_abandon_test },
+    { "multipath_abandon_last", multipath_abandon_last_test },
     { "multipath_back0", multipath_back0_test },
     { "multipath_back1", multipath_back1_test },
     { "multipath_nat", multipath_nat_test },

--- a/picoquictest/multipath_test.c
+++ b/picoquictest/multipath_test.c
@@ -1468,6 +1468,118 @@ int multipath_abandon_test(void)
     return  multipath_test_one(max_completion_microsec, multipath_test_abandon);
 }
 
+/* 
+ * Verify that abandoning the last valid path will fail.
+ *
+ * This test drives the connection into that state and checks the
+ * double abandon directly, by calling picoquic_delete_abandoned_paths()
+ * the way a live connection would before preparing its next packet
+ * -- so a still-broken tree fails this test cleanly
+ * instead of crashing the test binary.
+ */
+int multipath_abandon_last_test(void)
+{
+    uint64_t simulated_time = 0;
+    uint64_t loss_mask = 0;
+    picoquic_test_tls_api_ctx_t* test_ctx = NULL;
+    picoquic_tp_t server_parameters;
+    int ret = tls_api_init_ctx(&test_ctx, PICOQUIC_INTERNAL_TEST_VERSION_1,
+        PICOQUIC_TEST_SNI, PICOQUIC_TEST_ALPN, &simulated_time, NULL, NULL, 0, 1, 0);
+
+    if (ret == 0 && test_ctx == NULL) {
+        ret = -1;
+    }
+
+    if (ret == 0) {
+        test_ctx->c_to_s_link->queue_delay_max = 2 * test_ctx->c_to_s_link->microsec_latency;
+        test_ctx->s_to_c_link->queue_delay_max = 2 * test_ctx->s_to_c_link->microsec_latency;
+        /* Set the multipath option at both client and server */
+        multipath_init_params(&server_parameters, 0);
+        picoquic_set_default_tp(test_ctx->qserver, &server_parameters);
+        test_ctx->cnx_client->local_parameters.initial_max_path_id = 3;
+        (void)picoquic_start_client_cnx(test_ctx->cnx_client);
+    }
+
+    /* establish the connection */
+    if (ret == 0) {
+        ret = tls_api_connection_loop(test_ctx, &loss_mask, 2 * test_ctx->s_to_c_link->microsec_latency, &simulated_time);
+    }
+
+    if (ret == 0 && (!test_ctx->cnx_client->is_multipath_enabled || !test_ctx->cnx_server->is_multipath_enabled)) {
+        DBG_PRINTF("Multipath not fully negotiated (c=%d, s=%d)",
+            test_ctx->cnx_client->is_multipath_enabled, test_ctx->cnx_server->is_multipath_enabled);
+        ret = -1;
+    }
+
+    if (ret == 0) {
+        ret = wait_client_connection_ready(test_ctx, &simulated_time);
+    }
+
+    /* Add a second path, and wait until both sides have validated it. */
+    if (ret == 0) {
+        ret = multipath_test_add_links(test_ctx, 0);
+    }
+    if (ret == 0) {
+        ret = picoquic_probe_new_path(test_ctx->cnx_client, (struct sockaddr*)&test_ctx->server_addr,
+            (struct sockaddr*)&test_ctx->client_addr_2, simulated_time);
+    }
+    if (ret == 0) {
+        ret = wait_multipath_ready(test_ctx, &simulated_time);
+    }
+
+    if (ret == 0 && test_ctx->cnx_client->nb_paths != 2) {
+        DBG_PRINTF("Expected 2 paths on the client, got %d", test_ctx->cnx_client->nb_paths);
+        ret = -1;
+    }
+
+    /* Abandon path 1. This is normal, supported usage: more than one path is
+     * available, so the call succeeds and path 1 is marked for demotion. */
+    if (ret == 0) {
+        ret = picoquic_abandon_path(test_ctx->cnx_client, 1, 0, simulated_time);
+        if (ret != 0) {
+            DBG_PRINTF("Could not abandon path 1, ret=%d", ret);
+        }
+    }
+
+    /* Abandon path 0 as well -- the last path not yet marked for demotion.
+     * This call should be rejected. */
+    if (ret == 0) {
+        int abandon_ret = picoquic_abandon_path(test_ctx->cnx_client, 0, 0, simulated_time);
+
+        if (abandon_ret == PICOQUIC_ERROR_PATH_LAST_REMAINING) {
+            /* Expected: abandoning the last non-demoted path is refused. */
+            ret = 0;
+        }
+        else if (abandon_ret != 0) {
+            DBG_PRINTF("Abandoning the last non-demoted path returned %d, expected PICOQUIC_ERROR_PATH_LAST_REMAINING.", abandon_ret);
+            ret = -1;
+        }
+        else {
+            uint64_t next_wake_time = simulated_time;
+            uint64_t future_time = simulated_time + 10000000;
+
+            DBG_PRINTF("%s", "Abandoning the last non-demoted path wrongly succeeded.");
+
+            /* Let both demotion timers expire, then run the path cleanup
+             * that a live connection performs before sending. */
+            picoquic_delete_abandoned_paths(test_ctx->cnx_client, future_time, &next_wake_time);
+
+            if (test_ctx->cnx_client->nb_paths == 0 || test_ctx->cnx_client->path[0] == NULL) {
+                DBG_PRINTF("Client left with %d paths, path[0] = %p.",
+                    test_ctx->cnx_client->nb_paths,
+                    (void*)test_ctx->cnx_client->path[0]);
+            }
+            ret = -1;
+        }
+    }
+
+    if (test_ctx != NULL) {
+        tls_api_delete_ctx(test_ctx);
+    }
+
+    return ret;
+}
+
 /* Test that after breaking path 0 we can establish a new path on the
 * same link when it comes back up.
  */

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -586,6 +586,7 @@ int multipath_break1_test(void);
 int multipath_socket_error_test(void);
 int multipath_socket0_error_test(void);
 int multipath_abandon_test(void);
+int multipath_abandon_last_test(void);
 int multipath_back0_test(void);
 int multipath_back1_test(void);
 int multipath_perf_test(void);


### PR DESCRIPTION
This code change is motivated by issue #2188 . It tests the main scenario for ending up with zero valid paths, i.e., abandoning all the paths. The abandon path API will return an error PICOQUIC_ERROR_PATH_LAST_REMAINING in that case.

The PR also protects against two other mode of path deletions, by the peer and on timer. If the peer abandons the last path, this is treated as an error and the connection is immediately closed. If the last path is abandoned due to the validation timer, this is treated the same way as the idle timer and results in immediate connection closure.