### PR TITLE
Add optional bind address to the packet loop parameters

### DIFF
--- a/UnitTest1/unittest1.cpp
+++ b/UnitTest1/unittest1.cpp
@@ -181,6 +181,13 @@ namespace UnitTest1
             Assert::AreEqual(ret, 0);
         }
 
+        TEST_METHOD(sockloop_bind_addr)
+        {
+            int ret = sockloop_bind_addr_test();
+
+            Assert::AreEqual(ret, 0);
+        }
+
         TEST_METHOD(sockloop_migration)
         {
             int ret = sockloop_migration_test();

--- a/doc/parallel.md
+++ b/doc/parallel.md
@@ -80,6 +80,7 @@ typedef struct st_picoquic_packet_loop_param_t {
     int simulate_eio;
     size_t send_length_max;
     size_t send_batch_max;
+    struct sockaddr_storage local_addr; /* Optional bind address */
 } picoquic_packet_loop_param_t;
 ```
 

--- a/doc/parallel.md
+++ b/doc/parallel.md
@@ -80,7 +80,7 @@ typedef struct st_picoquic_packet_loop_param_t {
     int simulate_eio;
     size_t send_length_max;
     size_t send_batch_max;
-    struct sockaddr_storage local_addr; /* Optional bind address */
+    struct sockaddr_storage local_addr[PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX]; /* Optional bind addresses, one per family */
 } picoquic_packet_loop_param_t;
 ```
 

--- a/doc/socket_loop.md
+++ b/doc/socket_loop.md
@@ -57,6 +57,14 @@ The `param` argument contains data to parameterize the packet loop:
   the local socket. If the value is left to `AF_UNSPEC`, two sockets
   will be created, one for `AF_INET` (IPv4), and one for `AF_INET6` (IPv6).
 
+* `local_addr`: optional local address to which the socket will be bound,
+  as a `sockaddr_storage`. If the address family is left to `AF_UNSPEC`
+  (the default after zero initialization), sockets are bound to the
+  wildcard address and listen on all interfaces. If an address is set,
+  a single socket of that address family is created and bound to that
+  address and to `local_port`; the port inside `local_addr` is ignored.
+  Setting `local_af` to a different family than `local_addr` is an error.
+
 * `dest_if`: the interface identifier that should be associated with the local
   socket, or 0.
 

--- a/doc/socket_loop.md
+++ b/doc/socket_loop.md
@@ -57,13 +57,25 @@ The `param` argument contains data to parameterize the packet loop:
   the local socket. If the value is left to `AF_UNSPEC`, two sockets
   will be created, one for `AF_INET` (IPv4), and one for `AF_INET6` (IPv6).
 
-* `local_addr`: optional local address to which the socket will be bound,
-  as a `sockaddr_storage`. If the address family is left to `AF_UNSPEC`
-  (the default after zero initialization), sockets are bound to the
-  wildcard address and listen on all interfaces. If an address is set,
-  a single socket of that address family is created and bound to that
-  address and to `local_port`; the port inside `local_addr` is ignored.
-  Setting `local_af` to a different family than `local_addr` is an error.
+* `local_addr`: optional local addresses to which the sockets will be
+  bound, an array of `PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX` (2)
+  `sockaddr_storage` entries, at most one per address family. If every
+  entry is left to `AF_UNSPEC` (the default after zero initialization),
+  sockets are bound to the wildcard address and listen on all interfaces.
+  Otherwise one socket is created per entry, bound to that address and to
+  `local_port` (the port inside the entry is ignored), and no socket is
+  created for a family that has no entry, so setting one IPv4 address and
+  one IPv6 address serves both families on those two addresses only.
+  Every packet sent on a bound socket carries the bound address as its
+  source, whatever local address the path proposes; this pins the source
+  address of every path on that socket, so `local_addr` cannot be
+  combined with multipath across several local addresses. This is an
+  address binding, not an interface binding: on systems with a weak host
+  model (Linux) the kernel may still route packets from that address
+  through another interface. Two entries of the same family, or an entry
+  whose family differs from a non-zero `local_af`, are an error. The
+  extra socket, when requested, and any socket the loop opens later are
+  bound to the same addresses.
 
 * `dest_if`: the interface identifier that should be associated with the local
   socket, or 0.

--- a/picoquic/picoquic_packet_loop.h
+++ b/picoquic/picoquic_packet_loop.h
@@ -49,6 +49,7 @@ typedef struct st_picoquic_socket_ctx_t {
     unsigned int is_started : 1;
     unsigned int supports_udp_send_coalesced : 1;
     unsigned int supports_udp_recv_coalesced : 1;
+    struct sockaddr_storage bound_addr; /* Local address of the socket after bind, as reported by getsockname */
     /* Receive data buffer and fields */
     size_t recv_buffer_size;
     uint8_t* recv_buffer;
@@ -192,6 +193,8 @@ typedef struct st_picoquic_packet_loop_options_t {
 
 /* Version 2 of packet loop, obsoleted by v3
  */
+#define PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX 2
+
 typedef struct st_picoquic_packet_loop_param_t {
     uint16_t local_port; /* Default port for outgoing connection */
     int local_af;
@@ -207,11 +210,27 @@ typedef struct st_picoquic_packet_loop_param_t {
     int simulate_eio;
     size_t send_length_max;
     size_t send_batch_max; /* 0: use PICOQUIC_PACKET_LOOP_SEND_MAX */
-    struct sockaddr_storage local_addr; /* Optional bind address. If ss_family is 0, sockets
-                                         * bind to the wildcard address. If set, only a socket
-                                         * of that family is opened, bound to that address and
-                                         * to local_port. The port inside local_addr is ignored. */
+    /* Optional bind addresses, at most one per address family. If every entry
+     * has ss_family 0 (the default after zero initialization), sockets bind to
+     * the wildcard address. Otherwise one socket is opened per entry, bound to
+     * that address and to local_port (the port inside the entry is ignored),
+     * every packet sent on that socket carries that address as its source, and
+     * no socket is opened for a family that has no entry. Two entries of the
+     * same family, or an entry whose family differs from a non-zero local_af,
+     * are rejected. */
+    struct sockaddr_storage local_addr[PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX];
 } picoquic_packet_loop_param_t;
+
+/* Returns the entry of param->local_addr for the address family af, or NULL
+ * if there is none. */
+const struct sockaddr* picoquic_packet_loop_local_addr_for_af(const picoquic_packet_loop_param_t* param, int af);
+
+/* If the socket is bound to a specific (non wildcard) address, replace the
+ * address part of local_addr by that address, so the packet is sent from
+ * the address the socket can receive on. The port of local_addr is kept if
+ * it was set, otherwise the socket's port is used. Sockets bound to the
+ * wildcard address leave local_addr untouched. */
+void picoquic_packet_loop_set_send_source(const picoquic_socket_ctx_t* s_ctx, struct sockaddr_storage* local_addr);
 
 int picoquic_packet_loop_v2(picoquic_quic_t* quic,
     picoquic_packet_loop_param_t * param,

--- a/picoquic/picoquic_packet_loop.h
+++ b/picoquic/picoquic_packet_loop.h
@@ -207,6 +207,10 @@ typedef struct st_picoquic_packet_loop_param_t {
     int simulate_eio;
     size_t send_length_max;
     size_t send_batch_max; /* 0: use PICOQUIC_PACKET_LOOP_SEND_MAX */
+    struct sockaddr_storage local_addr; /* Optional bind address. If ss_family is 0, sockets
+                                         * bind to the wildcard address. If set, only a socket
+                                         * of that family is opened, bound to that address and
+                                         * to local_port. The port inside local_addr is ignored. */
 } picoquic_packet_loop_param_t;
 
 int picoquic_packet_loop_v2(picoquic_quic_t* quic,

--- a/picoquic/picosocks.c
+++ b/picoquic/picosocks.c
@@ -22,15 +22,23 @@
 #include "picosocks.h"
 #include "picoquic_utils.h"
 
-int picoquic_bind_to_port(SOCKET_TYPE fd, int af, int port)
+int picoquic_bind_to_address(SOCKET_TYPE fd, int af, int port, const struct sockaddr* local_addr)
 {
     struct sockaddr_storage sa;
     int addr_length = 0;
 
     memset(&sa, 0, sizeof(sa));
 
+    if (local_addr != NULL && local_addr->sa_family != AF_UNSPEC && local_addr->sa_family != af) {
+        /* Cannot bind a socket of one family to an address of another family */
+        return -1;
+    }
+
     if (af == AF_INET) {
         struct sockaddr_in* s4 = (struct sockaddr_in*)&sa;
+        if (local_addr != NULL && local_addr->sa_family == AF_INET) {
+            s4->sin_addr = ((const struct sockaddr_in*)local_addr)->sin_addr;
+        }
 #ifdef _WINDOWS
         s4->sin_family = (ADDRESS_FAMILY)af;
 #else
@@ -40,13 +48,21 @@ int picoquic_bind_to_port(SOCKET_TYPE fd, int af, int port)
         addr_length = sizeof(struct sockaddr_in);
     } else {
         struct sockaddr_in6* s6 = (struct sockaddr_in6*)&sa;
-
+        if (local_addr != NULL && local_addr->sa_family == AF_INET6) {
+            s6->sin6_addr = ((const struct sockaddr_in6*)local_addr)->sin6_addr;
+            s6->sin6_scope_id = ((const struct sockaddr_in6*)local_addr)->sin6_scope_id;
+        }
         s6->sin6_family = AF_INET6;
         s6->sin6_port = htons((unsigned short)port);
         addr_length = sizeof(struct sockaddr_in6);
     }
 
     return bind(fd, (struct sockaddr*)&sa, addr_length);
+}
+
+int picoquic_bind_to_port(SOCKET_TYPE fd, int af, int port)
+{
+    return picoquic_bind_to_address(fd, af, port, NULL);
 }
 
 int picoquic_get_local_address(SOCKET_TYPE sd, struct sockaddr_storage * addr)

--- a/picoquic/picosocks.h
+++ b/picoquic/picosocks.h
@@ -169,6 +169,10 @@ typedef struct st_picoquic_server_sockets_t {
 } picoquic_server_sockets_t;
 
 int picoquic_bind_to_port(SOCKET_TYPE fd, int af, int port);
+/* Bind to a specific local address and port. If local_addr is NULL or its family
+ * is unspecified, this is equivalent to picoquic_bind_to_port. The port inside
+ * local_addr is ignored; the port argument is used. */
+int picoquic_bind_to_address(SOCKET_TYPE fd, int af, int port, const struct sockaddr* local_addr);
 
 int picoquic_get_local_address(SOCKET_TYPE sd, struct sockaddr_storage * addr);
 

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -402,7 +402,8 @@ int picoquic_packet_loop_open_socket(picoquic_packet_loop_param_t* param,
         (s_ctx->is_port_shared && (setsockopt(s_ctx->fd, SOL_SOCKET, SO_REUSEPORT,
                                   (const char*)&opt_val, sizeof(opt_val)) != 0)) ||
 #endif
-        picoquic_bind_to_port(s_ctx->fd,s_ctx->af, s_ctx->port) != 0 ||
+        picoquic_bind_to_address(s_ctx->fd, s_ctx->af, s_ctx->port,
+            (param->local_addr.ss_family != AF_UNSPEC) ? (struct sockaddr*)&param->local_addr : NULL) != 0 ||
         picoquic_get_local_address(s_ctx->fd, &local_address) != 0 ||
         picoquic_socket_set_pmtud_options(s_ctx->fd, s_ctx->af) != 0)
     {
@@ -501,7 +502,16 @@ int picoquic_packet_loop_open_sockets(picoquic_packet_loop_param_t* param, picoq
     uint16_t current_port = param->local_port;
     int sock_ret = 0;
 
-    if (param->local_af == 0) {
+    if (param->local_addr.ss_family != AF_UNSPEC) {
+        /* Binding to a specific address implies a single socket of that family */
+        if (param->local_af != 0 && param->local_af != param->local_addr.ss_family) {
+            DBG_PRINTF("Cannot bind af=%d socket to address of af=%d\n", param->local_af, param->local_addr.ss_family);
+            return 0;
+        }
+        nb_af = 1;
+        af[0] = param->local_addr.ss_family;
+    }
+    else if (param->local_af == 0) {
 #ifdef ESP_PLATFORM
         nb_af = 1;
         af[0] = AF_INET;

--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -363,14 +363,79 @@ void picoquic_packet_loop_close_socket(picoquic_socket_ctx_t* s_ctx)
 #endif
 }
 
+/* Optional bind addresses: at most one per address family. */
+static int picoquic_packet_loop_has_local_addr(const picoquic_packet_loop_param_t* param)
+{
+    for (int i = 0; i < PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX; i++) {
+        if (param->local_addr[i].ss_family != AF_UNSPEC) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+const struct sockaddr* picoquic_packet_loop_local_addr_for_af(const picoquic_packet_loop_param_t* param, int af)
+{
+    for (int i = 0; i < PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX; i++) {
+        if (param->local_addr[i].ss_family == af) {
+            return (const struct sockaddr*)&param->local_addr[i];
+        }
+    }
+    return NULL;
+}
+
+static int picoquic_packet_loop_addr_is_wildcard(const struct sockaddr_storage* addr)
+{
+    if (addr->ss_family == AF_INET) {
+        return ((const struct sockaddr_in*)addr)->sin_addr.s_addr == INADDR_ANY;
+    }
+    else if (addr->ss_family == AF_INET6) {
+        return memcmp(&((const struct sockaddr_in6*)addr)->sin6_addr, &in6addr_any, sizeof(struct in6_addr)) == 0;
+    }
+    return 1;
+}
+
+void picoquic_packet_loop_set_send_source(const picoquic_socket_ctx_t* s_ctx, struct sockaddr_storage* local_addr)
+{
+    if (s_ctx == NULL || picoquic_packet_loop_addr_is_wildcard(&s_ctx->bound_addr) ||
+        (local_addr->ss_family != AF_UNSPEC && local_addr->ss_family != s_ctx->bound_addr.ss_family)) {
+        return;
+    }
+    if (s_ctx->bound_addr.ss_family == AF_INET) {
+        struct sockaddr_in* s4 = (struct sockaddr_in*)local_addr;
+        uint16_t port = (local_addr->ss_family == AF_INET) ? s4->sin_port : s_ctx->n_port;
+        memset(s4, 0, sizeof(struct sockaddr_in));
+        s4->sin_family = AF_INET;
+        s4->sin_port = port;
+        s4->sin_addr = ((const struct sockaddr_in*)&s_ctx->bound_addr)->sin_addr;
+    }
+    else {
+        struct sockaddr_in6* s6 = (struct sockaddr_in6*)local_addr;
+        uint16_t port = (local_addr->ss_family == AF_INET6) ? s6->sin6_port : s_ctx->n_port;
+        memset(s6, 0, sizeof(struct sockaddr_in6));
+        s6->sin6_family = AF_INET6;
+        s6->sin6_port = port;
+        s6->sin6_addr = ((const struct sockaddr_in6*)&s_ctx->bound_addr)->sin6_addr;
+        s6->sin6_scope_id = ((const struct sockaddr_in6*)&s_ctx->bound_addr)->sin6_scope_id;
+    }
+}
+
 int picoquic_packet_loop_open_socket(picoquic_packet_loop_param_t* param,
     picoquic_socket_ctx_t* s_ctx, uint8_t ecn_value)
 {
     int ret = 0;
     struct sockaddr_storage local_address;
+    const struct sockaddr* bind_addr = picoquic_packet_loop_local_addr_for_af(param, s_ctx->af);
     int recv_set = 0;
     int send_set = 0;
     int opt_val = 1;
+    if (bind_addr == NULL && picoquic_packet_loop_has_local_addr(param)) {
+        /* Bind addresses are configured, but none for this family: the loop
+         * must not open a socket that could send from an unrestricted address. */
+        DBG_PRINTF("No local address configured for af=%d\n", s_ctx->af);
+        return -1;
+    }
+
 #ifdef _WINDOWS
     int recv_coalesced = 0;
     int send_coalesced = 0;
@@ -402,8 +467,7 @@ int picoquic_packet_loop_open_socket(picoquic_packet_loop_param_t* param,
         (s_ctx->is_port_shared && (setsockopt(s_ctx->fd, SOL_SOCKET, SO_REUSEPORT,
                                   (const char*)&opt_val, sizeof(opt_val)) != 0)) ||
 #endif
-        picoquic_bind_to_address(s_ctx->fd, s_ctx->af, s_ctx->port,
-            (param->local_addr.ss_family != AF_UNSPEC) ? (struct sockaddr*)&param->local_addr : NULL) != 0 ||
+        picoquic_bind_to_address(s_ctx->fd, s_ctx->af, s_ctx->port, bind_addr) != 0 ||
         picoquic_get_local_address(s_ctx->fd, &local_address) != 0 ||
         picoquic_socket_set_pmtud_options(s_ctx->fd, s_ctx->af) != 0)
     {
@@ -412,6 +476,7 @@ int picoquic_packet_loop_open_socket(picoquic_packet_loop_param_t* param,
         ret = -1;
     }
     else {
+        picoquic_store_addr(&s_ctx->bound_addr, (struct sockaddr*)&local_address);
         if (local_address.ss_family == AF_INET6) {
             s_ctx->port = ntohs(((struct sockaddr_in6*)&local_address)->sin6_port);
         }
@@ -502,14 +567,28 @@ int picoquic_packet_loop_open_sockets(picoquic_packet_loop_param_t* param, picoq
     uint16_t current_port = param->local_port;
     int sock_ret = 0;
 
-    if (param->local_addr.ss_family != AF_UNSPEC) {
-        /* Binding to a specific address implies a single socket of that family */
-        if (param->local_af != 0 && param->local_af != param->local_addr.ss_family) {
-            DBG_PRINTF("Cannot bind af=%d socket to address of af=%d\n", param->local_af, param->local_addr.ss_family);
-            return 0;
+    if (picoquic_packet_loop_has_local_addr(param)) {
+        /* Binding to specific addresses: one socket per configured address */
+        nb_af = 0;
+        for (int i = 0; i < PICOQUIC_PACKET_LOOP_LOCAL_ADDR_MAX; i++) {
+            int addr_af = param->local_addr[i].ss_family;
+            if (addr_af == AF_UNSPEC) {
+                continue;
+            }
+            if (addr_af != AF_INET && addr_af != AF_INET6) {
+                DBG_PRINTF("Unsupported local address family af=%d\n", addr_af);
+                return 0;
+            }
+            if (param->local_af != 0 && param->local_af != addr_af) {
+                DBG_PRINTF("Cannot bind af=%d socket to address of af=%d\n", param->local_af, addr_af);
+                return 0;
+            }
+            if (picoquic_packet_loop_local_addr_for_af(param, addr_af) != (const struct sockaddr*)&param->local_addr[i]) {
+                DBG_PRINTF("Duplicate local address for af=%d\n", addr_af);
+                return 0;
+            }
+            af[nb_af++] = addr_af;
         }
-        nb_af = 1;
-        af[0] = param->local_addr.ss_family;
     }
     else if (param->local_af == 0) {
 #ifdef ESP_PLATFORM
@@ -2766,6 +2845,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                     * - either the source port is not specified, or it matches the local port.
                     */
                     SOCKET_TYPE send_socket = INVALID_SOCKET;
+                    picoquic_socket_ctx_t* send_ctx = NULL;
                     uint16_t send_port = (peer_addr.ss_family == AF_INET) ?
                         ((struct sockaddr_in*)&local_addr)->sin_port :
                         ((struct sockaddr_in6*)&local_addr)->sin6_port;
@@ -2776,6 +2856,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                     for (int i = 0; i < nb_sockets_available; i++) {
                         if (s_ctx[i].af == peer_addr.ss_family) {
                             send_socket = s_ctx[i].fd;
+                            send_ctx = &s_ctx[i];
                             if (send_port == 0 && !param->prefer_extra_socket) {
                                 break;
                             }
@@ -2799,6 +2880,7 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                             new_ctx->n_port = htons(new_ctx->port);
                             if (picoquic_packet_loop_open_socket(param, new_ctx, ecn_value) == 0) {
                                 send_socket = new_ctx->fd;
+                                send_ctx = new_ctx;
                                 send_port = new_ctx->n_port;
                                 nb_sockets_available++;
                                 if (nb_sockets < nb_sockets_available) {
@@ -2815,6 +2897,10 @@ void* picoquic_packet_loop_v3(void* v_ctx)
                             }
                         }
                     }
+                    /* A socket bound to a specific address must send from that address:
+                     * on a weak host model the kernel would otherwise honor a different
+                     * source from the path, whose replies this socket cannot receive. */
+                    picoquic_packet_loop_set_send_source(send_ctx, &local_addr);
                     ret = picoquic_packet_loop_do_udp_send(
                         quic, last_cnx, send_socket, param,
                         send_buffer, send_length, &peer_addr, &local_addr, if_index,

--- a/picoquic_t/picoquic_t.c
+++ b/picoquic_t/picoquic_t.c
@@ -131,6 +131,7 @@ static const picoquic_test_def_t test_table[] = {
     { "sockloop_eio", sockloop_eio_test },
     { "sockloop_errsock", sockloop_errsock_test },
     { "sockloop_ipv4", sockloop_ipv4_test },
+    { "sockloop_bind_addr", sockloop_bind_addr_test },
     { "sockloop_migration", sockloop_migration_test },
     { "sockloop_nat", sockloop_nat_test },
     { "sockloop_thread", sockloop_thread_test },

--- a/picoquictest/picoquictest.h
+++ b/picoquictest/picoquictest.h
@@ -202,6 +202,7 @@ int sockloop_basic_test(void);
 int sockloop_eio_test(void);
 int sockloop_errsock_test(void);
 int sockloop_ipv4_test(void);
+int sockloop_bind_addr_test(void);
 int sockloop_migration_test(void);
 int sockloop_nat_test(void);
 int sockloop_thread_test(void);

--- a/picoquictest/sockloop_test.c
+++ b/picoquictest/sockloop_test.c
@@ -536,7 +536,7 @@ int sockloop_test_one(sockloop_test_spec_t *spec)
             param.extra_socket_required = spec->extra_socket_required;
             param.prefer_extra_socket = spec->prefer_extra_socket;
             if (spec->bind_loopback) {
-                ret = sockloop_test_addr_config(&param.local_addr, spec->af, 0);
+                ret = sockloop_test_addr_config(&param.local_addr[0], spec->af, 0);
             }
 
             loop_cb.force_migration = spec->force_migration;
@@ -707,54 +707,187 @@ static int picoquic_addr_set_port_and_compare(struct sockaddr_storage* expected,
     return picoquic_compare_addr((struct sockaddr*)expected, (struct sockaddr*)actual);
 }
 
-/* Verify that a socket opened with param.local_addr is bound to that
- * address rather than to the wildcard address. */
-int sockloop_bind_addr_one(int af)
+/* Check that socket s_ctx is bound to the loopback address of its family,
+ * on a non-zero port. */
+static int sockloop_bind_addr_check_socket(picoquic_socket_ctx_t* s_ctx, int af)
+{
+    int ret = 0;
+    struct sockaddr_storage expected = { 0 };
+    struct sockaddr_storage actual = { 0 };
+
+    if (s_ctx->af != af) {
+        DBG_PRINTF("Expected socket af=%d, got %d", af, s_ctx->af);
+        ret = -1;
+    }
+    else if (sockloop_test_addr_config(&expected, af, 0) != 0) {
+        ret = -1;
+    }
+    else if (picoquic_get_local_address(s_ctx->fd, &actual) != 0) {
+        DBG_PRINTF("%s", "Cannot read local address of bound socket");
+        ret = -1;
+    }
+    else if (s_ctx->port == 0) {
+        DBG_PRINTF("%s", "Ephemeral port was not reported back");
+        ret = -1;
+    }
+    else if (picoquic_addr_set_port_and_compare(&expected, s_ctx->port, &actual) != 0 ||
+        picoquic_compare_addr((struct sockaddr*)&expected, (struct sockaddr*)&s_ctx->bound_addr) != 0) {
+        char expected_text[64];
+        char actual_text[64];
+        char bound_text[64];
+        DBG_PRINTF("Expected bind address %s, got %s, recorded %s",
+            picoquic_addr_text((struct sockaddr*)&expected, expected_text, sizeof(expected_text)),
+            picoquic_addr_text((struct sockaddr*)&actual, actual_text, sizeof(actual_text)),
+            picoquic_addr_text((struct sockaddr*)&s_ctx->bound_addr, bound_text, sizeof(bound_text)));
+        ret = -1;
+    }
+    return ret;
+}
+
+/* Verify that sockets opened with param.local_addr are bound to those
+ * addresses rather than to the wildcard address: one socket per entry,
+ * none for a family without an entry. af_list holds the families to
+ * configure, nb_af of them. local_af is left to 0 (unspecified). */
+static int sockloop_bind_addr_one(const int* af_list, int nb_af)
 {
     int ret = 0;
     picoquic_packet_loop_param_t param = { 0 };
     picoquic_socket_ctx_t s_ctx[4] = { 0 };
-    struct sockaddr_storage expected = { 0 };
-    struct sockaddr_storage actual = { 0 };
     int nb_sockets;
 
     for (int i = 0; i < 4; i++) {
         s_ctx[i].fd = INVALID_SOCKET;
     }
-    /* local_af is left to 0 (unspecified): the address family of local_addr
-     * must narrow the loop to a single socket of that family. */
-    ret = sockloop_test_addr_config(&expected, af, 0);
-    if (ret == 0) {
-        ret = sockloop_test_addr_config(&param.local_addr, af, 0);
+    for (int i = 0; ret == 0 && i < nb_af; i++) {
+        ret = sockloop_test_addr_config(&param.local_addr[i], af_list[i], 0);
     }
     if (ret == 0) {
         param.local_port = 0;
         param.socket_buffer_size = PICOQUIC_MAX_PACKET_SIZE;
         param.do_not_use_gso = 1;
         nb_sockets = picoquic_packet_loop_open_sockets(&param, s_ctx, 0);
+        if (nb_sockets != nb_af) {
+            DBG_PRINTF("Expected %d sockets, got %d", nb_af, nb_sockets);
+            ret = -1;
+        }
+        for (int i = 0; ret == 0 && i < nb_af; i++) {
+            ret = sockloop_bind_addr_check_socket(&s_ctx[i], af_list[i]);
+        }
+        for (int i = 0; i < 4; i++) {
+            picoquic_packet_loop_close_socket(&s_ctx[i]);
+        }
+    }
+    return ret;
+}
+
+/* Verify that inconsistent parameters are refused: a local_af that does not
+ * match the configured address, or two addresses of the same family. */
+static int sockloop_bind_addr_refused(int local_af, int af0, int af1)
+{
+    int ret = 0;
+    picoquic_packet_loop_param_t param = { 0 };
+    picoquic_socket_ctx_t s_ctx[4] = { 0 };
+    int nb_sockets;
+
+    for (int i = 0; i < 4; i++) {
+        s_ctx[i].fd = INVALID_SOCKET;
+    }
+    param.local_af = local_af;
+    ret = sockloop_test_addr_config(&param.local_addr[0], af0, 0);
+    if (ret == 0 && af1 != AF_UNSPEC) {
+        ret = sockloop_test_addr_config(&param.local_addr[1], af1, 0);
+    }
+    if (ret == 0) {
+        param.do_not_use_gso = 1;
+        nb_sockets = picoquic_packet_loop_open_sockets(&param, s_ctx, 0);
+        if (nb_sockets != 0) {
+            DBG_PRINTF("Expected refusal for local_af=%d, af0=%d, af1=%d, got %d sockets",
+                local_af, af0, af1, nb_sockets);
+            ret = -1;
+        }
+        for (int i = 0; i < 4; i++) {
+            picoquic_packet_loop_close_socket(&s_ctx[i]);
+        }
+    }
+    return ret;
+}
+
+/* Verify that the send path substitutes the bound address for whatever
+ * local address the path proposes, keeps the port, fills in an unspecified
+ * local address, and leaves sockets bound to the wildcard alone. */
+static int sockloop_bind_addr_send_source(int af)
+{
+    int ret = 0;
+    picoquic_packet_loop_param_t param = { 0 };
+    picoquic_socket_ctx_t s_ctx[4] = { 0 };
+    struct sockaddr_storage other = { 0 };
+    struct sockaddr_storage expected = { 0 };
+    struct sockaddr_storage local_addr = { 0 };
+    int nb_sockets;
+
+    for (int i = 0; i < 4; i++) {
+        s_ctx[i].fd = INVALID_SOCKET;
+    }
+    /* "other" is a different address of the same family, port 1234 */
+    ret = sockloop_test_addr_config(&other, af, 1234);
+    if (ret == 0) {
+        if (af == AF_INET6) {
+            ((uint8_t*)(&((struct sockaddr_in6*)&other)->sin6_addr))[14] = 0xff;
+        }
+        else {
+            ((uint8_t*)(&((struct sockaddr_in*)&other)->sin_addr))[3] = 5;
+        }
+        ret = sockloop_test_addr_config(&param.local_addr[0], af, 0);
+    }
+    if (ret == 0) {
+        param.do_not_use_gso = 1;
+        nb_sockets = picoquic_packet_loop_open_sockets(&param, s_ctx, 0);
         if (nb_sockets != 1) {
-            DBG_PRINTF("Expected 1 socket for af=%d, got %d", af, nb_sockets);
+            DBG_PRINTF("Expected 1 socket, got %d", nb_sockets);
             ret = -1;
         }
-        else if (s_ctx[0].af != af) {
-            DBG_PRINTF("Expected socket af=%d, got %d", af, s_ctx[0].af);
+    }
+    if (ret == 0) {
+        /* Path proposes another address: expect the bound address, same port */
+        picoquic_store_addr(&local_addr, (struct sockaddr*)&other);
+        picoquic_packet_loop_set_send_source(&s_ctx[0], &local_addr);
+        (void)sockloop_test_addr_config(&expected, af, 1234);
+        if (picoquic_compare_addr((struct sockaddr*)&expected, (struct sockaddr*)&local_addr) != 0) {
+            DBG_PRINTF("%s", "Bound address was not substituted for the path's local address");
             ret = -1;
         }
-        else if (picoquic_get_local_address(s_ctx[0].fd, &actual) != 0) {
-            DBG_PRINTF("%s", "Cannot read local address of bound socket");
+    }
+    if (ret == 0) {
+        /* Path has no local address yet: expect the bound address and port */
+        memset(&local_addr, 0, sizeof(local_addr));
+        picoquic_packet_loop_set_send_source(&s_ctx[0], &local_addr);
+        (void)sockloop_test_addr_config(&expected, af, s_ctx[0].port);
+        if (picoquic_compare_addr((struct sockaddr*)&expected, (struct sockaddr*)&local_addr) != 0) {
+            DBG_PRINTF("%s", "Unspecified local address was not filled from the bound address");
             ret = -1;
         }
-        else if (s_ctx[0].port == 0) {
-            DBG_PRINTF("%s", "Ephemeral port was not reported back");
+    }
+    for (int i = 0; i < 4; i++) {
+        picoquic_packet_loop_close_socket(&s_ctx[i]);
+        s_ctx[i].fd = INVALID_SOCKET;
+    }
+    if (ret == 0) {
+        /* Socket bound to the wildcard: the path's local address is kept */
+        memset(&param, 0, sizeof(param));
+        param.local_af = af;
+        param.do_not_use_gso = 1;
+        nb_sockets = picoquic_packet_loop_open_sockets(&param, s_ctx, 0);
+        if (nb_sockets != 1) {
+            DBG_PRINTF("Expected 1 wildcard socket, got %d", nb_sockets);
             ret = -1;
         }
-        else if (picoquic_addr_set_port_and_compare(&expected, s_ctx[0].port, &actual) != 0) {
-            char expected_text[64];
-            char actual_text[64];
-            DBG_PRINTF("Expected bind address %s, got %s",
-                picoquic_addr_text((struct sockaddr*)&expected, expected_text, sizeof(expected_text)),
-                picoquic_addr_text((struct sockaddr*)&actual, actual_text, sizeof(actual_text)));
-            ret = -1;
+        else {
+            picoquic_store_addr(&local_addr, (struct sockaddr*)&other);
+            picoquic_packet_loop_set_send_source(&s_ctx[0], &local_addr);
+            if (picoquic_compare_addr((struct sockaddr*)&other, (struct sockaddr*)&local_addr) != 0) {
+                DBG_PRINTF("%s", "Wildcard socket changed the path's local address");
+                ret = -1;
+            }
         }
         for (int i = 0; i < 4; i++) {
             picoquic_packet_loop_close_socket(&s_ctx[i]);
@@ -765,10 +898,28 @@ int sockloop_bind_addr_one(int af)
 
 int sockloop_bind_addr_test(void)
 {
-    int ret = sockloop_bind_addr_one(AF_INET);
+    const int af_v4[1] = { AF_INET };
+    const int af_v6[1] = { AF_INET6 };
+    const int af_both[2] = { AF_INET, AF_INET6 };
+    int ret = sockloop_bind_addr_one(af_v4, 1);
 
     if (ret == 0) {
-        ret = sockloop_bind_addr_one(AF_INET6);
+        ret = sockloop_bind_addr_one(af_v6, 1);
+    }
+    if (ret == 0) {
+        ret = sockloop_bind_addr_one(af_both, 2);
+    }
+    if (ret == 0) {
+        ret = sockloop_bind_addr_refused(AF_INET6, AF_INET, AF_UNSPEC);
+    }
+    if (ret == 0) {
+        ret = sockloop_bind_addr_refused(0, AF_INET, AF_INET);
+    }
+    if (ret == 0) {
+        ret = sockloop_bind_addr_send_source(AF_INET);
+    }
+    if (ret == 0) {
+        ret = sockloop_bind_addr_send_source(AF_INET6);
     }
     if (ret == 0) {
         /* Full loop, server bound to 127.0.0.1 only, client connecting to it. */

--- a/picoquictest/sockloop_test.c
+++ b/picoquictest/sockloop_test.c
@@ -63,6 +63,7 @@ typedef struct st_sockloop_test_spec_t {
     int extra_socket_required;
     int prefer_extra_socket;
     int force_migration;
+    int bind_loopback; /* bind the server socket to the loopback address of spec->af */
 } sockloop_test_spec_t;
 
 typedef struct st_sockloop_test_cb_t {
@@ -534,7 +535,9 @@ int sockloop_test_one(sockloop_test_spec_t *spec)
             param.simulate_eio = spec->simulate_eio;
             param.extra_socket_required = spec->extra_socket_required;
             param.prefer_extra_socket = spec->prefer_extra_socket;
-            
+            if (spec->bind_loopback) {
+                ret = sockloop_test_addr_config(&param.local_addr, spec->af, 0);
+            }
 
             loop_cb.force_migration = spec->force_migration;
             loop_cb.param = &param;
@@ -688,6 +691,95 @@ int sockloop_ipv4_test(void)
     spec.scenario_size = sizeof(sockloop_test_scenario_1M);
 
     return(sockloop_test_one(&spec));
+}
+
+/* Compare the address part of two sockaddr, after aligning the port of the
+ * expected address on the port reported by the socket. */
+static int picoquic_addr_set_port_and_compare(struct sockaddr_storage* expected, uint16_t port,
+    struct sockaddr_storage* actual)
+{
+    if (expected->ss_family == AF_INET6) {
+        ((struct sockaddr_in6*)expected)->sin6_port = htons(port);
+    }
+    else if (expected->ss_family == AF_INET) {
+        ((struct sockaddr_in*)expected)->sin_port = htons(port);
+    }
+    return picoquic_compare_addr((struct sockaddr*)expected, (struct sockaddr*)actual);
+}
+
+/* Verify that a socket opened with param.local_addr is bound to that
+ * address rather than to the wildcard address. */
+int sockloop_bind_addr_one(int af)
+{
+    int ret = 0;
+    picoquic_packet_loop_param_t param = { 0 };
+    picoquic_socket_ctx_t s_ctx[4] = { 0 };
+    struct sockaddr_storage expected = { 0 };
+    struct sockaddr_storage actual = { 0 };
+    int nb_sockets;
+
+    for (int i = 0; i < 4; i++) {
+        s_ctx[i].fd = INVALID_SOCKET;
+    }
+    /* local_af is left to 0 (unspecified): the address family of local_addr
+     * must narrow the loop to a single socket of that family. */
+    ret = sockloop_test_addr_config(&expected, af, 0);
+    if (ret == 0) {
+        ret = sockloop_test_addr_config(&param.local_addr, af, 0);
+    }
+    if (ret == 0) {
+        param.local_port = 0;
+        param.socket_buffer_size = PICOQUIC_MAX_PACKET_SIZE;
+        param.do_not_use_gso = 1;
+        nb_sockets = picoquic_packet_loop_open_sockets(&param, s_ctx, 0);
+        if (nb_sockets != 1) {
+            DBG_PRINTF("Expected 1 socket for af=%d, got %d", af, nb_sockets);
+            ret = -1;
+        }
+        else if (s_ctx[0].af != af) {
+            DBG_PRINTF("Expected socket af=%d, got %d", af, s_ctx[0].af);
+            ret = -1;
+        }
+        else if (picoquic_get_local_address(s_ctx[0].fd, &actual) != 0) {
+            DBG_PRINTF("%s", "Cannot read local address of bound socket");
+            ret = -1;
+        }
+        else if (s_ctx[0].port == 0) {
+            DBG_PRINTF("%s", "Ephemeral port was not reported back");
+            ret = -1;
+        }
+        else if (picoquic_addr_set_port_and_compare(&expected, s_ctx[0].port, &actual) != 0) {
+            char expected_text[64];
+            char actual_text[64];
+            DBG_PRINTF("Expected bind address %s, got %s",
+                picoquic_addr_text((struct sockaddr*)&expected, expected_text, sizeof(expected_text)),
+                picoquic_addr_text((struct sockaddr*)&actual, actual_text, sizeof(actual_text)));
+            ret = -1;
+        }
+        for (int i = 0; i < 4; i++) {
+            picoquic_packet_loop_close_socket(&s_ctx[i]);
+        }
+    }
+    return ret;
+}
+
+int sockloop_bind_addr_test(void)
+{
+    int ret = sockloop_bind_addr_one(AF_INET);
+
+    if (ret == 0) {
+        ret = sockloop_bind_addr_one(AF_INET6);
+    }
+    if (ret == 0) {
+        /* Full loop, server bound to 127.0.0.1 only, client connecting to it. */
+        sockloop_test_spec_t spec;
+        sockloop_test_set_spec(&spec, 11);
+        spec.af = AF_INET;
+        spec.bind_loopback = 1;
+        spec.do_not_use_gso = 1;
+        ret = sockloop_test_one(&spec);
+    }
+    return ret;
 }
 
 int sockloop_migration_test(void)


### PR DESCRIPTION
## Problem

`picoquic_packet_loop_param_t` only carries `local_port` and `local_af`, and `picoquic_bind_to_port` zeroes the sockaddr before `bind()`, so every socket opened by the packet loop (v2/v3, network thread) listens on the wildcard address. An application that needs to serve on a single interface of a multi-homed host has no way to express that.

## Change

- Add `struct sockaddr_storage local_addr` at the end of `picoquic_packet_loop_param_t`. Zero-initialized params behave exactly as before.
- When `local_addr.ss_family` is set, `picoquic_packet_loop_open_sockets` opens a single socket of that family and binds it to that address and to `local_port` (the port inside `local_addr` is ignored). A conflicting non-zero `local_af` is rejected.
- Add `picoquic_bind_to_address()` in picosocks; `picoquic_bind_to_port()` is now a wrapper around it, so existing callers are unchanged.
- The legacy `picoquic_packet_loop_win` path (`picoquic_packet_loop_open_sockets_win`) is untouched.

## Tests

New `sockloop_bind_addr` test:
- opens sockets with `local_addr` set to 127.0.0.1 and ::1 with `local_af` left unspecified, and verifies via `getsockname` that exactly one socket of the right family is created and bound to that address;
- runs a full client/server loop with the server bound to 127.0.0.1 only.

Registered in `picoquic_t`, `picoquictest.h`, and `UnitTest1`. All `sockloop_*` tests pass locally on Linux.

## Docs

`doc/socket_loop.md` and `doc/parallel.md` updated with the new parameter.
