### PR TITLE
Add a quicperf loopback test

### DIFF
--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -101,6 +101,7 @@ static LONG WINAPI picohttp_t_crash_handler(EXCEPTION_POINTERS* ex)
 extern size_t picohttp_nb_stress_clients;
 extern size_t picohttp_test_multifile_number;
 extern uint64_t picohttp_random_stress_context;
+extern uint64_t picohttp_perf_loopback_size;
 
 typedef struct st_picoquic_test_def_t {
     char const* test_name;
@@ -202,6 +203,7 @@ static const picoquic_test_def_t test_table[] = {
     { "quicperf_multipath_race", quicperf_multipath_race_test },
     { "quicperf_multipath_race_delayed", quicperf_multipath_race_delayed_test },
     { "quicperf_multipath_settled", quicperf_multipath_settled_test },
+    { "perf_loopback", perf_loopback_test },
     { "cc_compete_cubic2", cc_compete_cubic2_test },
     { "cc_compete_prague2", cc_compete_prague2_test },
     { "cc_compete_c4c4", cc_compete_c4c4_test },
@@ -267,6 +269,7 @@ int usage(char const * argv0)
     fprintf(stderr, "  -s nnn            Set the number of stress clients to nnn.\n");
     fprintf(stderr, "  -R xxxxxxxx       Set seed for stress tests to xxxxxxxx.\n");
     fprintf(stderr, "  -m nnn            Set number of files in multi file tests to nnn.\n");
+    fprintf(stderr, "  -p nnn            Set the response size in bytes for perf_loopback to nnn.\n");
     fprintf(stderr, "  -n                Disable debug prints.\n");
     fprintf(stderr, "  -r                Retry failed tests with debug print enabled.\n");
     fprintf(stderr, "  -h                Print this help message\n");
@@ -284,6 +287,13 @@ int usage(char const * argv0)
     fprintf(stderr, "with loss and using preemptive repeat. For all these tests,\n");
     fprintf(stderr, "the number of files is controlled by the \"-m\" option\n");
     fprintf(stderr, "(default: 1000).\n");
+    fprintf(stderr, "\nThe perf_loopback test downloads a batch of the given size over\n");
+    fprintf(stderr, "a single QUIC context looped back on itself, with no socket and\n");
+    fprintf(stderr, "no simulated network delay -- it is meant for profiling the sending\n");
+    fprintf(stderr, "path. The response size is controlled by the \"-p\" option, in bytes\n");
+    fprintf(stderr, "(default: 1000000). Set it much higher (e.g. 10000000000 for 10GB)\n");
+    fprintf(stderr, "when actually profiling; the default is kept small so the test\n");
+    fprintf(stderr, "suite stays fast.\n");
 
     return -1;
 }
@@ -324,7 +334,7 @@ int main(int argc, char** argv)
     }
     else
     {
-        while (ret == 0 && (opt = getopt(argc, argv, "R:s:m:S:x:nrh")) != -1) {
+        while (ret == 0 && (opt = getopt(argc, argv, "R:s:m:p:S:x:nrh")) != -1) {
             switch (opt) {
             case 'x': {
                 int test_number = get_test_number(optarg);
@@ -368,6 +378,19 @@ int main(int argc, char** argv)
                     picohttp_test_multifile_number = (size_t)nb_multi_file;
                 }
                 break;
+            case 'p': {
+                char* end_ptr = NULL;
+                unsigned long long perf_loopback_size = strtoull(optarg, &end_ptr, 10);
+
+                if (perf_loopback_size == 0 || end_ptr == NULL || *end_ptr != 0) {
+                    fprintf(stderr, "Incorrect response size for perf_loopback: %s\n", optarg);
+                    ret = usage(argv[0]);
+                }
+                else {
+                    picohttp_perf_loopback_size = (uint64_t)perf_loopback_size;
+                }
+                break;
+            }
             case 'S':
                 picoquic_set_solution_dir(optarg);
                 break;

--- a/picohttp_t/picohttp_t.c
+++ b/picohttp_t/picohttp_t.c
@@ -204,6 +204,7 @@ static const picoquic_test_def_t test_table[] = {
     { "quicperf_multipath_race_delayed", quicperf_multipath_race_delayed_test },
     { "quicperf_multipath_settled", quicperf_multipath_settled_test },
     { "perf_loopback", perf_loopback_test },
+    { "perf_loopback_loss", perf_loopback_loss_test },
     { "cc_compete_cubic2", cc_compete_cubic2_test },
     { "cc_compete_prague2", cc_compete_prague2_test },
     { "cc_compete_c4c4", cc_compete_c4c4_test },

--- a/picoquic/packet.c
+++ b/picoquic/packet.c
@@ -2188,7 +2188,6 @@ int picoquic_incoming_segment(
         }
 
         if (ret == 0) {
-            picoquic_scone_ready_to_send(cnx, (path_id < 0) ? NULL : cnx->path[path_id], current_time);
             picoquic_log_packet(cnx, (path_id < 0)?NULL:cnx->path[path_id], 1, current_time, &ph, bytes, *consumed);
         }
         else if (is_buffered) {

--- a/picoquic/picoquic_internal.h
+++ b/picoquic/picoquic_internal.h
@@ -1794,7 +1794,7 @@ void picoquic_client_almost_ready_transition(picoquic_cnx_t* cnx);
 void picoquic_ready_state_transition(picoquic_cnx_t* cnx, uint64_t current_time);
 int picoquic_prepare_segment(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
-    uint64_t* next_wake_time, int* is_initial_sent);
+    uint64_t* next_wake_time, int* is_initial_sent, int is_first_in_batch);
 
 int picoquic_parse_header_and_decrypt(
     picoquic_quic_t* quic,

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -453,7 +453,9 @@ static void picoquic_update_issued_ticket(
         ip_addr_length = PICOQUIC_STORED_IP_MAX;
     }
     ticket->ip_addr_length = ip_addr_length;
-    memcpy(ticket->ip_addr, ip_addr, ip_addr_length);
+    if (ip_addr_length > 0) {
+        memcpy(ticket->ip_addr, ip_addr, ip_addr_length);
+    }
     ticket->rtt = rtt;
     ticket->cwin = cwin;
 }

--- a/picoquic/quicctx.c
+++ b/picoquic/quicctx.c
@@ -1558,9 +1558,15 @@ static void picoquic_insert_cnx_by_wake_time(picoquic_quic_t* quic, picoquic_cnx
 
 void picoquic_reinsert_by_wake_time(picoquic_quic_t* quic, picoquic_cnx_t* cnx, uint64_t next_time)
 {
-    picoquic_remove_cnx_from_wake_list(cnx);
-    cnx->next_wake_time = next_time;
-    picoquic_insert_cnx_by_wake_time(quic, cnx);
+    if (cnx->is_wake_ready && cnx == quic->cnx_wake_ready_last && next_time <= picoquic_get_quic_time(quic)) {
+        /* Already at the tail of the ready list: no change needed. */
+        cnx->next_wake_time = next_time;
+    }
+    else {
+        picoquic_remove_cnx_from_wake_list(cnx);
+        cnx->next_wake_time = next_time;
+        picoquic_insert_cnx_by_wake_time(quic, cnx);
+    }
 }
 
 static void picoquic_wake_list_promote_ready(picoquic_quic_t* quic, uint64_t max_wake_time)

--- a/picoquic/sacks.c
+++ b/picoquic/sacks.c
@@ -177,8 +177,13 @@ int picoquic_is_pn_already_received(picoquic_cnx_t* cnx,
 {
     int is_received = 0;
     picoquic_sack_list_t* sack_list = picoquic_sack_list_from_cnx_context(cnx, pc, l_cid);
+    picoquic_sack_item_t* highest = picoquic_sack_last_item(sack_list);
 
-    if (sack_list->horizon_delay > 0 && pn64 < sack_list->ack_horizon) {
+    if (highest != NULL && pn64 > highest->end_of_sack_range) {
+        /* Fast path: beyond everything received so far, so it cannot be a duplicate. */
+        is_received = 0;
+    }
+    else if (sack_list->horizon_delay > 0 && pn64 < sack_list->ack_horizon) {
         is_received = 1;
     }
     else {
@@ -197,59 +202,72 @@ int picoquic_is_pn_already_received(picoquic_cnx_t* cnx,
 int picoquic_update_sack_list(picoquic_sack_list_t* sack_list,
     uint64_t pn64_min, uint64_t pn64_max, uint64_t current_time)
 {
-    int ret = 1; /* duplicate by default, reset to 0 if update found */
-    picoquic_sack_item_t* previous = picoquic_sack_find_range_below_number(sack_list, NULL, pn64_min);
+    int ret;
+    picoquic_sack_item_t* highest = picoquic_sack_last_item(sack_list);
 
-    if (previous == NULL || previous->end_of_sack_range + 1 < pn64_min) {
-        /* No overlap with a range below */
-        picoquic_sack_item_t* next = (previous == NULL) ?
-            picoquic_sack_first_item(sack_list) : picoquic_sack_next_item(previous);
-        if (next == NULL || next->start_of_sack_range - 1 > pn64_max) {
-            /* create a new item in the list */
-            ret = picoquic_sack_insert_item(sack_list, pn64_min, pn64_max, current_time);
-            /* set previous to null to bypass the next block */
-            previous = NULL;
-        }
-        else {
-            /* extend the existing item towards the min. */
-            next->start_of_sack_range = pn64_min;
-            /* record that this item was modified. */
-            picoquic_sack_item_record_reset(sack_list, next);
-            next->time_created = current_time;
-            ret = 0;
-            /* set previous to next and do the extension part */
-            previous = next;
-        }
+    if (highest != NULL && pn64_min == highest->end_of_sack_range + 1) {
+        /* Fast path: packet is the next expected one, so just extend the highest range. */
+        highest->end_of_sack_range = pn64_max;
+        picoquic_sack_item_record_reset(sack_list, highest);
+        highest->time_created = current_time;
+        ret = 0;
     }
-    while (previous != NULL && previous->end_of_sack_range < pn64_max) {
-        /* we found or created an item that includes the beginning
-         * of the acked range. Check the next one */
-        picoquic_sack_item_t* next = picoquic_sack_next_item(previous);
-        if (next == NULL || next->start_of_sack_range - 1 > pn64_max) {
-            /* No overlap. Extend the previous item up to the max of the range */
-            previous->end_of_sack_range = pn64_max;
-            /* record that this item was modified. */
-            picoquic_sack_item_record_reset(sack_list, previous);
-            previous->time_created = current_time;
-            ret = 0;
-        }
-        else {
-            /* Overlap. */
-            /* Extend the range of the previous item to include the next one. */
-            previous->end_of_sack_range = next->end_of_sack_range;
-            /* record that this item was modified. */
-            picoquic_sack_item_record_reset(sack_list, previous);
-            if (next->time_created > previous->time_created) {
-                previous->time_created = next->time_created;
+    else {
+        picoquic_sack_item_t* previous = picoquic_sack_find_range_below_number(sack_list, NULL, pn64_min);
+
+        ret = 1; /* duplicate by default, reset to 0 if update found */
+
+        if (previous == NULL || previous->end_of_sack_range + 1 < pn64_min) {
+            /* No overlap with a range below */
+            picoquic_sack_item_t* next = (previous == NULL) ?
+                picoquic_sack_first_item(sack_list) : picoquic_sack_next_item(previous);
+            if (next == NULL || next->start_of_sack_range - 1 > pn64_max) {
+                /* create a new item in the list */
+                ret = picoquic_sack_insert_item(sack_list, pn64_min, pn64_max, current_time);
+                /* set previous to null to bypass the next block */
+                previous = NULL;
             }
-            ret = 0;
-            /* Delete the next item, accounting of ack times, etc. */
-            picoquic_sack_delete_item(sack_list, next);
+            else {
+                /* extend the existing item towards the min. */
+                next->start_of_sack_range = pn64_min;
+                /* record that this item was modified. */
+                picoquic_sack_item_record_reset(sack_list, next);
+                next->time_created = current_time;
+                ret = 0;
+                /* set previous to next and do the extension part */
+                previous = next;
+            }
         }
-    }
+        while (previous != NULL && previous->end_of_sack_range < pn64_max) {
+            /* we found or created an item that includes the beginning
+             * of the acked range. Check the next one */
+            picoquic_sack_item_t* next = picoquic_sack_next_item(previous);
+            if (next == NULL || next->start_of_sack_range - 1 > pn64_max) {
+                /* No overlap. Extend the previous item up to the max of the range */
+                previous->end_of_sack_range = pn64_max;
+                /* record that this item was modified. */
+                picoquic_sack_item_record_reset(sack_list, previous);
+                previous->time_created = current_time;
+                ret = 0;
+            }
+            else {
+                /* Overlap. */
+                /* Extend the range of the previous item to include the next one. */
+                previous->end_of_sack_range = next->end_of_sack_range;
+                /* record that this item was modified. */
+                picoquic_sack_item_record_reset(sack_list, previous);
+                if (next->time_created > previous->time_created) {
+                    previous->time_created = next->time_created;
+                }
+                ret = 0;
+                /* Delete the next item, accounting of ack times, etc. */
+                picoquic_sack_delete_item(sack_list, next);
+            }
+        }
 
-    if (sack_list->horizon_delay > 0) {
-        picoquic_update_ack_horizon(sack_list, current_time);
+        if (sack_list->horizon_delay > 0) {
+            picoquic_update_ack_horizon(sack_list, current_time);
+        }
     }
 
     return ret;
@@ -446,7 +464,7 @@ int picoquic_sack_list_reset(picoquic_sack_list_t* sack_list, uint64_t range_min
     return ret;
 }
 
-/* Free the elements of a sack list 
+/* Free the elements of a sack list
  */
 void picoquic_sack_list_free(picoquic_sack_list_t* sack_list)
 {

--- a/picoquic/scone.c
+++ b/picoquic/scone.c
@@ -271,7 +271,7 @@ int picoquic_scone_prepare(picoquic_cnx_t * cnx, picoquic_path_t* path_x, picoqu
         size_t next_segment_length = 0;
 
         ret = picoquic_prepare_segment(cnx, path_x, packet, current_time,
-            bytes, available - coalesced_packet_size, &next_segment_length, next_wake_time, is_initial_sent);
+            bytes, available - coalesced_packet_size, &next_segment_length, next_wake_time, is_initial_sent, 1);
         if (ret == 0 && next_segment_length > 0) {
             /* we are actually sending a segment.
             * add the SCONE packet size to the segment length,

--- a/picoquic/sender.c
+++ b/picoquic/sender.c
@@ -2797,6 +2797,128 @@ int picoquic_prepare_packet_almost_ready(picoquic_cnx_t* cnx, picoquic_path_t* p
 }
 
 /*  Prepare the next packet to send when in the ready state */
+/* Shared closing logic for a 1-RTT packet: PTO/keep-alive/ack-of-ack bookkeeping,
+ * padding, and encryption. Used both by the full picoquic_prepare_packet_ready (every
+ * first packet of a send-buffer batch) and by picoquic_prepare_packet_ready_fast (every
+ * later packet of the same batch, see picoquic_prepare_packet_ex): the two differ only in
+ * how much of the "is there something other than stream data to send" gauntlet they run
+ * before reaching this point, never in how a packet gets closed out once its content is
+ * decided. Keeping that one implementation shared avoids the two versions silently
+ * drifting apart on padding policy or encryption. */
+static int picoquic_prepare_packet_ready_finish(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_packet_t* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t* send_length, uint64_t* next_wake_time,
+    picoquic_packet_context_t* pkt_ctx, picoquic_packet_type_enum packet_type, picoquic_packet_context_enum pc,
+    uint8_t* bytes, size_t header_length, size_t length, int ret, int is_pure_ack, int ack_sent, int more_data,
+    int is_challenge_padding_needed, size_t checksum_overhead, size_t send_buffer_min_max)
+{
+    uint8_t* bytes_max = bytes + send_buffer_min_max - checksum_overhead;
+    uint8_t* bytes_next;
+
+    if (length <= header_length) {
+        length = 0;
+    }
+
+    if (cnx->cnx_state != picoquic_state_disconnected) {
+        if (length > 0){
+            path_x->is_pto_required &= is_pure_ack;
+            pkt_ctx->ack_of_ack_requested |= !is_pure_ack;
+            if (!pkt_ctx->ack_of_ack_requested && ack_sent) {
+                /* If we have sent many ACKs, add a PING to get an ack of ack */
+                /* The number 24 is chosen to not break any of the unit tests. If the number is
+                 * too small, the PING mechanism can cause delayed end of the connection, or
+                 * early breakage */
+                const uint64_t ack_repeat_interval = 24;
+                bytes_next = bytes + length;
+                if (bytes_next < bytes_max &&
+                    pkt_ctx->highest_acknowledged + ack_repeat_interval < pkt_ctx->send_sequence &&
+                    path_x == cnx->path[0] &&
+                    pkt_ctx->highest_acknowledged_time + path_x->smoothed_rtt < current_time) {
+                    /* Bundle a Ping with ACK, so as to get trigger an Acknowledgement */
+                    *bytes_next++ = picoquic_frame_type_ping;
+                    pkt_ctx->ack_of_ack_requested = 1;
+                    is_pure_ack = 0;
+                    length = bytes_next - bytes;
+                }
+            }
+
+            if (is_pure_ack && cnx->is_multipath_enabled &&
+                path_x->is_ack_lost && !path_x->is_ack_expected) {
+                /* In some multipath scenarios, we may need to ping a path if we see
+                 * non-ackable packets being lost. */
+                bytes_next = bytes + length;
+                if (bytes_next < bytes_max) {
+                    is_pure_ack = 0;
+                    *bytes_next = picoquic_frame_type_ping;
+                    length++;
+                }
+            }
+
+            if (!is_pure_ack) {
+                path_x->is_ack_expected = 1;
+            }
+        }
+
+        if (is_pure_ack == 0)
+        {
+            cnx->latest_progress_time = current_time;
+        }
+        else if (cnx->keep_alive_interval != 0) {
+            /* If necessary, encode and send the keep alive packet.
+             * We only send keep alive packets when no other data is sent.
+             */
+            if (cnx->latest_progress_time + cnx->keep_alive_interval <= current_time && length == 0) {
+                length = picoquic_predict_packet_header_length(
+                    cnx, packet_type, pkt_ctx);
+                packet->ptype = packet_type;
+                packet->pc = pc;
+                packet->offset = length;
+                header_length = length;
+                packet->sequence_number = pkt_ctx->send_sequence;
+                packet->send_path = path_x;
+                packet->send_time = current_time;
+                bytes[length++] = picoquic_frame_type_ping;
+                bytes[length++] = 0;
+                cnx->latest_progress_time = current_time;
+            }
+            else if (cnx->latest_progress_time + cnx->keep_alive_interval < *next_wake_time) {
+                *next_wake_time = cnx->latest_progress_time + cnx->keep_alive_interval;
+                SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+            }
+        }
+
+        if (more_data) {
+            *next_wake_time = current_time;
+            SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+            ret = 0;
+        }
+    }
+
+    if (ret == 0 && length > header_length) {
+        /* Ensure that all packets are properly padded before being sent. */
+        if (is_challenge_padding_needed && length < PICOQUIC_ENFORCED_INITIAL_MTU) {
+            length = picoquic_pad_to_target_length(bytes, length, (uint32_t)(send_buffer_min_max - checksum_overhead));
+        }
+        else {
+            length = picoquic_pad_to_policy(cnx, bytes, length, (uint32_t)(send_buffer_min_max - checksum_overhead));
+        }
+    }
+
+    picoquic_finalize_and_protect_packet(cnx, packet,
+        ret, length, header_length, checksum_overhead,
+        send_length, send_buffer, send_buffer_min_max,
+        path_x, current_time, !is_pure_ack);
+
+    if (*send_length > 0) {
+        *next_wake_time = current_time;
+        SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
+
+        if (ret == 0 && picoquic_cnx_is_still_logging(cnx)) {
+            picoquic_log_cc_dump(cnx, current_time);
+        }
+    }
+    return ret;
+}
+
 int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length, uint64_t* next_wake_time)
 {
@@ -2895,10 +3017,13 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
         /* If required, prepare challenge and response frames.
          * These frames will be sent immediately, regardless of pacing or flow control.
          */
-        bytes_next = picoquic_prepare_path_challenge_frames(cnx, path_x,
-            bytes_next, bytes_max,
-            &more_data, &is_pure_ack, &is_challenge_padding_needed,
-            current_time, next_wake_time);
+        if ((path_x->first_tuple->challenge_verified == 0 && path_x->first_tuple->challenge_failed == 0) ||
+            path_x->first_tuple->response_required) {
+            bytes_next = picoquic_prepare_path_challenge_frames(cnx, path_x,
+                bytes_next, bytes_max,
+                &more_data, &is_pure_ack, &is_challenge_padding_needed,
+                current_time, next_wake_time);
+        }
 
         /* Compute the length before pacing block */
         length = bytes_next - bytes;
@@ -3124,109 +3249,107 @@ int picoquic_prepare_packet_ready(picoquic_cnx_t* cnx, picoquic_path_t* path_x, 
         } /* End of challenge verified */
     }
 
-    if (length <= header_length) {
-        length = 0;
-    }
+    return picoquic_prepare_packet_ready_finish(cnx, path_x, packet, current_time, send_buffer, send_length, next_wake_time,
+        pkt_ctx, packet_type, pc, bytes, header_length, length, ret, is_pure_ack, ack_sent, more_data,
+        is_challenge_padding_needed, checksum_overhead, send_buffer_min_max);
+}
 
-    if (cnx->cnx_state != picoquic_state_disconnected) {
-        if (length > 0){
-            path_x->is_pto_required &= is_pure_ack;
-            pkt_ctx->ack_of_ack_requested |= !is_pure_ack;
-            if (!pkt_ctx->ack_of_ack_requested && ack_sent) {
-                /* If we have sent many ACKs, add a PING to get an ack of ack */
-                /* The number 24 is chosen to not break any of the unit tests. If the number is
-                 * too small, the PING mechanism can cause delayed end of the connection, or 
-                 * early breakage */
-                const uint64_t ack_repeat_interval = 24;
-                bytes_next = bytes + length;
-                if (bytes_next < bytes_max &&
-                    pkt_ctx->highest_acknowledged + ack_repeat_interval < pkt_ctx->send_sequence &&
-                    path_x == cnx->path[0] &&
-                    pkt_ctx->highest_acknowledged_time + path_x->smoothed_rtt < current_time) {
-                    /* Bundle a Ping with ACK, so as to get trigger an Acknowledgement */
-                    *bytes_next++ = picoquic_frame_type_ping;
-                    pkt_ctx->ack_of_ack_requested = 1;
-                    is_pure_ack = 0;
-                    length = bytes_next - bytes;
+/* Lean alternate path for the second and later packets of the same send-buffer batch
+ * (see picoquic_prepare_packet_ex): just check pacing and flow control, and if OK
+ * move directly to format stream frames and datagrams, thus bypassing a large number
+ * of tests. */
+static int picoquic_prepare_packet_ready_fast(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_packet_t* packet,
+    uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length, uint64_t* next_wake_time)
+{
+    int ret = 0;
+    picoquic_packet_type_enum packet_type = picoquic_packet_1rtt_protected;
+    picoquic_packet_context_enum pc = picoquic_packet_context_application;
+    int is_pure_ack = 1;
+    size_t header_length;
+    size_t length;
+    size_t checksum_overhead = picoquic_get_checksum_length(cnx, picoquic_epoch_1rtt);
+    size_t send_buffer_min_max = (send_buffer_max > path_x->send_mtu) ? path_x->send_mtu : send_buffer_max;
+    uint8_t* bytes = packet->bytes;
+    uint8_t* bytes_max = bytes + send_buffer_min_max - checksum_overhead;
+    uint8_t* bytes_next;
+    int more_data = 0;
+
+    picoquic_packet_context_t* pkt_ctx = (cnx->is_multipath_enabled) ?
+        &path_x->pkt_ctx :
+        &cnx->pkt_ctx[picoquic_packet_context_application];
+
+    packet->pc = picoquic_packet_context_application;
+    length = picoquic_predict_packet_header_length(cnx, packet_type, pkt_ctx);
+    packet->ptype = packet_type;
+    packet->offset = length;
+    header_length = length;
+    packet->sequence_number = pkt_ctx->send_sequence;
+    packet->send_time = current_time;
+    packet->send_path = path_x;
+    bytes_next = bytes + length;
+
+    /* We apply here the same pacing and congestion control as the full path,
+    * including the same bypass code. No PTO tests, since PTO only makes sense
+    * for the first packet in a a batch.
+    */
+    if (picoquic_is_sending_authorized_by_pacing(cnx, path_x, current_time, next_wake_time)) {
+        if (path_x->cwin < path_x->bytes_in_transit || cnx->quic->cwin_max < path_x->bytes_in_transit) {
+            uint8_t* bytes_next_before_bypass = bytes_next;
+
+            if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1) {
+                int no_data_to_send_bypass = 0;
+
+                bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+                    (size_t)(bytes_next - bytes) <= packet->offset, cnx->priority_limit_for_bypass,
+                    &more_data, &is_pure_ack, &no_data_to_send_bypass, &ret);
+            }
+
+            if (bytes_next != bytes_next_before_bypass) {
+                length = bytes_next - bytes;
+            }
+            else {
+                cnx->cwin_blocked = 1;
+                path_x->last_cwin_blocked_time = current_time;
+                if (cnx->congestion_alg != NULL) {
+                    picoquic_per_ack_state_t ack_state = { 0 };
+                    ack_state.pc = pc;
+                    cnx->congestion_alg->alg_notify(cnx, path_x,
+                        picoquic_congestion_notification_cwin_blocked,
+                        &ack_state, current_time);
                 }
             }
-
-            if (is_pure_ack && cnx->is_multipath_enabled && 
-                path_x->is_ack_lost && !path_x->is_ack_expected) {
-                /* In some multipath scenarios, we may need to ping a path if we see 
-                 * non-ackable packets being lost. */
-                bytes_next = bytes + length;
-                if (bytes_next < bytes_max) {
-                    is_pure_ack = 0;
-                    *bytes_next = picoquic_frame_type_ping;
-                    length++;
-                }
-            }
-
-            if (!is_pure_ack) {
-                path_x->is_ack_expected = 1;
-            }
-        }
-
-        if (is_pure_ack == 0)
-        {
-            cnx->latest_progress_time = current_time;
-        }
-        else if (cnx->keep_alive_interval != 0) {
-            /* If necessary, encode and send the keep alive packet.
-             * We only send keep alive packets when no other data is sent.
-             */
-            if (cnx->latest_progress_time + cnx->keep_alive_interval <= current_time && length == 0) {
-                length = picoquic_predict_packet_header_length(
-                    cnx, packet_type, pkt_ctx);
-                packet->ptype = packet_type;
-                packet->pc = pc;
-                packet->offset = length;
-                header_length = length;
-                packet->sequence_number = pkt_ctx->send_sequence;
-                packet->send_path = path_x;
-                packet->send_time = current_time;
-                bytes[length++] = picoquic_frame_type_ping;
-                bytes[length++] = 0;
-                cnx->latest_progress_time = current_time;
-            }
-            else if (cnx->latest_progress_time + cnx->keep_alive_interval < *next_wake_time) {
-                *next_wake_time = cnx->latest_progress_time + cnx->keep_alive_interval;
-                SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
-            }
-        }
-
-        if (more_data) {
-            *next_wake_time = current_time;
-            SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
-            ret = 0;
-        }
-    }
-
-    if (ret == 0 && length > header_length) {
-        /* Ensure that all packets are properly padded before being sent. */
-        if (is_challenge_padding_needed && length < PICOQUIC_ENFORCED_INITIAL_MTU) {
-            length = picoquic_pad_to_target_length(bytes, length, (uint32_t)(send_buffer_min_max - checksum_overhead));
         }
         else {
-            length = picoquic_pad_to_policy(cnx, bytes, length, (uint32_t)(send_buffer_min_max - checksum_overhead));
+            int no_data_to_send = 1;
+
+            bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+                (size_t)(bytes_next - bytes) <= packet->offset, UINT64_MAX, &more_data, &is_pure_ack, &no_data_to_send, &ret);
+            length = bytes_next - bytes;
+
+            if (length <= header_length || is_pure_ack) {
+                picoquic_mark_path_app_limited(path_x);
+                bytes_next = picoquic_format_blocked_frames(cnx, &bytes[length], bytes_max, &more_data, &is_pure_ack);
+                length = bytes_next - bytes;
+            }
+
+            if (no_data_to_send) {
+                path_x->last_sender_limited_time = current_time;
+            }
+        }
+    }
+    else if (cnx->priority_limit_for_bypass > 0 && cnx->nb_paths == 1) {
+        int no_data_to_send = 0;
+
+        if ((bytes_next = picoquic_prepare_stream_and_datagrams(cnx, path_x, bytes_next, bytes_max,
+            (size_t)(bytes_next - bytes) <= packet->offset, cnx->priority_limit_for_bypass,
+            &more_data, &is_pure_ack, &no_data_to_send, &ret)) != NULL) {
+            length = bytes_next - bytes;
         }
     }
 
-    picoquic_finalize_and_protect_packet(cnx, packet,
-        ret, length, header_length, checksum_overhead,
-        send_length, send_buffer, send_buffer_min_max,
-        path_x, current_time, !is_pure_ack);
-
-    if (*send_length > 0) {
-        *next_wake_time = current_time;
-        SET_LAST_WAKE(cnx->quic, PICOQUIC_SENDER);
-
-        if (ret == 0 && picoquic_cnx_is_still_logging(cnx)) {
-            picoquic_log_cc_dump(cnx, current_time);
-        }
-    }
-    return ret;
+    return picoquic_prepare_packet_ready_finish(cnx, path_x, packet, current_time, send_buffer, send_length, next_wake_time,
+        pkt_ctx, packet_type, pc, bytes, header_length, length, ret, is_pure_ack, 0 /* ack_sent */, more_data,
+        0 /* is_challenge_padding_needed */, checksum_overhead, send_buffer_min_max);
 }
 
 static int picoquic_check_idle_timer(picoquic_cnx_t* cnx, uint64_t* next_wake_time, uint64_t current_time)
@@ -3274,7 +3397,7 @@ static int picoquic_check_idle_timer(picoquic_cnx_t* cnx, uint64_t* next_wake_ti
 /* Prepare next packet to send, or nothing.. */
 int picoquic_prepare_segment(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoquic_packet_t* packet,
     uint64_t current_time, uint8_t* send_buffer, size_t send_buffer_max, size_t* send_length,
-    uint64_t* next_wake_time, int* is_initial_sent)
+    uint64_t* next_wake_time, int* is_initial_sent, int is_first_in_batch)
 {
     int ret = 0;
 
@@ -3315,7 +3438,22 @@ int picoquic_prepare_segment(picoquic_cnx_t* cnx, picoquic_path_t* path_x, picoq
         ret = picoquic_prepare_packet_almost_ready(cnx, path_x, packet, current_time, send_buffer, send_buffer_max, send_length, next_wake_time, is_initial_sent);
         break;
     case picoquic_state_ready:
-        ret = picoquic_prepare_packet_ready(cnx, path_x, packet, current_time, send_buffer, send_buffer_max, send_length, next_wake_time);
+        /* The lean fast path is only valid for continuation packets of a batch already
+         * started by a full picoquic_prepare_packet_ready call (see the long comment on
+         * picoquic_prepare_packet_ready_fast for why that is safe), and only when there is
+         * nothing this specific packet still needs to do outside of pacing and stream
+         * data: no path validation pending, no multipath probe pending, no PTO probe
+         * pending. PTO handling in particular is excluded here rather than inside the fast
+         * path itself: a PTO probe is explicitly exempt from congestion control (RFC 9002
+         * 6.2.4) and can carry new data even while cwin-blocked, which is exactly the kind
+         * of exception the fast path is not meant to reason about. */
+        if (!is_first_in_batch && path_x->first_tuple->challenge_verified != 0 &&
+            !path_x->is_multipath_probe_needed && !path_x->is_pto_required) {
+            ret = picoquic_prepare_packet_ready_fast(cnx, path_x, packet, current_time, send_buffer, send_buffer_max, send_length, next_wake_time);
+        }
+        else {
+            ret = picoquic_prepare_packet_ready(cnx, path_x, packet, current_time, send_buffer, send_buffer_max, send_length, next_wake_time);
+        }
         break;
     case picoquic_state_handshake_failure:
     case picoquic_state_handshake_failure_resend:
@@ -3587,8 +3725,14 @@ int picoquic_prepare_packet_ex(picoquic_cnx_t* cnx,
                             packet_buffer, available, &segment_length, &next_wake_time, &is_initial_sent);
                     }
                     else {
+                        /* *send_length accumulates bytes written across the whole batch
+                         * (it is only reset to 0 at the very top of this function), so it
+                         * is 0 only for the very first packet -- exactly the signal
+                         * picoquic_prepare_segment needs to decide between the full check
+                         * and the lean fast path (see picoquic_prepare_packet_ready_fast). */
                         ret = picoquic_prepare_segment(cnx, path_x, packet, current_time,
-                            packet_buffer + coalesced_packet_size, available, &segment_length, &next_wake_time, &is_initial_sent);
+                            packet_buffer + coalesced_packet_size, available, &segment_length, &next_wake_time, &is_initial_sent,
+                            *send_length == 0);
                     }
 
                     if (ret == 0) {

--- a/picoquic/timing.c
+++ b/picoquic/timing.c
@@ -100,7 +100,7 @@ static void picoquic_validate_bdp_seed(picoquic_cnx_t* cnx, picoquic_path_t* pat
             picoquic_get_ip_addr((struct sockaddr*)&path_x->first_tuple->peer_addr, &ip_addr, &ip_addr_length);
 
             if (ip_addr_length == cnx->seed_ip_addr_length &&
-                memcmp(ip_addr, cnx->seed_ip_addr, ip_addr_length) == 0) {
+                (ip_addr_length == 0 || memcmp(ip_addr, cnx->seed_ip_addr, ip_addr_length) == 0)) {
                 picoquic_per_ack_state_t ack_state = { 0 };
                 ack_state.pc = picoquic_packet_context_application; /* Arbitrary! */
                 ack_state.nb_bytes_acknowledged = (uint64_t)cnx->seed_cwin;

--- a/picoquic/token_store.c
+++ b/picoquic/token_store.c
@@ -46,7 +46,9 @@ picoquic_stored_token_t* picoquic_format_token(uint64_t time_valid_until,
 
         stored->ip_addr = next_p;
         stored->ip_addr_length = ip_addr_length;
-        memcpy(next_p, ip_addr, ip_addr_length);
+        if (ip_addr_length > 0) {
+            memcpy(next_p, ip_addr, ip_addr_length);
+        }
         next_p += ip_addr_length;
         *next_p++ = 0;
 
@@ -184,7 +186,7 @@ int picoquic_store_token(picoquic_quic_t * quic,
 
             /* Now remove the old tokens for that SNI & ip_addr */
             while (next != NULL) {
-                if (next->time_valid_until <= stored->time_valid_until && next->sni_length == sni_length && next->ip_addr_length == ip_addr_length && memcmp(next->sni, sni, sni_length) == 0 && memcmp(next->ip_addr, ip_addr, ip_addr_length) == 0) {
+                if (next->time_valid_until <= stored->time_valid_until && next->sni_length == sni_length && next->ip_addr_length == ip_addr_length && memcmp(next->sni, sni, sni_length) == 0 && (ip_addr_length == 0 || memcmp(next->ip_addr, ip_addr, ip_addr_length) == 0)) {
                     picoquic_stored_token_t* deleted = next;
                     next = next->next_token;
                     *pprevious = next;

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -148,6 +148,7 @@ static const picoquic_test_def_t test_table[] = {
     { "varint", varint_test },
     { "sqrt_for_test", sqrt_for_test_test },
     { "ack_sack", sacktest },
+    { "ack_stress", sack_stress_test },
     { "frames_skip", skip_frame_test },
     { "frames_parse", parse_frame_test },
     { "frames_repeat", frames_repeat_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -56,6 +56,7 @@ int header_length_test(void);
 int pn2pn64test(void);
 int intformattest(void);
 int sacktest(void);
+int sack_stress_test(void);
 int StreamZeroFrameTest(void);
 int sendacktest(void);
 int sendack_loop_test(void);
@@ -712,6 +713,7 @@ int quicperf_multipath_race_test(void);
 int quicperf_multipath_race_delayed_test(void);
 int quicperf_multipath_settled_test(void);
 int perf_loopback_test(void);
+int perf_loopback_loss_test(void);
 int cplusplustest(void);
 int error_name_test(void);
 

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -711,6 +711,7 @@ int quicperf_overflow_test(void);
 int quicperf_multipath_race_test(void);
 int quicperf_multipath_race_delayed_test(void);
 int quicperf_multipath_settled_test(void);
+int perf_loopback_test(void);
 int cplusplustest(void);
 int error_name_test(void);
 

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -1560,13 +1560,10 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t loss_mask, ui
             nb_stall_jumps++;
         }
 
-        /* Safety net: quicperf already closes the client connection on its own once the
-         * scenario completes (see quicperf_close_stream in picohttp/quicperf.c), but we
-         * mirror the same belt-and-suspenders check used by the regular quicperf e2e tests
-         * above in case a future scenario type does not. */
-        if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_ready &&
-            picoquic_is_cnx_backlog_empty(cnx_client) &&
-            quicperf_ctx->nb_open_streams == 0) {
+        /* Safety net in case a future scenario type does not self-close like this one does. */
+        if (ret == 0 && quicperf_ctx->nb_open_streams == 0 &&
+            picoquic_get_cnx_state(cnx_client) == picoquic_state_ready &&
+            picoquic_is_cnx_backlog_empty(cnx_client)) {
             ret = picoquic_close(cnx_client, 0);
         }
     }

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -1264,7 +1264,7 @@ int quicperf_multipath_settled_test(void)
  * meant to profile.
  */
 
-#define PERF_LOOPBACK_TEST_RESPONSE_SIZE 1000000;
+#define PERF_LOOPBACK_TEST_RESPONSE_SIZE 1000000
 #define PERF_LOOPBACK_MAX_LOOPS 100000000
 #define PERF_LOOPBACK_MAX_TIME 300000000ull /* 300 simulated seconds, safety net against a stall */
 #define PERF_LOOPBACK_SEND_BUFFER_SIZE 65536 /* 64KB: large enough to let prepare_next_packet_ex

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -1,4 +1,3 @@
-#include "picoquic_internal.h"
 /*
 * Author: Christian Huitema
 * Copyright (c) 2024, Private Octopus, Inc.
@@ -32,6 +31,7 @@
 #include "picosplay.h"
 #include "picoquictest_internal.h"
 #include "quicperf.h"
+#include "c4.h"
 
 #define qpstr_batch "256:12345;"
 #define qpstr_batch100 "* 100:256 : 12345;"
@@ -1245,16 +1245,10 @@ int quicperf_multipath_settled_test(void)
  * Goal: profile the "prepare next packet" sending path -- picoquic_prepare_next_packet_ex,
  * picoquic_prepare_segment, picoquic_prepare_packet_ready -- without the cost or noise of
  * an actual socket, or of the simulated-link machinery used by the rest of this file
- * (queueing, bandwidth/propagation model, NAT rewriting, etc). picoquic_protect_packet and
- * the sendmsg() call itself are already known to dominate; this harness is meant to make it
- * easy to see everything else.
+ * (queueing, bandwidth/propagation model, NAT rewriting, etc). 
  *
- * A single picoquic_quic_t context plays both ends of the connection: it is configured with
- * a server certificate (so it can accept an incoming connection) and is then also used to
- * originate a client connection to a fictitious server address. There is nothing in picoquic
- * that requires a context to be exclusively client or server -- connections are looked up by
- * CID in the context's own table -- so this works exactly like two back-to-back stacks
- * sharing one process, minus the second context.
+ * A single picoquic_quic_t context plays both ends of the connection: it used to
+ * originate a client connection to a fictitious server address. 
  *
  * Packets are never queued or delayed: each call to picoquic_prepare_next_packet_ex is
  * immediately followed by a call to picoquic_incoming_packet_ex feeding the produced bytes
@@ -1262,17 +1256,15 @@ int quicperf_multipath_settled_test(void)
  * There is no simulated bandwidth or propagation delay -- the two connections just run as
  * fast as the host CPU can prepare, protect and process packets.
  *
- * The QUIC clock still needs to move forward, for pacing, loss timers, etc. When neither
- * connection has anything ready to send, the clock jumps straight to
- * picoquic_get_next_wake_time(). When a packet is handed off, the clock is nudged forward by
- * a single microsecond -- just enough to keep timestamps strictly increasing and RTT samples
- * away from a degenerate zero, without adding any artificial delay of consequence.
+ * We use the "real" clock, not a simulated clock, too have realistic handling of
+ * pacing and congestion control.
  *
- * The client runs a quicperf "batch" scenario asking for a large download (10GB by default),
+ * The client runs a quicperf "batch" scenario asking for a large download (e.g., 10GB),
  * which puts the load on the server's sending path -- the part of the code this test is
  * meant to profile.
  */
 
+#define PERF_LOOPBACK_TEST_RESPONSE_SIZE 1000000;
 #define PERF_LOOPBACK_MAX_LOOPS 100000000
 #define PERF_LOOPBACK_MAX_TIME 300000000ull /* 300 simulated seconds, safety net against a stall */
 #define PERF_LOOPBACK_SEND_BUFFER_SIZE 65536 /* 64KB: large enough to let prepare_next_packet_ex
@@ -1282,14 +1274,14 @@ int quicperf_multipath_settled_test(void)
  * regular test suite stays fast; picohttp_t accepts a "-p nnn" option to run a bigger
  * transfer (e.g. 10GB) when the point is to actually profile the sending path rather than
  * just exercise it. */
-uint64_t picohttp_perf_loopback_size = 1000000;
+uint64_t picohttp_perf_loopback_size = PERF_LOOPBACK_TEST_RESPONSE_SIZE;
 
 static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_us, uint64_t* p_nb_packets)
 {
     int ret = 0;
-    uint64_t simulated_time = 0;
     picoquic_quic_t* quic = NULL;
     picoquic_cnx_t* cnx_client = NULL;
+    picoquic_cnx_t* cnx_server = NULL;
     quicperf_ctx_t* quicperf_ctx = NULL;
     struct sockaddr_in client_addr;
     struct sockaddr_in server_addr;
@@ -1301,6 +1293,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     uint64_t nb_packets = 0;
     uint64_t nb_client_packets = 0;
     uint64_t nb_server_packets = 0;
+    uint64_t nb_batches = 0;
     uint64_t nb_bytes = 0;
     uint64_t nb_stall_jumps = 0;
     uint64_t wall_start = 0;
@@ -1336,19 +1329,18 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
 #endif
     (void)client_addr; /* not otherwise referenced: the addresses only need to be distinct */
 
-    /* A single context plays both the client and the server roles: it is configured with a
-     * server certificate so incoming Initial packets can be accepted, and the default
-     * callback is quicperf's, which lazily creates a fresh server-side quicperf_ctx_t the
-     * first time it sees a new connection (see quicperf_callback in picohttp/quicperf.c). */
+    /* A single context plays both the client and the server roles. */
     quic = picoquic_create(8,
         test_server_cert_file, test_server_key_file, test_server_cert_store_file,
         QUICPERF_ALPN, quicperf_callback, NULL, NULL, NULL, NULL,
-        simulated_time, &simulated_time, NULL, NULL, 0);
+        picoquic_current_time(), NULL, NULL, NULL, 0);
 
     if (quic == NULL) {
         DBG_PRINTF("%s", "Could not create the perf loopback QUIC context.\n");
         return -1;
     }
+
+    picoquic_set_default_congestion_algorithm(quic, c4_algorithm);
 
     /* No qlog, no binlog: this is meant to measure the sending path itself, not I/O. */
     picoquic_set_random_initial(quic, 0);
@@ -1362,7 +1354,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     }
 
     cnx_client = picoquic_create_cnx(quic, picoquic_null_connection_id, picoquic_null_connection_id,
-        (struct sockaddr*)&server_addr, simulated_time, 0, PICOQUIC_TEST_SNI, QUICPERF_ALPN, 1);
+        (struct sockaddr*)&server_addr, picoquic_get_quic_time(quic), 0, PICOQUIC_TEST_SNI, QUICPERF_ALPN, 1);
 
     if (cnx_client == NULL) {
         DBG_PRINTF("%s", "Could not create the perf loopback client connection.\n");
@@ -1377,9 +1369,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
         DBG_PRINTF("Could not start the client connection, ret = %d\n", ret);
     }
 
-    /* Allocated on the heap rather than kept as a stack array: 64KB is large enough to let
-     * picoquic_prepare_next_packet_ex batch several UDP datagrams per call (see the GSO
-     * splitting below), which would be a wasteful amount of stack to reserve by default. */
+    /* Allocated on the heap rather than kept as a stack array. */
     send_buffer = (uint8_t*)malloc(PERF_LOOPBACK_SEND_BUFFER_SIZE);
 
     if (send_buffer == NULL) {
@@ -1392,7 +1382,6 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     wall_start = picoquic_current_time();
 
     while (ret == 0 && nb_loops < PERF_LOOPBACK_MAX_LOOPS &&
-        simulated_time < PERF_LOOPBACK_MAX_TIME &&
         picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected) {
         struct sockaddr_storage addr_to;
         struct sockaddr_storage addr_from;
@@ -1405,7 +1394,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
 
         nb_loops++;
 
-        ret = picoquic_prepare_next_packet_ex(quic, simulated_time, send_buffer, PERF_LOOPBACK_SEND_BUFFER_SIZE,
+        ret = picoquic_prepare_next_packet_ex(quic, picoquic_get_quic_time(quic), send_buffer, PERF_LOOPBACK_SEND_BUFFER_SIZE,
             &send_length, &addr_to, &addr_from, &if_index, &log_cid, &last_cnx, &send_msg_size);
 
         if (ret != 0) {
@@ -1413,18 +1402,19 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
             break;
         }
 
+        if (last_cnx != NULL && cnx_server == NULL) {
+            cnx_server = last_cnx;
+        }
+
+
         if (send_length > 0) {
-            /* picoquic_prepare_next_packet_ex may coalesce several independent UDP
-             * datagrams into one buffer (the GSO case), reporting the per-datagram
-             * size in send_msg_size. Each such datagram must be handed to
-             * picoquic_incoming_packet_ex separately -- feeding the whole buffer as
-             * one datagram silently corrupts everything past the first segment,
-             * since the trailing short-header packet has no explicit length and
-             * swallows whatever follows it. See tls_api_one_sim_round in
-             * tls_api_test.c for the same splitting logic in the regular harness. */
             size_t segment_size = (send_msg_size == 0 || send_msg_size > send_length) ? send_length : send_msg_size;
             size_t sent_so_far = 0;
             uint8_t* segment_bytes = send_buffer;
+
+            /* Each call to picoquic_prepare_next_packet_ex produces a batch of
+             * up to 40 packets, depending on pacing and congestion control */
+            nb_batches++;
 
             while (ret == 0 && sent_so_far < send_length) {
                 size_t this_length = send_length - sent_so_far;
@@ -1441,14 +1431,10 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
                     nb_server_packets++;
                 }
 
-                /* Deliver the packet right away: no queue, no delay. Just nudge the
-                 * clock by one microsecond so timestamps stay strictly increasing and
-                 * RTT samples never land on exactly zero. */
-                simulated_time += 1;
-
+                /* Deliver the packet right away: no queue, no delay. */
                 ret = picoquic_incoming_packet_ex(quic, segment_bytes, this_length,
                     (struct sockaddr*)&addr_from, (struct sockaddr*)&addr_to, if_index, 0,
-                    &first_cnx, simulated_time);
+                    &first_cnx, picoquic_get_quic_time(quic));
 
                 if (ret != 0) {
                     DBG_PRINTF("Incoming packet returned %d\n", ret);
@@ -1460,19 +1446,11 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
             }
         }
         else {
-            uint64_t next_time = picoquic_get_next_wake_time(quic, simulated_time);
-
-            if (next_time <= simulated_time) {
-                next_time = simulated_time + 1;
-            }
-            simulated_time = next_time;
             nb_stall_jumps++;
         }
-
-        /* Safety net: quicperf already closes the client connection on its own once the
-         * scenario completes (see quicperf_close_stream in picohttp/quicperf.c), but we
-         * mirror the same belt-and-suspenders check used by the regular quicperf e2e tests
-         * above in case a future scenario type does not. */
+        /* Safety net: in case quicperf would not close the connection on its own.
+         * Probably not needed, since we also have a test on number of loops.
+         */
         if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_ready &&
             picoquic_is_cnx_backlog_empty(cnx_client) &&
             quicperf_ctx->nb_open_streams == 0) {
@@ -1494,18 +1472,19 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     }
 
     fprintf(stdout, "Perf loopback: %" PRIu64 " app bytes, %" PRIu64 " wire bytes, %" PRIu64
-        " packets (%" PRIu64 " client, %" PRIu64 " server), %" PRIu64 " stall jumps, in %" PRIu64 " us.\n",
+        " packets (%" PRIu64 " client, %" PRIu64 " server), %" PRIu64 " batches, %" PRIu64 " stall jumps, in %" PRIu64 " us.\n",
         quicperf_ctx->data_received, nb_bytes, nb_packets, nb_client_packets, nb_server_packets,
-        nb_stall_jumps, wall_end - wall_start);
+        nb_batches, nb_stall_jumps, wall_end - wall_start);
 
     if (wall_end > wall_start) {
         double seconds = (double)(wall_end - wall_start) / 1000000.0;
         double us_per_packet = (nb_packets == 0) ? 0.0 :
             (double)(wall_end - wall_start) / (double)nb_packets;
+        double packets_per_batch = (nb_batches == 0) ? 0.0 : (double)nb_packets / (double)nb_batches;
 
-        fprintf(stdout, "Perf loopback: %.3f seconds, %.1f MB/s, %.0f packets/s, %.3f us/packet.\n",
+        fprintf(stdout, "Perf loopback: %.3f seconds, %.1f MB/s, %.0f packets/s, %.3f us/packet, %.2f packets/batch.\n",
             seconds, ((double)nb_bytes / (1024.0 * 1024.0)) / seconds,
-            (double)nb_packets / seconds, us_per_packet);
+            (double)nb_packets / seconds, us_per_packet, packets_per_batch);
     }
 
     if (p_wall_time_us != NULL) {

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -31,7 +31,6 @@
 #include "picosplay.h"
 #include "picoquictest_internal.h"
 #include "quicperf.h"
-#include "c4.h"
 
 #define qpstr_batch "256:12345;"
 #define qpstr_batch100 "* 100:256 : 12345;"
@@ -1245,10 +1244,7 @@ int quicperf_multipath_settled_test(void)
  * Goal: profile the "prepare next packet" sending path -- picoquic_prepare_next_packet_ex,
  * picoquic_prepare_segment, picoquic_prepare_packet_ready -- without the cost or noise of
  * an actual socket, or of the simulated-link machinery used by the rest of this file
- * (queueing, bandwidth/propagation model, NAT rewriting, etc). 
- *
- * A single picoquic_quic_t context plays both ends of the connection: it used to
- * originate a client connection to a fictitious server address. 
+ * (queueing, bandwidth/propagation model, NAT rewriting, etc).
  *
  * Packets are never queued or delayed: each call to picoquic_prepare_next_packet_ex is
  * immediately followed by a call to picoquic_incoming_packet_ex feeding the produced bytes
@@ -1256,8 +1252,18 @@ int quicperf_multipath_settled_test(void)
  * There is no simulated bandwidth or propagation delay -- the two connections just run as
  * fast as the host CPU can prepare, protect and process packets.
  *
- * We use the "real" clock, not a simulated clock, too have realistic handling of
- * pacing and congestion control.
+ * The QUIC clock still needs to move forward, for pacing, loss timers, etc. When neither
+ * connection has anything ready to send, the clock jumps straight to
+ * picoquic_get_next_wake_time(). When a packet is handed off, the clock is nudged forward by
+ * a single microsecond -- just enough to keep timestamps strictly increasing and RTT samples
+ * away from a degenerate zero, without adding any artificial delay of consequence. Using a
+ * simulated clock instead of the real one keeps the test fast and repeatable -- it runs at
+ * whatever speed the host CPU can prepare and process packets, not at wall-clock speed.
+ * 
+ * This simplified clock does not play well with classic congestion control algorithms like
+ * Reno, Cubic, etc. Instead, we use a simple "fixed window" algorithm to ensure that
+ * the congestion window is sufficient to get proper packet trains and
+ * thus realistic CPU estimates. 
  *
  * The client runs a quicperf "batch" scenario asking for a large download (e.g., 10GB),
  * which puts the load on the server's sending path -- the part of the code this test is
@@ -1276,12 +1282,100 @@ int quicperf_multipath_settled_test(void)
  * just exercise it. */
 uint64_t picohttp_perf_loopback_size = PERF_LOOPBACK_TEST_RESPONSE_SIZE;
 
-static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_us, uint64_t* p_nb_packets)
+/* "Fixed window" congestion control, for use in the following performance test:
+ * ensure that the congestion window is kept at a large static value.
+ * Defined as static functions here because this algorithm should not be used in production.
+ */
+#define PERF_LOOPBACK_FIXEDCWIN_VALUE (128 * 1024)
+
+static void perf_loopback_fixedcwin_set(picoquic_path_t* path_x)
+{
+    path_x->cwin = PERF_LOOPBACK_FIXEDCWIN_VALUE;
+    path_x->is_ssthresh_initialized = 1;
+    picoquic_update_pacing_data(path_x, 0);
+}
+
+static void perf_loopback_fixedcwin_init(picoquic_path_t* path_x, char const* UNUSED(option_string), uint64_t UNUSED(current_time))
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(option_string);
+    UNREFERENCED_PARAMETER(current_time);
+#endif
+    /* Stateless: there is nothing to track between calls, cwin is always the same fixed
+     * value regardless of what happens on the path. */
+    path_x->congestion_alg_state = NULL;
+    perf_loopback_fixedcwin_set(path_x);
+}
+
+static void perf_loopback_fixedcwin_notify(
+    picoquic_cnx_t* UNUSED(cnx),
+    picoquic_path_t* path_x,
+    picoquic_congestion_notification_t notification,
+    picoquic_per_ack_state_t* UNUSED(ack_state),
+    uint64_t UNUSED(current_time))
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(cnx);
+    UNREFERENCED_PARAMETER(ack_state);
+    UNREFERENCED_PARAMETER(current_time);
+#endif
+    /* Every notification -- acknowledgement, repeat, timeout, ecn, spurious repeat, rtt
+     * measurement, cwin_blocked, seed_cwin, reset, lost_feedback, restart_from_idle -- is
+     * treated the same way: none of them are allowed to move cwin. This is deliberately
+     * not a switch on `notification`: there is no case that should do anything different. */
+    (void)notification;
+    path_x->is_cc_data_updated = 1;
+    perf_loopback_fixedcwin_set(path_x);
+}
+
+static void perf_loopback_fixedcwin_delete(picoquic_path_t* UNUSED(path_x))
+{
+#ifdef _WINDOWS
+    UNREFERENCED_PARAMETER(path_x);
+#endif
+    /* Nothing was allocated in perf_loopback_fixedcwin_init. */
+}
+
+static void perf_loopback_fixedcwin_observe(picoquic_path_t* path_x, uint64_t* cc_state, uint64_t* cc_param)
+{
+    *cc_state = 0;
+    *cc_param = path_x->cwin;
+}
+
+#define PERF_LOOPBACK_FIXEDCWIN_ID "perf_loopback_fixedcwin"
+
+static picoquic_congestion_algorithm_t perf_loopback_fixedcwin_algorithm_struct = {
+    PERF_LOOPBACK_FIXEDCWIN_ID, 0, PICOQUIC_ECN_ECT_0,
+    perf_loopback_fixedcwin_init,
+    perf_loopback_fixedcwin_notify,
+    perf_loopback_fixedcwin_delete,
+    perf_loopback_fixedcwin_observe
+};
+
+static picoquic_congestion_algorithm_t* perf_loopback_fixedcwin_algorithm = &perf_loopback_fixedcwin_algorithm_struct;
+
+/* Same rotating-bitmask loss idiom as picoquictest_sim_link_testloss in sim_link.c, kept
+ * local since perf_loopback bypasses sim_link entirely and that function is file-static. */
+static int perf_loopback_testloss(uint64_t* loss_mask)
+{
+    uint64_t loss_bit = 0;
+
+    if (loss_mask != NULL) {
+        loss_bit = (uint64_t)((*loss_mask) & 1ull);
+        *loss_mask >>= 1;
+        *loss_mask |= (loss_bit << 63);
+    }
+
+    return (int)loss_bit;
+}
+
+static int perf_loopback_test_one(uint64_t response_size, uint64_t loss_mask, uint64_t* p_wall_time_us, uint64_t* p_nb_packets)
 {
     int ret = 0;
+    uint64_t simulated_time = 0;
     picoquic_quic_t* quic = NULL;
     picoquic_cnx_t* cnx_client = NULL;
-    picoquic_cnx_t* cnx_server = NULL;
+    picoquic_cnx_t* cnx_server = NULL; /* discovered as first connection that is not the client connection */
     quicperf_ctx_t* quicperf_ctx = NULL;
     struct sockaddr_in client_addr;
     struct sockaddr_in server_addr;
@@ -1291,6 +1385,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     char scenario[128];
     uint8_t* send_buffer = NULL;
     uint64_t nb_packets = 0;
+    uint64_t nb_packets_lost = 0;
     uint64_t nb_client_packets = 0;
     uint64_t nb_server_packets = 0;
     uint64_t nb_batches = 0;
@@ -1333,14 +1428,15 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     quic = picoquic_create(8,
         test_server_cert_file, test_server_key_file, test_server_cert_store_file,
         QUICPERF_ALPN, quicperf_callback, NULL, NULL, NULL, NULL,
-        picoquic_current_time(), NULL, NULL, NULL, 0);
+        simulated_time, &simulated_time, NULL, NULL, 0);
 
     if (quic == NULL) {
         DBG_PRINTF("%s", "Could not create the perf loopback QUIC context.\n");
         return -1;
     }
 
-    picoquic_set_default_congestion_algorithm(quic, c4_algorithm);
+    /* Set as the default for the context, before creating any connection */
+    picoquic_set_default_congestion_algorithm(quic, perf_loopback_fixedcwin_algorithm);
 
     /* No qlog, no binlog: this is meant to measure the sending path itself, not I/O. */
     picoquic_set_random_initial(quic, 0);
@@ -1354,7 +1450,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     }
 
     cnx_client = picoquic_create_cnx(quic, picoquic_null_connection_id, picoquic_null_connection_id,
-        (struct sockaddr*)&server_addr, picoquic_get_quic_time(quic), 0, PICOQUIC_TEST_SNI, QUICPERF_ALPN, 1);
+        (struct sockaddr*)&server_addr, simulated_time, 0, PICOQUIC_TEST_SNI, QUICPERF_ALPN, 1);
 
     if (cnx_client == NULL) {
         DBG_PRINTF("%s", "Could not create the perf loopback client connection.\n");
@@ -1382,6 +1478,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     wall_start = picoquic_current_time();
 
     while (ret == 0 && nb_loops < PERF_LOOPBACK_MAX_LOOPS &&
+        simulated_time < PERF_LOOPBACK_MAX_TIME &&
         picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected) {
         struct sockaddr_storage addr_to;
         struct sockaddr_storage addr_from;
@@ -1394,7 +1491,7 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
 
         nb_loops++;
 
-        ret = picoquic_prepare_next_packet_ex(quic, picoquic_get_quic_time(quic), send_buffer, PERF_LOOPBACK_SEND_BUFFER_SIZE,
+        ret = picoquic_prepare_next_packet_ex(quic, simulated_time, send_buffer, PERF_LOOPBACK_SEND_BUFFER_SIZE,
             &send_length, &addr_to, &addr_from, &if_index, &log_cid, &last_cnx, &send_msg_size);
 
         if (ret != 0) {
@@ -1402,18 +1499,15 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
             break;
         }
 
-        if (last_cnx != NULL && cnx_server == NULL) {
+        if (last_cnx != NULL && last_cnx != cnx_client && cnx_server == NULL) {
             cnx_server = last_cnx;
         }
-
 
         if (send_length > 0) {
             size_t segment_size = (send_msg_size == 0 || send_msg_size > send_length) ? send_length : send_msg_size;
             size_t sent_so_far = 0;
             uint8_t* segment_bytes = send_buffer;
 
-            /* Each call to picoquic_prepare_next_packet_ex produces a batch of
-             * up to 40 packets, depending on pacing and congestion control */
             nb_batches++;
 
             while (ret == 0 && sent_so_far < send_length) {
@@ -1431,14 +1525,25 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
                     nb_server_packets++;
                 }
 
-                /* Deliver the packet right away: no queue, no delay. */
-                ret = picoquic_incoming_packet_ex(quic, segment_bytes, this_length,
-                    (struct sockaddr*)&addr_from, (struct sockaddr*)&addr_to, if_index, 0,
-                    &first_cnx, picoquic_get_quic_time(quic));
+                /* Deliver the packet right away: no queue, no delay. Just nudge the
+                 * clock by one microsecond so timestamps stay strictly increasing and
+                 * RTT samples never land on exactly zero. */
+                simulated_time += 1;
 
-                if (ret != 0) {
-                    DBG_PRINTF("Incoming packet returned %d\n", ret);
-                    break;
+                if (perf_loopback_testloss(&loss_mask)) {
+                    /* Simulated loss: the packet was "sent" (already counted above,
+                     * same as a real dropped packet would be) but never delivered. */
+                    nb_packets_lost++;
+                }
+                else {
+                    ret = picoquic_incoming_packet_ex(quic, segment_bytes, this_length,
+                        (struct sockaddr*)&addr_from, (struct sockaddr*)&addr_to, if_index, 0,
+                        &first_cnx, simulated_time);
+
+                    if (ret != 0) {
+                        DBG_PRINTF("Incoming packet returned %d\n", ret);
+                        break;
+                    }
                 }
 
                 segment_bytes += this_length;
@@ -1446,11 +1551,19 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
             }
         }
         else {
+            uint64_t next_time = picoquic_get_next_wake_time(quic, simulated_time);
+
+            if (next_time <= simulated_time) {
+                next_time = simulated_time + 1;
+            }
+            simulated_time = next_time;
             nb_stall_jumps++;
         }
-        /* Safety net: in case quicperf would not close the connection on its own.
-         * Probably not needed, since we also have a test on number of loops.
-         */
+
+        /* Safety net: quicperf already closes the client connection on its own once the
+         * scenario completes (see quicperf_close_stream in picohttp/quicperf.c), but we
+         * mirror the same belt-and-suspenders check used by the regular quicperf e2e tests
+         * above in case a future scenario type does not. */
         if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_ready &&
             picoquic_is_cnx_backlog_empty(cnx_client) &&
             quicperf_ctx->nb_open_streams == 0) {
@@ -1472,9 +1585,9 @@ static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_
     }
 
     fprintf(stdout, "Perf loopback: %" PRIu64 " app bytes, %" PRIu64 " wire bytes, %" PRIu64
-        " packets (%" PRIu64 " client, %" PRIu64 " server), %" PRIu64 " batches, %" PRIu64 " stall jumps, in %" PRIu64 " us.\n",
+        " packets (%" PRIu64 " client, %" PRIu64 " server, %" PRIu64 " lost), %" PRIu64 " batches, %" PRIu64 " stall jumps, in %" PRIu64 " us.\n",
         quicperf_ctx->data_received, nb_bytes, nb_packets, nb_client_packets, nb_server_packets,
-        nb_batches, nb_stall_jumps, wall_end - wall_start);
+        nb_packets_lost, nb_batches, nb_stall_jumps, wall_end - wall_start);
 
     if (wall_end > wall_start) {
         double seconds = (double)(wall_end - wall_start) / 1000000.0;
@@ -1506,5 +1619,17 @@ int perf_loopback_test(void)
     uint64_t wall_time_us = 0;
     uint64_t nb_packets = 0;
 
-    return perf_loopback_test_one(picohttp_perf_loopback_size, &wall_time_us, &nb_packets);
+    return perf_loopback_test_one(picohttp_perf_loopback_size, 0, &wall_time_us, &nb_packets);
+}
+
+/* Same scenario, but with a single bit set in the rotating loss mask: one packet in 64
+ * (~1.6%) is dropped in each direction, deterministically and reproducibly, to exercise
+ * the sack-list code paths that perf_loopback's loss-free run never reaches -- multiple
+ * concurrent ranges, merges, and duplicate-after-retransmission checks. */
+int perf_loopback_loss_test(void)
+{
+    uint64_t wall_time_us = 0;
+    uint64_t nb_packets = 0;
+
+    return perf_loopback_test_one(picohttp_perf_loopback_size, 1, &wall_time_us, &nb_packets);
 }

--- a/picoquictest/quicperf_test.c
+++ b/picoquictest/quicperf_test.c
@@ -1239,3 +1239,293 @@ int quicperf_multipath_settled_test(void)
     return quicperf_e2e_test_multipath(0x1f, quicperf_mp_scenario, 5000000, 1, &quicperf_mp_target,
         quicperf_mp_probe_settled, 0);
 }
+
+/* Loopback performance test.
+ *
+ * Goal: profile the "prepare next packet" sending path -- picoquic_prepare_next_packet_ex,
+ * picoquic_prepare_segment, picoquic_prepare_packet_ready -- without the cost or noise of
+ * an actual socket, or of the simulated-link machinery used by the rest of this file
+ * (queueing, bandwidth/propagation model, NAT rewriting, etc). picoquic_protect_packet and
+ * the sendmsg() call itself are already known to dominate; this harness is meant to make it
+ * easy to see everything else.
+ *
+ * A single picoquic_quic_t context plays both ends of the connection: it is configured with
+ * a server certificate (so it can accept an incoming connection) and is then also used to
+ * originate a client connection to a fictitious server address. There is nothing in picoquic
+ * that requires a context to be exclusively client or server -- connections are looked up by
+ * CID in the context's own table -- so this works exactly like two back-to-back stacks
+ * sharing one process, minus the second context.
+ *
+ * Packets are never queued or delayed: each call to picoquic_prepare_next_packet_ex is
+ * immediately followed by a call to picoquic_incoming_packet_ex feeding the produced bytes
+ * back into the very same context, which dispatches them to the right connection by CID.
+ * There is no simulated bandwidth or propagation delay -- the two connections just run as
+ * fast as the host CPU can prepare, protect and process packets.
+ *
+ * The QUIC clock still needs to move forward, for pacing, loss timers, etc. When neither
+ * connection has anything ready to send, the clock jumps straight to
+ * picoquic_get_next_wake_time(). When a packet is handed off, the clock is nudged forward by
+ * a single microsecond -- just enough to keep timestamps strictly increasing and RTT samples
+ * away from a degenerate zero, without adding any artificial delay of consequence.
+ *
+ * The client runs a quicperf "batch" scenario asking for a large download (10GB by default),
+ * which puts the load on the server's sending path -- the part of the code this test is
+ * meant to profile.
+ */
+
+#define PERF_LOOPBACK_MAX_LOOPS 100000000
+#define PERF_LOOPBACK_MAX_TIME 300000000ull /* 300 simulated seconds, safety net against a stall */
+#define PERF_LOOPBACK_SEND_BUFFER_SIZE 65536 /* 64KB: large enough to let prepare_next_packet_ex
+                                               * batch several UDP datagrams in one call (GSO) */
+
+/* Response size used by perf_loopback_test, in bytes. Kept small by default (1MB) so the
+ * regular test suite stays fast; picohttp_t accepts a "-p nnn" option to run a bigger
+ * transfer (e.g. 10GB) when the point is to actually profile the sending path rather than
+ * just exercise it. */
+uint64_t picohttp_perf_loopback_size = 1000000;
+
+static int perf_loopback_test_one(uint64_t response_size, uint64_t* p_wall_time_us, uint64_t* p_nb_packets)
+{
+    int ret = 0;
+    uint64_t simulated_time = 0;
+    picoquic_quic_t* quic = NULL;
+    picoquic_cnx_t* cnx_client = NULL;
+    quicperf_ctx_t* quicperf_ctx = NULL;
+    struct sockaddr_in client_addr;
+    struct sockaddr_in server_addr;
+    char test_server_cert_file[512];
+    char test_server_key_file[512];
+    char test_server_cert_store_file[512];
+    char scenario[128];
+    uint8_t* send_buffer = NULL;
+    uint64_t nb_packets = 0;
+    uint64_t nb_client_packets = 0;
+    uint64_t nb_server_packets = 0;
+    uint64_t nb_bytes = 0;
+    uint64_t nb_stall_jumps = 0;
+    uint64_t wall_start = 0;
+    uint64_t wall_end = 0;
+    int nb_loops = 0;
+
+    if ((ret = picoquic_get_input_path(test_server_cert_file, sizeof(test_server_cert_file),
+        picoquic_solution_dir, PICOQUIC_TEST_FILE_SERVER_CERT)) != 0 ||
+        (ret = picoquic_get_input_path(test_server_key_file, sizeof(test_server_key_file),
+            picoquic_solution_dir, PICOQUIC_TEST_FILE_SERVER_KEY)) != 0 ||
+        (ret = picoquic_get_input_path(test_server_cert_store_file, sizeof(test_server_cert_store_file),
+            picoquic_solution_dir, PICOQUIC_TEST_FILE_CERT_STORE)) != 0) {
+        DBG_PRINTF("%s", "Cannot set the cert, key or store file names.\n");
+        return -1;
+    }
+
+    memset(&client_addr, 0, sizeof(client_addr));
+    client_addr.sin_family = AF_INET;
+    client_addr.sin_port = 1234;
+#ifdef _WINDOWS
+    client_addr.sin_addr.S_un.S_addr = htonl(0x0A000002);
+#else
+    client_addr.sin_addr.s_addr = htonl(0x0A000002);
+#endif
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = 4321;
+#ifdef _WINDOWS
+    server_addr.sin_addr.S_un.S_addr = htonl(0x0A000001);
+#else
+    server_addr.sin_addr.s_addr = htonl(0x0A000001);
+#endif
+    (void)client_addr; /* not otherwise referenced: the addresses only need to be distinct */
+
+    /* A single context plays both the client and the server roles: it is configured with a
+     * server certificate so incoming Initial packets can be accepted, and the default
+     * callback is quicperf's, which lazily creates a fresh server-side quicperf_ctx_t the
+     * first time it sees a new connection (see quicperf_callback in picohttp/quicperf.c). */
+    quic = picoquic_create(8,
+        test_server_cert_file, test_server_key_file, test_server_cert_store_file,
+        QUICPERF_ALPN, quicperf_callback, NULL, NULL, NULL, NULL,
+        simulated_time, &simulated_time, NULL, NULL, 0);
+
+    if (quic == NULL) {
+        DBG_PRINTF("%s", "Could not create the perf loopback QUIC context.\n");
+        return -1;
+    }
+
+    /* No qlog, no binlog: this is meant to measure the sending path itself, not I/O. */
+    picoquic_set_random_initial(quic, 0);
+
+    (void)snprintf(scenario, sizeof(scenario), "=b1:*1:1000:%" PRIu64 ";", response_size);
+
+    if ((quicperf_ctx = quicperf_create_ctx(scenario, stderr)) == NULL) {
+        DBG_PRINTF("Could not parse scenario <%s>\n", scenario);
+        picoquic_free(quic);
+        return -1;
+    }
+
+    cnx_client = picoquic_create_cnx(quic, picoquic_null_connection_id, picoquic_null_connection_id,
+        (struct sockaddr*)&server_addr, simulated_time, 0, PICOQUIC_TEST_SNI, QUICPERF_ALPN, 1);
+
+    if (cnx_client == NULL) {
+        DBG_PRINTF("%s", "Could not create the perf loopback client connection.\n");
+        quicperf_delete_ctx(quicperf_ctx);
+        picoquic_free(quic);
+        return -1;
+    }
+
+    picoquic_set_callback(cnx_client, quicperf_callback, quicperf_ctx);
+
+    if ((ret = picoquic_start_client_cnx(cnx_client)) != 0) {
+        DBG_PRINTF("Could not start the client connection, ret = %d\n", ret);
+    }
+
+    /* Allocated on the heap rather than kept as a stack array: 64KB is large enough to let
+     * picoquic_prepare_next_packet_ex batch several UDP datagrams per call (see the GSO
+     * splitting below), which would be a wasteful amount of stack to reserve by default. */
+    send_buffer = (uint8_t*)malloc(PERF_LOOPBACK_SEND_BUFFER_SIZE);
+
+    if (send_buffer == NULL) {
+        DBG_PRINTF("%s", "Could not allocate the perf loopback send buffer.\n");
+        quicperf_delete_ctx(quicperf_ctx);
+        picoquic_free(quic);
+        return -1;
+    }
+
+    wall_start = picoquic_current_time();
+
+    while (ret == 0 && nb_loops < PERF_LOOPBACK_MAX_LOOPS &&
+        simulated_time < PERF_LOOPBACK_MAX_TIME &&
+        picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected) {
+        struct sockaddr_storage addr_to;
+        struct sockaddr_storage addr_from;
+        int if_index = 0;
+        picoquic_connection_id_t log_cid;
+        picoquic_cnx_t* last_cnx = NULL;
+        picoquic_cnx_t* first_cnx = NULL;
+        size_t send_length = 0;
+        size_t send_msg_size = 0;
+
+        nb_loops++;
+
+        ret = picoquic_prepare_next_packet_ex(quic, simulated_time, send_buffer, PERF_LOOPBACK_SEND_BUFFER_SIZE,
+            &send_length, &addr_to, &addr_from, &if_index, &log_cid, &last_cnx, &send_msg_size);
+
+        if (ret != 0) {
+            DBG_PRINTF("Prepare packet returned %d\n", ret);
+            break;
+        }
+
+        if (send_length > 0) {
+            /* picoquic_prepare_next_packet_ex may coalesce several independent UDP
+             * datagrams into one buffer (the GSO case), reporting the per-datagram
+             * size in send_msg_size. Each such datagram must be handed to
+             * picoquic_incoming_packet_ex separately -- feeding the whole buffer as
+             * one datagram silently corrupts everything past the first segment,
+             * since the trailing short-header packet has no explicit length and
+             * swallows whatever follows it. See tls_api_one_sim_round in
+             * tls_api_test.c for the same splitting logic in the regular harness. */
+            size_t segment_size = (send_msg_size == 0 || send_msg_size > send_length) ? send_length : send_msg_size;
+            size_t sent_so_far = 0;
+            uint8_t* segment_bytes = send_buffer;
+
+            while (ret == 0 && sent_so_far < send_length) {
+                size_t this_length = send_length - sent_so_far;
+                if (this_length > segment_size) {
+                    this_length = segment_size;
+                }
+
+                nb_packets++;
+                nb_bytes += this_length;
+                if (last_cnx == cnx_client) {
+                    nb_client_packets++;
+                }
+                else {
+                    nb_server_packets++;
+                }
+
+                /* Deliver the packet right away: no queue, no delay. Just nudge the
+                 * clock by one microsecond so timestamps stay strictly increasing and
+                 * RTT samples never land on exactly zero. */
+                simulated_time += 1;
+
+                ret = picoquic_incoming_packet_ex(quic, segment_bytes, this_length,
+                    (struct sockaddr*)&addr_from, (struct sockaddr*)&addr_to, if_index, 0,
+                    &first_cnx, simulated_time);
+
+                if (ret != 0) {
+                    DBG_PRINTF("Incoming packet returned %d\n", ret);
+                    break;
+                }
+
+                segment_bytes += this_length;
+                sent_so_far += this_length;
+            }
+        }
+        else {
+            uint64_t next_time = picoquic_get_next_wake_time(quic, simulated_time);
+
+            if (next_time <= simulated_time) {
+                next_time = simulated_time + 1;
+            }
+            simulated_time = next_time;
+            nb_stall_jumps++;
+        }
+
+        /* Safety net: quicperf already closes the client connection on its own once the
+         * scenario completes (see quicperf_close_stream in picohttp/quicperf.c), but we
+         * mirror the same belt-and-suspenders check used by the regular quicperf e2e tests
+         * above in case a future scenario type does not. */
+        if (ret == 0 && picoquic_get_cnx_state(cnx_client) == picoquic_state_ready &&
+            picoquic_is_cnx_backlog_empty(cnx_client) &&
+            quicperf_ctx->nb_open_streams == 0) {
+            ret = picoquic_close(cnx_client, 0);
+        }
+    }
+
+    wall_end = picoquic_current_time();
+
+    if (ret == 0 && picoquic_get_cnx_state(cnx_client) != picoquic_state_disconnected) {
+        DBG_PRINTF("%s", "Perf loopback test did not reach a clean disconnect.\n");
+        ret = -1;
+    }
+
+    if (ret == 0 && quicperf_ctx->data_received < response_size) {
+        DBG_PRINTF("Received only %" PRIu64 " of %" PRIu64 " requested bytes\n",
+            quicperf_ctx->data_received, response_size);
+        ret = -1;
+    }
+
+    fprintf(stdout, "Perf loopback: %" PRIu64 " app bytes, %" PRIu64 " wire bytes, %" PRIu64
+        " packets (%" PRIu64 " client, %" PRIu64 " server), %" PRIu64 " stall jumps, in %" PRIu64 " us.\n",
+        quicperf_ctx->data_received, nb_bytes, nb_packets, nb_client_packets, nb_server_packets,
+        nb_stall_jumps, wall_end - wall_start);
+
+    if (wall_end > wall_start) {
+        double seconds = (double)(wall_end - wall_start) / 1000000.0;
+        double us_per_packet = (nb_packets == 0) ? 0.0 :
+            (double)(wall_end - wall_start) / (double)nb_packets;
+
+        fprintf(stdout, "Perf loopback: %.3f seconds, %.1f MB/s, %.0f packets/s, %.3f us/packet.\n",
+            seconds, ((double)nb_bytes / (1024.0 * 1024.0)) / seconds,
+            (double)nb_packets / seconds, us_per_packet);
+    }
+
+    if (p_wall_time_us != NULL) {
+        *p_wall_time_us = wall_end - wall_start;
+    }
+    if (p_nb_packets != NULL) {
+        *p_nb_packets = nb_packets;
+    }
+
+    free(send_buffer);
+    quicperf_delete_ctx(quicperf_ctx);
+    picoquic_free(quic);
+
+    return ret;
+}
+
+int perf_loopback_test(void)
+{
+    uint64_t wall_time_us = 0;
+    uint64_t nb_packets = 0;
+
+    return perf_loopback_test_one(picohttp_perf_loopback_size, &wall_time_us, &nb_packets);
+}

--- a/picoquictest/sacktest.c
+++ b/picoquictest/sacktest.c
@@ -239,6 +239,135 @@ int sacktest(void)
     return ret;
 }
 
+/* Stress test: push the SACK list far beyond the 22-entry table above, with a
+ * delivery order designed to keep it holding many disjoint ranges at once --
+ * the scenario an on-path adversary could force by reordering packets, which
+ * organic loss does not reach because retransmission heals gaps long before
+ * thousands of them pile up. Checks correctness at scale, and reports timing
+ * for the first half of the run against the second half so a regression (or,
+ * eventually, an improvement from replacing the underlying tree) is visible
+ * without needing a separate profiling tool. Pass/fail on that timing compares the two
+ * halves against each other, never against an absolute number -- see the check below. */
+#define SACK_STRESS_NB_PACKETS 20000
+#define SACK_STRESS_MAX_GROWTH_RATIO 8.0
+
+static int sack_stress_check_coverage(picoquic_sack_list_t* sack_list, uint64_t nb_packets)
+{
+    int ret = 0;
+    picoquic_sack_item_t* sack = picoquic_sack_first_item(sack_list);
+    uint64_t next_expected = 0;
+
+    while (ret == 0 && sack != NULL) {
+        if (sack->start_of_sack_range != next_expected) {
+            ret = -1;
+        }
+        else {
+            next_expected = sack->end_of_sack_range + 1;
+            sack = picoquic_sack_next_item(sack);
+        }
+    }
+
+    if (ret == 0 && next_expected != nb_packets) {
+        ret = -1;
+    }
+
+    return ret;
+}
+
+int sack_stress_test(void)
+{
+    int ret = 0;
+    picoquic_cnx_t* cnx;
+    picoquic_quic_t* quic;
+    picoquic_packet_context_enum pc = 0;
+    uint64_t nb_ops = 0;
+    uint64_t chunk_start_time;
+    uint64_t chunk_ops = 0;
+    double first_half_us_per_op = 0.0;
+    double second_half_us_per_op = 0.0;
+    uint64_t* pn = (uint64_t*)malloc(SACK_STRESS_NB_PACKETS * sizeof(uint64_t));
+
+    if (picoquic_test_set_minimal_cnx(&quic, &cnx) != 0) {
+        free(pn);
+        return -1;
+    }
+
+    if (pn == NULL || picoquic_create_local_cnxid(cnx, 0, NULL, 0) == NULL) {
+        ret = -1;
+    }
+    else {
+        /* Alternate delivery between the low and high end of the packet-number space,
+         * each walking towards the middle: every packet is far from anything recorded
+         * by the other end, so ranges stay disjoint far longer than organic reordering
+         * would allow, and each side's insertion point keeps moving relative to
+         * wherever the other side last landed. */
+        for (uint64_t i = 0; i < SACK_STRESS_NB_PACKETS; i++) {
+            pn[i] = (i % 2 == 0) ? (i / 2) : (SACK_STRESS_NB_PACKETS - 1 - (i / 2));
+        }
+    }
+
+    chunk_start_time = picoquic_current_time();
+
+    for (uint64_t i = 0; ret == 0 && i < SACK_STRESS_NB_PACKETS; i++) {
+        uint64_t current_time = i + 1;
+
+        /* Mirror the real receive path: check for duplicate, then record. */
+        if (picoquic_is_pn_already_received(cnx, pc,
+            cnx->first_local_cnxid_list->local_cnxid_first, pn[i]) != 0) {
+            ret = -1;
+        }
+        else if (picoquic_record_pn_received(cnx, pc,
+            cnx->first_local_cnxid_list->local_cnxid_first, pn[i], current_time) != 0) {
+            ret = -1;
+        }
+        else if (picoquic_is_pn_already_received(cnx, pc,
+            cnx->first_local_cnxid_list->local_cnxid_first, pn[i]) == 0) {
+            ret = -1;
+        }
+
+        nb_ops++;
+        chunk_ops++;
+
+        if (ret == 0 && i == SACK_STRESS_NB_PACKETS / 2 - 1) {
+            uint64_t now = picoquic_current_time();
+            first_half_us_per_op = (double)(now - chunk_start_time) / (double)chunk_ops;
+            chunk_start_time = now;
+            chunk_ops = 0;
+        }
+    }
+
+    if (ret == 0) {
+        uint64_t now = picoquic_current_time();
+        second_half_us_per_op = (double)(now - chunk_start_time) / (double)chunk_ops;
+    }
+
+    if (ret == 0 && second_half_us_per_op > first_half_us_per_op * SACK_STRESS_MAX_GROWTH_RATIO + 0.01) {
+        /* Compare the two halves of the same run instead of an absolute threshold, so the
+         * check does not depend on how fast this particular machine is: flat per-op cost
+         * keeps the ratio near 1, while a real O(N) degradation would blow it out by many
+         * orders of magnitude at this N, so a generous margin still catches it. */
+        DBG_PRINTF("Sack stress cost grew from %.3f to %.3f us/op between halves",
+            first_half_us_per_op, second_half_us_per_op);
+        ret = -1;
+    }
+
+    if (ret == 0) {
+        ret = check_ack_ranges(&cnx->ack_ctx[pc].sack_list);
+    }
+
+    if (ret == 0) {
+        ret = sack_stress_check_coverage(&cnx->ack_ctx[pc].sack_list, SACK_STRESS_NB_PACKETS);
+    }
+
+    fprintf(stdout, "Sack stress: %" PRIu64 " packets, first half %.3f us/op, second half %.3f us/op.\n",
+        nb_ops, first_half_us_per_op, second_half_us_per_op);
+
+    free(pn);
+    picoquic_test_delete_minimal_cnx(&quic, &cnx);
+
+    return ret;
+}
+
 static void ack_range_mask(uint64_t* mask, uint64_t highest, uint64_t range)
 {
     for (uint64_t i = 0; i < range; i++) {


### PR DESCRIPTION
A very simple PR to add a "software performance" test. The test just manages two "back to back" client and server connections, running a simple quicperf scenario, downloading a large file. The point is to measure CPU load when the network is not an issue, and thus get estimates of the cost of key functions on the send path.