### PR TITLE
Move full payload in fuzz

### DIFF
--- a/picoquictest/stresstest.c
+++ b/picoquictest/stresstest.c
@@ -1441,7 +1441,7 @@ static uint32_t initial_fuzzer(void * fuzz_ctx, picoquic_cnx_t* cnx,
             case 1:
                 if (length + len <= bytes_max) {
                     /* Second test variant: add a random frame at the beginning of the packet */
-                    memmove(bytes + header_length + len, bytes + header_length, len);
+                    memmove(bytes + header_length + len, bytes + header_length, length - header_length);
                     memcpy(&bytes[header_length], test_skip_list[stress_ctx->current_frame].val, len);
                     length += len;
                 }


### PR DESCRIPTION
(On the topic of fuzzing!) Something that came up while I was testing another change with memcheck - I think the memmove count here should be the length of the payload (`length - header_length`), rather than the length of the injected frame (`len`). 