### PR TITLE
C4: do not trim or drain if rtt < 1ms

### DIFF
--- a/picoquic/c4.c
+++ b/picoquic/c4.c
@@ -545,13 +545,17 @@ static void c4_exit_initial(picoquic_path_t* path_x, c4_state_t* c4_state)
         /* We assume that any required correction is done prior to calling this */
         uint64_t ssthresh = c4_state->initial_cwnd / 2;
         c4_state->nominal_max_rtt = ssthresh * 1000000 / c4_state->nominal_rate;
+        c4_state->is_drain_required = 1;
         if (c4_state->nominal_max_rtt < C4_MAX_RTT_MIN) {
             c4_state->nominal_max_rtt = C4_MAX_RTT_MIN;
+            c4_state->is_drain_required = 0;
+        }
+        else if (path_x->smoothed_rtt < C4_MAX_RTT_MIN) {
+            c4_state->is_drain_required = 0;
         }
         c4_state->delay_threshold = c4_delay_threshold(c4_state);
         c4_state->nb_eras_no_increase = 0;
         c4_state->probe_level = C4_PROBE_LEVEL_DEFAULT;
-        c4_state->is_drain_required = 1;
         c4_enter_recovery(path_x, c4_state, c4_congestion_none);
     }
 }
@@ -719,7 +723,8 @@ static void c4_exit_recovery(
         else {
             c4_state->recent_congestions = 0;
             if (c4_state->nominal_rate > c4_state->recent_maximum_rate &&
-                c4_state->push_was_not_limited) {
+                c4_state->push_was_not_limited &&
+                path_x->smoothed_rtt > C4_MAX_RTT_MIN) {
                 c4_state->nominal_rate = (c4_state->nominal_rate + c4_state->recent_maximum_rate)/2;
             }
         }
@@ -917,7 +922,9 @@ void c4_update_min_max_rtt(picoquic_path_t* path_x, c4_state_t* c4_state)
     }
     if (path_x->rtt_sample < c4_state->era_min_rtt) {
         c4_state->era_min_rtt = path_x->rtt_sample;
-        c4_state->is_drain_required = 1;
+        if (path_x->smoothed_rtt > C4_MAX_RTT_MIN) {
+            c4_state->is_drain_required = 1;
+        }
     }
 
     /* TODO: some of that logic might be located at the end of the RTT cycle, or the end of the era.
@@ -957,6 +964,7 @@ void c4_update_min_max_rtt(picoquic_path_t* path_x, c4_state_t* c4_state)
     }
 
     if (c4_state->nominal_max_rtt < C4_MAX_RTT_MIN) {
+        c4_state->is_drain_required = 0;
         c4_state->nominal_max_rtt = C4_MAX_RTT_MIN;
         c4_state->delay_threshold = c4_delay_threshold(c4_state);
     }


### PR DESCRIPTION
The recent changes in C4 implementation added functions to "trim" the nominal rate if it remains constantly over the measured values, and to "drain" the standing queues after the Initial phase, or if the nominal max RTT is decreasing. These functions make C4 less aggressive, reduce the amount of queueing and the RTT values, but generally maintain performance. However, they also had the effect of lowering the performance of C4 in high speed tests over low latency connections such as loopback. C4 used to be on par or slightly better than Cubic; after the changes, it became 24% slower.

Trial | Cubic | C4-current | C4-no-trim
------|-------|------|---------
1 | 2643 | 1983 | 2943
2 | 2678 | 2030 | 3009
3 | 2680 | 2040 | 3020
4 | 2705 | 2046 | 3022
5 | 2723 | 2088 | 3035
Average | 2686 | 2037 | 3006

In the table above, we see the data rates (in Mbit/s) achieved over 5 trials with Cubic, the current version of C4, and the version in this PR. All measurements were done on my laptop,  with software compiled in Windows 64 bit release mode. The change is to not perform the "drain" and "trim" functions if the RTT is lower than 1 ms. In such conditions, the bandwidth is only reduced if congestion is noticed, or once the queues cause the RTT to exceed 1ms. After the changes, C4 is 12% faster than Cubic.

