### PR TITLE
Do not use OPENSSL_INCLUDE_DIR when WITH_OPENSSL is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,7 @@ endif()
 
 if(WITH_OPENSSL)
     find_package(OpenSSL REQUIRED)
+    set(PICOQUIC_OPENSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})
     message(STATUS "root: ${OPENSSL_ROOT_DIR}")
     message(STATUS "OpenSSL_VERSION: ${OPENSSL_VERSION}")
     message(STATUS "OpenSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
@@ -394,6 +395,7 @@ if(WITH_OPENSSL)
     message(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 else()
     message(STATUS "Building without picotls-openssl")
+    set(PICOQUIC_OPENSSL_INCLUDE_DIRS "")
     list(APPEND PICOQUIC_COMPILE_DEFINITIONS PTLS_WITHOUT_OPENSSL)
 endif()
 
@@ -490,7 +492,7 @@ message(STATUS "mbedtls/include: ${MBEDTLS_INCLUDE_DIRS}")
 target_include_directories(picoquic-core
     PRIVATE
         ${PTLS_INCLUDE_DIRS}
-        ${OPENSSL_INCLUDE_DIR}
+        ${PICOQUIC_OPENSSL_INCLUDE_DIRS}
         ${PICOQUIC_CRYPTO_EXTRA_INCLUDE_DIRS}
     PUBLIC
         $<BUILD_INTERFACE:${MBEDTLS_INCLUDE_DIRS}>
@@ -549,7 +551,7 @@ if (BUILD_HTTP)
     target_include_directories(picohttp-core
         PRIVATE
             ${PTLS_INCLUDE_DIRS}
-            ${OPENSSL_INCLUDE_DIR}
+            ${PICOQUIC_OPENSSL_INCLUDE_DIRS}
             ${MBEDTLS_INCLUDE_DIRS}
         PUBLIC
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/picoquic>


### PR DESCRIPTION
`WITH_OPENSSL` guards `find_package(OpenSSL REQUIRED)`, but `picoquic-core` and `picohttp-core` add `${OPENSSL_INCLUDE_DIR}` to their include directories unconditionally.

With `WITH_OPENSSL=OFF` that is usually just empty. It is not when another project in the same build already ran CMake's `FindOpenSSL` and failed — picotls does exactly that — which leaves `OPENSSL_INCLUDE_DIR-NOTFOUND` in the cache and fails the generate step:

```
CMake Error: The following variables are used in this project, but they are
set to NOTFOUND: .../OPENSSL_INCLUDE_DIR
```

Hit cross-compiling for Android with `WITH_OPENSSL=OFF` and picotls-minicrypto, where there is no OpenSSL to find. The error names neither OpenSSL nor the cause, which made it slow to track down.
