### PR TITLE
Fix DBG_PRINTF issue with __VA_ARGS__

### DIFF
--- a/picoquic/sockloop.c
+++ b/picoquic/sockloop.c
@@ -448,7 +448,7 @@ int picoquic_packet_loop_open_socket(picoquic_packet_loop_param_t* param,
                 DBG_PRINTF("Cannot set %s to %d, err=%d, so_sndbuf=%d (%d)",
                     last_op_name, param->socket_buffer_size, sock_error, so_errbuf, opt_ret);
 #ifdef __FreeBSD__
-                DBG_PRINTF("- If increasing buffer size, verify requested size fits within kern.ipc.maxsockbuf");
+                DBG_PRINTF("%s", "- If increasing buffer size, verify requested size fits within kern.ipc.maxsockbuf");
 #endif
                 ret = -1;
             }


### PR DESCRIPTION
This resolves a FreeBSD-specific build failure that I introduced with a previous PR.

DBG_PRINTF needs more than one argument.